### PR TITLE
Implement HTTP asset certification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,6 +148,7 @@ name = "certified-assets"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "hex",
  "ic-cdk",
  "ic-cdk-macros",
  "ic-certified-map",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.13"
+hex = "0.4.3"
 ic-cdk = "0.2.4"
 ic-cdk-macros = "0.2"
 ic-types = "0.1.1"


### PR DESCRIPTION
Highlights:

  * Encoding SHA256 used to be optional internally, but it's not anymore.
    If the requester specifies a hash explicitly, we hash anyway and
    check if the hashes agrees, just in case.  We can revise this behaviour
    later because it can be problematic for large assets.

  * Content encoding negotiation is a bit tricky because we can only
    certify one encoding with the current scheme.
    I decided to specify the explicit order in which we try to certify
    encodings ("identity" is the most preferred one).

  * Automatic substitution of /index.html instead of missing assets forces us
     to use a slightly more elaborate witness structure.