### PR TITLE
fix: http_request_streaming_callback response type

### DIFF
--- a/assets.did
+++ b/assets.did
@@ -134,7 +134,7 @@ service: {
   }) -> ();
 
   http_request: (request: HttpRequest) -> (HttpResponse) query;
-  http_request_streaming_callback: (token: StreamingCallbackToken) -> (opt StreamingCallbackHttpResponse) query;
+  http_request_streaming_callback: (token: StreamingCallbackToken) -> (StreamingCallbackHttpResponse) query;
 
   authorize: (principal) -> ();
 }


### PR DESCRIPTION
`http_request_streaming_callback` has no `opt` in implementation.
https://docs.rs/ic-certified-assets/latest/src/ic_certified_assets/lib.rs.html#745

I'm caught with this when making query-requests from frontend