### PR TITLE
fix: disable etags and redirects 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "certified-assets"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2018"
 
@@ -14,6 +14,6 @@ path = "src/lib.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-ic-certified-assets = "0.2.4"
+ic-certified-assets = "0.2.5"
 ic-cdk = "0.5.0"
 ic-cdk-macros = "0.5.0"


### PR DESCRIPTION
continuation of https://github.com/dfinity/cdk-rs/pull/305

> ETags functionality hasn't been implemented in icx-proxy. [Until that happens](https://dfinity.atlassian.net/browse/BOUN-446), this feature is dropped from the asset canister.
>
> The support for more robust redirects will come in future dfx release (https://github.com/dfinity/sdk/pull/2414)

