### PR TITLE
chore: update `assets.did` to support `max_age` filed

### DIFF
--- a/assets.did
+++ b/assets.did
@@ -6,6 +6,7 @@ type Time = int;
 type CreateAssetArguments = record {
   key: Key;
   content_type: text;
+  max_age: opt nat64;
 };
 
 // Add or change content for an asset, by content encoding


### PR DESCRIPTION
leftovers after latest changes (i.e. bump from 0.2.0 to 0.2.2)