### PR TITLE
feat: update did for passing chunks tree and sha256

### DIFF
--- a/assets.did
+++ b/assets.did
@@ -59,7 +59,7 @@ type HttpResponse = record {
 type StreamingCallbackHttpResponse = record {
   body: blob;
   token: opt StreamingCallbackToken;
-  chunk_tree: opt text;
+  chunk_tree: opt blob;
 };
 
 type StreamingCallbackToken = record {

--- a/assets.did
+++ b/assets.did
@@ -59,6 +59,7 @@ type HttpResponse = record {
 type StreamingCallbackHttpResponse = record {
   body: blob;
   token: opt StreamingCallbackToken;
+  chunk_tree: opt text;
 };
 
 type StreamingCallbackToken = record {
@@ -110,7 +111,7 @@ service: {
 
   create_batch : (record {}) -> (record { batch_id: BatchId });
 
-  create_chunk: (record { batch_id: BatchId; content: blob }) -> (record { chunk_id: ChunkId });
+  create_chunk: (record { batch_id: BatchId; content: blob; sha256: opt blob }) -> (record { chunk_id: ChunkId });
 
   // Perform all operations successfully, or reject
   commit_batch: (record { batch_id: BatchId; operations: vec BatchOperationKind }) -> ();
@@ -134,7 +135,7 @@ service: {
   }) -> ();
 
   http_request: (request: HttpRequest) -> (HttpResponse) query;
-  http_request_streaming_callback: (token: StreamingCallbackToken) -> (opt StreamingCallbackHttpResponse) query;
+  http_request_streaming_callback: (token: StreamingCallbackToken) -> (StreamingCallbackHttpResponse) query;
 
   authorize: (principal) -> ();
 }


### PR DESCRIPTION
That is a part of proposal about chunks certification (with backward compatibility).

_These improvements are a proposal to improve the certification infrastructure around IC and might be considered as a recommendation for dfinity-team._

### Goal
Make it possible to certify asset chunks. Validate chunk certificates on the service-worker and icx-proxy.

### Why
At the moment, the service-worker and icx-proxy does not support the certification of chunkified files. Moreover, right now it is not possible to correctly stream chunkified and large audio and video files to the front-end.
This problems could be solved independently if it would be possible to install an additional service-worker in the certified zone of the domain `ic0.app` (for 206 partial http-request handling). But is is impossible because there is unable to place custom worker on `ic0.app` domain.
Making your own custom player for audio and video is extremely difficult due to the large number of formats and non-native implementation.

### Details
To make this possible, support for HTTP-range requests for `http_request` query method has been added. This is done to support native html `audio/video` element (which uses 206 partial http-request) and to determine the index of the chunk throught 206 partial http-request.
Using 206 partial http-requests allows you to focus only on certification in the worker and icx-proxy.

### Steps
1. It all starts with [PR for certified-assets-canister in cdk-rs](https://github.com/dfinity/cdk-rs/pull/219)
2. (Here) Did file was updated here
3. Service-worker started supporting chunk_tree certificate verification in [PR for ic](https://github.com/dfinity/ic/pull/12)
4. icx-proxy started supporting chunk_tree certificate verification in [PR for icx-proxy](https://github.com/dfinity/icx-proxy/pull/24)
5. Added support for new certified-assets-canister did in [PR for agent-rs](https://github.com/dfinity/agent-rs/pull/313)