### PR TITLE
fix: trust full asset SHA-256 hashes provided by the caller

### DIFF
--- a/src/rc_bytes.rs
+++ b/src/rc_bytes.rs
@@ -4,6 +4,7 @@ use ic_cdk::export::candid::{
 };
 use serde::de::Deserializer;
 use serde_bytes::ByteBuf;
+use std::convert::AsRef;
 use std::ops::Deref;
 use std::rc::Rc;
 
@@ -35,6 +36,12 @@ impl<'de> Deserialize<'de> for RcBytes {
 impl From<ByteBuf> for RcBytes {
     fn from(b: ByteBuf) -> Self {
         Self(Rc::new(b))
+    }
+}
+
+impl AsRef<[u8]> for RcBytes {
+    fn as_ref(&self) -> &[u8] {
+        &*self.0
     }
 }
 


### PR DESCRIPTION
This change removes abligatory SHA-256 recomputation when a full asset
is assembled out of chunks.  The hash is only recomputed if it wasn't
specified by the caller.

Computing the full hash causes the canister to run out of cycles when
large assets are uploaded (~50MiB. Yes, there are people who do this).

Fixes #5.