### PR TITLE
feat(assets-sync): security policy header injection

### DIFF
--- a/assets-sync/src/config.rs
+++ b/assets-sync/src/config.rs
@@ -60,7 +60,10 @@ impl AssetConfig {
     pub fn combined_headers(&self) -> Option<HeadersConfig> {
         match (self.headers.as_ref(), self.security_policy) {
             (None, None) => None,
-            (None, Some(policy)) => Some(policy.to_headers()),
+            (None, Some(policy)) => {
+                let headers = policy.to_headers();
+                (!headers.is_empty()).then_some(headers)
+            }
             (Some(custom), None) => Some(custom.clone()),
             (Some(custom), Some(policy)) => {
                 let mut headers = custom.clone();
@@ -721,13 +724,14 @@ mod tests {
     }
 
     #[test]
-    fn combined_headers_disabled_policy_is_empty() {
+    fn combined_headers_disabled_policy_is_none() {
         let cfg = AssetConfig {
             security_policy: Some(SecurityPolicy::Disabled),
             ..AssetConfig::default()
         };
         // Disabled policy carries no headers; with no custom headers, the
-        // result is an empty (but `Some`) map.
-        assert!(cfg.combined_headers().unwrap().is_empty());
+        // result should be `None` (not `Some(empty)`), so callers downstream
+        // can't confuse an opted-out policy with an empty header set.
+        assert!(cfg.combined_headers().is_none());
     }
 }

--- a/assets-sync/src/config.rs
+++ b/assets-sync/src/config.rs
@@ -6,10 +6,11 @@
 //! lazily (one directory at a time), which avoids a separate pre-walk.
 
 use crate::content::Encoder;
+use crate::security_policy::SecurityPolicy;
 use globset::{Glob, GlobMatcher};
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
@@ -32,7 +33,6 @@ pub struct AssetConfig {
     pub enable_aliasing: Option<bool>,
     pub allow_raw_access: Option<bool>,
     pub encodings: Option<Vec<Encoder>>,
-    /// Parsed but not acted upon until the security-policy TODO is implemented.
     pub security_policy: Option<SecurityPolicy>,
     pub disable_security_policy_warning: Option<bool>,
 }
@@ -53,20 +53,53 @@ impl Default for AssetConfig {
 }
 
 impl AssetConfig {
-    /// Returns the effective HTTP headers for this asset.
-    /// Security-policy header injection is deferred to the security-policy TODO.
+    /// Returns the effective HTTP headers for this asset, merging any
+    /// `security_policy` standard headers with the user-supplied `headers`
+    /// map. Custom headers win on conflict, compared case-insensitively
+    /// (HTTP header names are case-insensitive).
     pub fn combined_headers(&self) -> Option<HeadersConfig> {
-        self.headers.clone()
+        match (self.headers.as_ref(), self.security_policy) {
+            (None, None) => None,
+            (None, Some(policy)) => Some(policy.to_headers()),
+            (Some(custom), None) => Some(custom.clone()),
+            (Some(custom), Some(policy)) => {
+                let mut headers = custom.clone();
+                let custom_names: HashSet<String> =
+                    custom.keys().map(|k| k.to_lowercase()).collect();
+                for (name, value) in policy.to_headers() {
+                    if !custom_names.contains(&name.to_lowercase()) {
+                        headers.insert(name, value);
+                    }
+                }
+                Some(headers)
+            }
+        }
     }
-}
 
-/// Parsed but not yet acted upon — see the security-policy TODO.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum SecurityPolicy {
-    Disabled,
-    Standard,
-    Hardened,
+    /// True when this asset has no security policy configured and the user
+    /// has not opted out of the warning via `disable_security_policy_warning`.
+    pub fn warn_about_no_security_policy(&self) -> bool {
+        self.security_policy.is_none() && self.disable_security_policy_warning != Some(true)
+    }
+
+    /// True when this asset uses the `standard` policy and the user has not
+    /// opted out of the hardening hint.
+    pub fn warn_about_standard_security_policy(&self) -> bool {
+        self.security_policy == Some(SecurityPolicy::Standard)
+            && self.disable_security_policy_warning != Some(true)
+    }
+
+    /// True when this asset declares `hardened` but supplies no custom
+    /// headers — a hard error, not silenceable by the warning flag.
+    pub fn warn_about_missing_hardening_headers(&self) -> bool {
+        let is_hardened = self.security_policy == Some(SecurityPolicy::Hardened);
+        let has_headers = self
+            .headers
+            .as_ref()
+            .map(|h| !h.is_empty())
+            .unwrap_or(false);
+        is_hardened && !has_headers
+    }
 }
 
 // ── Internal types ───────────────────────────────────────────────────────────
@@ -620,5 +653,61 @@ mod tests {
         let ac = load(&d);
         let _ = cfg(&ac, &d, "index.html");
         assert!(ac.get_unused_configs().is_empty());
+    }
+
+    #[test]
+    fn combined_headers_none_when_no_inputs() {
+        assert!(AssetConfig::default().combined_headers().is_none());
+    }
+
+    #[test]
+    fn combined_headers_uses_policy_when_no_custom_headers() {
+        let cfg = AssetConfig {
+            security_policy: Some(SecurityPolicy::Standard),
+            ..AssetConfig::default()
+        };
+        let headers = cfg.combined_headers().unwrap();
+        assert_eq!(headers["X-Frame-Options"], "DENY");
+    }
+
+    #[test]
+    fn combined_headers_merges_custom_and_policy() {
+        let mut custom = HeadersConfig::new();
+        custom.insert("X-Custom".to_string(), "1".to_string());
+        let cfg = AssetConfig {
+            headers: Some(custom),
+            security_policy: Some(SecurityPolicy::Standard),
+            ..AssetConfig::default()
+        };
+        let headers = cfg.combined_headers().unwrap();
+        assert_eq!(headers["X-Custom"], "1");
+        assert_eq!(headers["X-Frame-Options"], "DENY");
+    }
+
+    #[test]
+    fn combined_headers_custom_wins_case_insensitive() {
+        let mut custom = HeadersConfig::new();
+        custom.insert("x-frame-options".to_string(), "SAMEORIGIN".to_string());
+        let cfg = AssetConfig {
+            headers: Some(custom),
+            security_policy: Some(SecurityPolicy::Standard),
+            ..AssetConfig::default()
+        };
+        let headers = cfg.combined_headers().unwrap();
+        // The policy entry (`X-Frame-Options`) must NOT override the custom
+        // lowercase entry — case-insensitive header-name comparison.
+        assert_eq!(headers["x-frame-options"], "SAMEORIGIN");
+        assert!(!headers.contains_key("X-Frame-Options"));
+    }
+
+    #[test]
+    fn combined_headers_disabled_policy_is_empty() {
+        let cfg = AssetConfig {
+            security_policy: Some(SecurityPolicy::Disabled),
+            ..AssetConfig::default()
+        };
+        // Disabled policy carries no headers; with no custom headers, the
+        // result is an empty (but `Some`) map.
+        assert!(cfg.combined_headers().unwrap().is_empty());
     }
 }

--- a/assets-sync/src/config.rs
+++ b/assets-sync/src/config.rs
@@ -701,6 +701,26 @@ mod tests {
     }
 
     #[test]
+    fn security_policy_fields_parse_from_json5() {
+        let content = r#"[
+          { "match": "*.html", "security_policy": "standard" },
+          { "match": "*.skip", "security_policy": "disabled", "disable_security_policy_warning": true }
+        ]"#;
+        let mut files = HashMap::new();
+        files.insert("", content);
+        let d = make_assets_dir(files, &["index.html", "ignore.skip"]);
+        let ac = load(&d);
+
+        let html_cfg = cfg(&ac, &d, "index.html");
+        assert_eq!(html_cfg.security_policy, Some(SecurityPolicy::Standard));
+        assert_eq!(html_cfg.disable_security_policy_warning, None);
+
+        let skip_cfg = cfg(&ac, &d, "ignore.skip");
+        assert_eq!(skip_cfg.security_policy, Some(SecurityPolicy::Disabled));
+        assert_eq!(skip_cfg.disable_security_policy_warning, Some(true));
+    }
+
+    #[test]
     fn combined_headers_disabled_policy_is_empty() {
         let cfg = AssetConfig {
             security_policy: Some(SecurityPolicy::Disabled),

--- a/assets-sync/src/lib.rs
+++ b/assets-sync/src/lib.rs
@@ -2,4 +2,5 @@ pub mod canister;
 pub mod config;
 pub mod content;
 pub mod scan;
+pub mod security_policy;
 pub mod sync;

--- a/assets-sync/src/security_policy.rs
+++ b/assets-sync/src/security_policy.rs
@@ -1,0 +1,250 @@
+//! Standard CSP and security headers selectable via `.ic-assets.json5`.
+//!
+//! Ported from `ic-asset/src/security_policy.rs`. The `ConcreteSecurityPolicy`
+//! struct and its `to_headers()` method produce the same canonical set of
+//! headers (`Content-Security-Policy`, `Permissions-Policy`, `X-Frame-Options`,
+//! `Referrer-Policy`, `Strict-Transport-Security`, `X-Content-Type-Options`,
+//! `X-XSS-Protection`) that `dfx deploy` would emit. The dfx-only
+//! `to_json5_str()` helper (used by `dfx info security-policy`) is not ported.
+//!
+//! The scan-time warnings about projects missing or under-hardening their
+//! policy live in [`report_security_policy_issues`]; the per-asset predicates
+//! they consult are methods on [`crate::config::AssetConfig`].
+
+use crate::config::HeadersConfig;
+use crate::scan::AssetSource;
+use serde::{Deserialize, Serialize};
+
+/// How an asset's security headers should be populated.
+///
+/// Selectable in `.ic-assets.json5` via the `"security_policy"` field.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Copy, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum SecurityPolicy {
+    /// No security headers are injected.
+    Disabled,
+    /// A baseline policy that works for most apps. Sync still warns that it
+    /// could be hardened further.
+    Standard,
+    /// Same headers as `Standard`, but the user has acknowledged the policy
+    /// and supplied custom hardening headers; the hardening warning is
+    /// suppressed and missing custom headers become a hard error.
+    Hardened,
+}
+
+impl SecurityPolicy {
+    pub(crate) fn to_headers(self) -> HeadersConfig {
+        self.to_policy().to_headers()
+    }
+
+    fn to_policy(self) -> ConcreteSecurityPolicy {
+        match self {
+            SecurityPolicy::Disabled => ConcreteSecurityPolicy { headers: vec![] },
+            SecurityPolicy::Standard | SecurityPolicy::Hardened => ConcreteSecurityPolicy {
+                headers: STANDARD_HEADERS.to_vec(),
+            },
+        }
+    }
+}
+
+struct ConcreteSecurityPolicy {
+    headers: Vec<(&'static str, &'static str)>,
+}
+
+impl ConcreteSecurityPolicy {
+    fn to_headers(&self) -> HeadersConfig {
+        self.headers
+            .iter()
+            .map(|(name, content)| (name.to_string(), content.to_string()))
+            .collect()
+    }
+}
+
+const STANDARD_HEADERS: &[(&str, &str)] = &[
+    (
+        "Content-Security-Policy",
+        "default-src 'self';script-src 'self';connect-src 'self' http://localhost:* https://icp0.io https://*.icp0.io https://icp-api.io;img-src 'self' data:;style-src * 'unsafe-inline';style-src-elem * 'unsafe-inline';font-src *;object-src 'none';base-uri 'self';frame-ancestors 'none';form-action 'self';upgrade-insecure-requests;",
+    ),
+    (
+        "Permissions-Policy",
+        "accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=(), clipboard-read=(), clipboard-write=(), gamepad=(), speaker-selection=(), conversion-measurement=(), focus-without-user-activation=(), hid=(), idle-detection=(), interest-cohort=(), serial=(), sync-script=(), trust-token-redemption=(), window-placement=(), vertical-scroll=()",
+    ),
+    ("X-Frame-Options", "DENY"),
+    ("Referrer-Policy", "same-origin"),
+    (
+        "Strict-Transport-Security",
+        "max-age=31536000; includeSubDomains",
+    ),
+    ("X-Content-Type-Options", "nosniff"),
+    ("X-XSS-Protection", "1; mode=block"),
+];
+
+/// Inspects the resolved configs across all sources and prints the same
+/// warnings that `ic-asset/src/sync.rs::gather_asset_descriptors` emits:
+/// no-policy notice, standard-policy hardening hint, and a hard error if any
+/// asset declares the `hardened` policy without supplying custom headers.
+pub fn report_security_policy_issues(sources: &[AssetSource]) -> Result<(), String> {
+    let no_policy: Vec<&AssetSource> = sources
+        .iter()
+        .filter(|s| s.config.warn_about_no_security_policy())
+        .collect();
+    if !no_policy.is_empty() {
+        let qnt = if no_policy.len() == sources.len() {
+            "any"
+        } else {
+            "some"
+        };
+        eprintln!("This project does not define a security policy for {qnt} assets.");
+        eprintln!("You should define a security policy in .ic-assets.json5. For example:");
+        eprintln!("[");
+        eprintln!("  {{");
+        eprintln!(r#"    "match": "**/*","#);
+        eprintln!(r#"    "security_policy": "standard""#);
+        eprintln!("  }}");
+        eprintln!("]");
+        if no_policy.len() != sources.len() {
+            eprintln!("Assets without any security policy:");
+            for s in &no_policy {
+                eprintln!("  - {}", s.key);
+            }
+        }
+    }
+
+    let standard: Vec<&AssetSource> = sources
+        .iter()
+        .filter(|s| s.config.warn_about_standard_security_policy())
+        .collect();
+    if !standard.is_empty() {
+        let qnt = if standard.len() == sources.len() {
+            "all"
+        } else {
+            "some"
+        };
+        eprintln!(
+            "This project uses the default security policy for {qnt} assets. While it is set up to work with many applications, it is recommended to further harden the policy to increase security against attacks like XSS."
+        );
+        if standard.len() != sources.len() {
+            eprintln!("Unhardened assets:");
+            for s in &standard {
+                eprintln!("  - {}", s.key);
+            }
+        }
+    }
+    if !standard.is_empty() || !no_policy.is_empty() {
+        eprintln!(
+            r#"To disable the policy warning, define "disable_security_policy_warning": true in .ic-assets.json5."#
+        );
+    }
+
+    let missing_hardening: Vec<&AssetSource> = sources
+        .iter()
+        .filter(|s| s.config.warn_about_missing_hardening_headers())
+        .collect();
+    if !missing_hardening.is_empty() {
+        let mut detail = String::new();
+        if missing_hardening.len() == sources.len() {
+            detail.push_str("Unhardened assets: all");
+        } else {
+            detail.push_str("Unhardened assets:");
+            for s in &missing_hardening {
+                detail.push_str(&format!("\n  - {}", s.key));
+            }
+        }
+        return Err(format!(
+            "security_policy is set to \"hardened\" but no custom headers are configured. {detail}"
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::AssetConfig;
+    use std::path::PathBuf;
+
+    fn src(key: &str, config: AssetConfig) -> AssetSource {
+        AssetSource {
+            path: PathBuf::from(key.trim_start_matches('/')),
+            key: key.to_string(),
+            config,
+        }
+    }
+
+    #[test]
+    fn disabled_policy_has_no_headers() {
+        assert!(SecurityPolicy::Disabled.to_headers().is_empty());
+    }
+
+    #[test]
+    fn standard_policy_includes_canonical_headers() {
+        let h = SecurityPolicy::Standard.to_headers();
+        assert!(h.contains_key("Content-Security-Policy"));
+        assert!(h.contains_key("Permissions-Policy"));
+        assert_eq!(h["X-Frame-Options"], "DENY");
+        assert_eq!(h["X-Content-Type-Options"], "nosniff");
+    }
+
+    #[test]
+    fn hardened_policy_returns_same_headers_as_standard() {
+        assert_eq!(
+            SecurityPolicy::Standard.to_headers(),
+            SecurityPolicy::Hardened.to_headers()
+        );
+    }
+
+    #[test]
+    fn report_warns_when_no_policy_for_all_assets() {
+        // Sanity: the predicate fires on default config.
+        let sources = vec![src("/a", AssetConfig::default())];
+        assert!(report_security_policy_issues(&sources).is_ok());
+    }
+
+    #[test]
+    fn report_errors_when_hardened_without_headers() {
+        let config = AssetConfig {
+            security_policy: Some(SecurityPolicy::Hardened),
+            ..AssetConfig::default()
+        };
+        let sources = vec![src("/a", config)];
+        let err = report_security_policy_issues(&sources).unwrap_err();
+        assert!(err.contains("hardened"), "got: {err}");
+    }
+
+    #[test]
+    fn report_ok_when_hardened_with_custom_headers() {
+        let mut headers = HeadersConfig::new();
+        headers.insert("X-Custom".to_string(), "1".to_string());
+        let config = AssetConfig {
+            security_policy: Some(SecurityPolicy::Hardened),
+            headers: Some(headers),
+            ..AssetConfig::default()
+        };
+        let sources = vec![src("/a", config)];
+        assert!(report_security_policy_issues(&sources).is_ok());
+    }
+
+    #[test]
+    fn report_ok_when_standard_policy_set() {
+        let config = AssetConfig {
+            security_policy: Some(SecurityPolicy::Standard),
+            ..AssetConfig::default()
+        };
+        let sources = vec![src("/a", config)];
+        assert!(report_security_policy_issues(&sources).is_ok());
+    }
+
+    #[test]
+    fn report_skips_warning_when_disabled_flag_set() {
+        let config = AssetConfig {
+            disable_security_policy_warning: Some(true),
+            ..AssetConfig::default()
+        };
+        let sources = vec![src("/a", config)];
+        // No policy + warning disabled → predicate is false; nothing to assert
+        // beyond a successful return (capturing stderr would be over-fit).
+        assert!(!sources[0].config.warn_about_no_security_policy());
+        assert!(report_security_policy_issues(&sources).is_ok());
+    }
+}

--- a/assets-sync/src/sync.rs
+++ b/assets-sync/src/sync.rs
@@ -3,7 +3,7 @@
 //! V2-only port of `ic-asset`'s `sync` flow, simplified:
 //! - synchronous (drives the host's sync `canister-call` import)
 //! - uses `create_chunk` (one-chunk-per-call) — no batched `create_chunks`
-//! - no proposal mode; no security policy
+//! - no proposal mode
 
 use candid::{Nat, Principal};
 use mime::Mime;
@@ -17,6 +17,7 @@ use crate::canister::{
 };
 use crate::content::{encoders_for, Content, Encoder};
 use crate::scan::AssetSource;
+use crate::security_policy::report_security_policy_issues;
 
 // Stay safely under the canister's ingress message limit (~2 MB).
 const MAX_CHUNK_SIZE: usize = 1_900_000;
@@ -80,6 +81,8 @@ pub fn sync<C: CanisterCall>(
 
     let sources = crate::scan::scan(dirs)?;
     println!("found {} file(s) from {:?}", sources.len(), dirs);
+
+    report_security_policy_issues(&sources)?;
 
     let canister_assets: HashMap<String, AssetDetails> = list_assets(canister)?
         .into_iter()

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -2,6 +2,7 @@ use assert_cmd::Command as AssertCmd;
 use candid::CandidType;
 use serde::Deserialize;
 use std::{
+    collections::BTreeMap,
     fs,
     path::{Path, PathBuf},
     process::Command,
@@ -103,6 +104,39 @@ pub fn setup_project(fixture_path: &str) -> tempfile::TempDir {
         .expect("failed to copy plugin.wasm");
 
     tmp
+}
+
+#[derive(CandidType, Clone, Debug, Deserialize, PartialEq)]
+pub struct AssetProperties {
+    pub max_age: Option<u64>,
+    pub headers: Option<BTreeMap<String, String>>,
+    pub allow_raw_access: Option<bool>,
+    pub is_aliased: Option<bool>,
+}
+
+/// Call `get_asset_properties` on the `frontend` canister for `key`.
+pub fn get_asset_properties(project: &Path, key: &str) -> AssetProperties {
+    let stdout = icp_cmd(project)
+        .args([
+            "canister",
+            "call",
+            "frontend",
+            "get_asset_properties",
+            &format!("(\"{key}\")"),
+            "-o",
+            "hex",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let hex_str = String::from_utf8_lossy(&stdout);
+    let bytes = hex::decode(hex_str.trim()).expect("failed to decode hex response");
+    let (properties,) = candid::decode_args::<(AssetProperties,)>(&bytes)
+        .expect("failed to decode candid response");
+    properties
 }
 
 /// Call `list` on the `frontend` canister and return all asset details.

--- a/e2e/tests/fixture/security-policy/dist/.ic-assets.json5
+++ b/e2e/tests/fixture/security-policy/dist/.ic-assets.json5
@@ -1,0 +1,4 @@
+[
+  // Apply the standard security policy to every asset.
+  { "match": "**/*", "security_policy": "standard" },
+]

--- a/e2e/tests/fixture/security-policy/dist/index.html
+++ b/e2e/tests/fixture/security-policy/dist/index.html
@@ -1,0 +1,1 @@
+<html><body><h1>hello</h1></body></html>

--- a/e2e/tests/fixture/security-policy/icp.yaml
+++ b/e2e/tests/fixture/security-policy/icp.yaml
@@ -1,0 +1,19 @@
+networks:
+  - name: local
+    mode: managed
+    gateway:
+      port: 0
+
+canisters:
+  - name: frontend
+    build:
+      steps:
+        - type: pre-built
+          path: wasms/canister.wasm
+
+    sync:
+      steps:
+        - type: plugin
+          path: wasms/plugin.wasm
+          dirs:
+            - dist

--- a/e2e/tests/sync.rs
+++ b/e2e/tests/sync.rs
@@ -1,5 +1,5 @@
 use candid::Principal;
-use e2e::{icp_cmd, list_assets, setup_project, AssetDetails, LocalNetwork};
+use e2e::{get_asset_properties, icp_cmd, list_assets, setup_project, AssetDetails, LocalNetwork};
 use std::fs;
 
 /// Deploy the test fixture to a local replica and verify that `/index.html` appears
@@ -182,6 +182,40 @@ fn asset_deletion() {
     assert!(
         !assets_after.iter().any(|a| a.key == "/style.css"),
         "/style.css should be removed from the canister after local deletion",
+    );
+}
+
+/// Deploy a fixture whose `.ic-assets.json5` declares `security_policy: "standard"`.
+/// The canister must store the canonical CSP / X-Frame-Options / etc. headers
+/// against the asset, proving the full chain — JSON5 parse → policy expansion →
+/// `CreateAssetArguments.headers` → canister state — is wired up.
+#[test]
+fn security_policy_headers_persisted() {
+    let tmp = setup_project("tests/fixture/security-policy");
+    let project = tmp.path();
+    let _network = LocalNetwork::start(project);
+
+    icp_cmd(project).arg("deploy").assert().success();
+
+    let props = get_asset_properties(project, "/index.html");
+    let headers = props
+        .headers
+        .expect("/index.html should have headers after deploy");
+
+    let csp = headers
+        .get("Content-Security-Policy")
+        .expect("Content-Security-Policy header should be present");
+    assert!(
+        csp.starts_with("default-src 'self'"),
+        "unexpected CSP value: {csp}",
+    );
+    assert_eq!(
+        headers.get("X-Frame-Options").map(String::as_str),
+        Some("DENY")
+    );
+    assert_eq!(
+        headers.get("X-Content-Type-Options").map(String::as_str),
+        Some("nosniff"),
     );
 }
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -53,7 +53,7 @@ The plugin calls `api_version` first and aborts if the canister advertises anyth
 
 - [x] **Warn on unmatched config rules** — track which `AssetConfigRule` glob patterns actually matched at least one asset during scanning, and warn about the unused ones so users are alerted to typos. Mirrors `ic-asset`'s `AssetSourceDirectoryConfiguration::get_unused_configs()` (see `ic-asset/src/asset/config.rs`).
 
-- [ ] **Security policy** — adopt `ic-asset`'s CSP / standard security headers. Depends on `.ic-assets.json5` parsing above.
+- [x] **Security policy** — adopt `ic-asset`'s CSP / standard security headers. Depends on `.ic-assets.json5` parsing above.
   - Port `SecurityPolicy` enum (`disabled` / `standard` / `hardened`) and the `ConcreteSecurityPolicy` / `to_headers()` logic from `ic-asset/src/security_policy.rs` into `assets-sync`.
   - Wire it into `AssetConfig::combined_headers()` so that `security_policy` entries in `.ic-assets.json5` expand into the corresponding `Content-Security-Policy`, `Permissions-Policy`, `X-Frame-Options`, etc. headers before the headers map is passed to `CreateAssetArguments`.
   - Emit the same warnings as `ic-asset/src/sync.rs` (`gather_asset_descriptors`): warn when no security policy is set for any asset, warn when `standard` policy is in use (suggesting hardening), and error when `hardened` is declared but no custom headers are provided.


### PR DESCRIPTION
## Summary
- Port `SecurityPolicy` (`disabled` / `standard` / `hardened`) and the canonical CSP / Permissions-Policy / X-Frame-Options / Referrer-Policy / HSTS / X-Content-Type-Options / X-XSS-Protection headers from `ic-asset/src/security_policy.rs` into `assets-sync`.
- `AssetConfig::combined_headers()` now merges policy-derived headers with user-supplied `headers` (custom wins, case-insensitively) before they reach `CreateAssetArguments`.
- `sync()` calls `report_security_policy_issues()` after `scan()`, mirroring `ic-asset/src/sync.rs::gather_asset_descriptors`: warns when no policy is set, hints that `standard` can be hardened, and errors out when `hardened` is declared without custom headers.

Resolves the **Security policy** TODO in `plugin/README.md`.