### PR TITLE
fix: candid spec supports setting multiple HTTP headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "certified-assets"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 
@@ -14,6 +14,6 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-ic-certified-assets = "0.2.3"
+ic-certified-assets = "0.2.4"
 ic-cdk = "0.5.0"
 ic-cdk-macros = "0.5.0"

--- a/assets.did
+++ b/assets.did
@@ -7,7 +7,7 @@ type CreateAssetArguments = record {
   key: Key;
   content_type: text;
   max_age: opt nat64;
-  headers: opt HeaderField;
+  headers: opt vec HeaderField;
 };
 
 // Add or change content for an asset, by content encoding


### PR DESCRIPTION
continuation of https://github.com/dfinity/cdk-rs/pull/284