### PR TITLE
feat(ic-certified-assets): `_redirects`-style rules (Part 1, canister side)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1271,6 +1271,7 @@ dependencies = [
  "base64 0.22.1",
  "candid",
  "hex",
+ "http",
  "ic-cdk",
  "ic-certification 3.2.0",
  "ic-certification-testing",

--- a/canister/assets.did
+++ b/canister/assets.did
@@ -45,6 +45,24 @@ type BatchOperationKind = variant {
   DeleteAsset: DeleteAssetArguments;
 
   Clear: ClearArguments;
+
+  SetRedirectRules: SetRedirectRulesArguments;
+};
+
+type SetRedirectRulesArguments = record {
+  rules: vec RedirectRule;
+};
+
+type RulePattern = variant {
+  Exact: text;
+  Subtree: text;
+};
+
+type RedirectRule = record {
+  from: RulePattern;
+  to: text;
+  status: nat16;
+  headers: opt vec HeaderField;
 };
 
 type CommitBatchArguments = record {
@@ -257,6 +275,10 @@ service: (asset_canister_args: opt AssetCanisterArgs) -> {
   take_ownership: () -> ();
   list_authorized: () -> (vec principal);
   list_permitted: (ListPermitted) -> (vec principal);
+
+  // ───────── Redirect rules ─────────
+
+  get_redirect_rules: () -> (vec RedirectRule) query;
 
   // ───────── State integrity ─────────
 

--- a/canister/src/lib.rs
+++ b/canister/src/lib.rs
@@ -9,6 +9,7 @@ use ic_certified_assets::{
     http::{HttpRequest, HttpResponse, StreamingCallbackHttpResponse, StreamingCallbackToken},
     is_controller, is_manager_or_controller,
     rc_bytes::RcBytes,
+    redirect::RedirectRule,
     state::CertifiedTree,
     types::{
         AssetCanisterArgs, AssetProperties, CommitBatchArguments, ConfigurationResponse,
@@ -96,6 +97,11 @@ fn get_asset_properties(key: AssetKey) -> AssetProperties {
 #[query]
 fn get_state_info() -> StateInfo {
     ic_certified_assets::get_state_info()
+}
+
+#[query]
+fn get_redirect_rules() -> Vec<RedirectRule> {
+    ic_certified_assets::get_redirect_rules()
 }
 
 // Update methods

--- a/ic-certified-assets/Cargo.toml
+++ b/ic-certified-assets/Cargo.toml
@@ -15,6 +15,7 @@ rust-version = "1.84.0"
 base64.workspace = true
 candid.workspace = true
 hex.workspace = true
+http = "1"
 ic-cdk.workspace = true
 ic-certification = "3.0.3"
 ic-response-verification = "3.0.3"

--- a/ic-certified-assets/src/asset.rs
+++ b/ic-certified-assets/src/asset.rs
@@ -189,6 +189,12 @@ impl Asset {
         )
     }
 
+    /// Builds the response for one encoding.
+    ///
+    /// When `status_override` is `None` this serves the normal 200/304 path
+    /// (etag-based not-modified). When it is `Some(s)` — used by redirect
+    /// rules that serve a custom error page — the response always carries
+    /// the body with status `s`, and the etag / 304 logic is skipped.
     #[allow(clippy::too_many_arguments)]
     pub fn build_ok_http_response(
         &self,
@@ -199,6 +205,7 @@ impl Asset {
         certificate_header: Option<&HeaderField>,
         callback: &CallbackFunc,
         etags: &[Hash],
+        status_override: Option<u16>,
     ) -> HttpResponse {
         let mut headers = self.get_headers_for_asset(enc_name);
         if let Some(head) = certificate_header {
@@ -217,7 +224,9 @@ impl Asset {
             token,
         });
 
-        let (status_code, body) = if etags.contains(&enc.sha256) {
+        let (status_code, body) = if let Some(status) = status_override {
+            (status, enc.content_chunks[chunk_index].clone())
+        } else if etags.contains(&enc.sha256) {
             (304, RcBytes::default())
         } else {
             if !headers
@@ -241,6 +250,7 @@ impl Asset {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn build_http_response_for_encodings(
         &self,
         requested_encodings: &[String],
@@ -249,6 +259,7 @@ impl Asset {
         certificate_header: Option<&HeaderField>,
         callback: &CallbackFunc,
         etags: &[Hash],
+        status_override: Option<u16>,
     ) -> Option<HttpResponse> {
         // Return a requested encoding that is certified
         for enc_name in requested_encodings.iter() {
@@ -262,6 +273,7 @@ impl Asset {
                         certificate_header,
                         callback,
                         etags,
+                        status_override,
                     ));
                 }
             }
@@ -279,6 +291,7 @@ impl Asset {
                         certificate_header,
                         callback,
                         etags,
+                        status_override,
                     ));
                 }
             }

--- a/ic-certified-assets/src/asset.rs
+++ b/ic-certified-assets/src/asset.rs
@@ -8,20 +8,17 @@
 //!   Candid surface types used by `get` / `list`.
 //! - [`on_asset_change`] is the central re-certification routine: every State
 //!   method that mutates an asset funnels through it.
-//! - Aliasing helpers ([`aliases_of`], [`aliased_by`], [`is_html_key`]) and
-//!   [`encoding_certification_order`] are small key/encoding utilities shared
+//! - [`encoding_certification_order`] is a small encoding utility shared
 //!   between the state machine and the asset itself.
 
 use crate::certification::{
     build_ic_certificate_expression_from_headers_and_encoding,
     build_ic_certificate_expression_header, response_hash, AssetKey, AssetPath,
-    CertificateExpression, CertifiedResponses, HashTreePath, NestedTreeKey, RequestHash,
-    ResponseHash,
+    CertificateExpression, CertifiedResponses, HashTreePath, RequestHash, ResponseHash,
 };
 use crate::cookies::add_ic_env_cookie;
 use crate::http::{
     CallbackFunc, HeaderField, HttpResponse, StreamingCallbackToken, StreamingStrategy,
-    FALLBACK_FILE,
 };
 use crate::rc_bytes::RcBytes;
 use candid::{CandidType, Deserialize, Int, Nat};
@@ -51,9 +48,6 @@ pub fn encoding_certification_order<'a>(
     encoding_order
 }
 
-/// Default aliasing behavior.
-pub(crate) const DEFAULT_ALIAS_ENABLED: bool = true;
-
 const STATUS_CODES_TO_CERTIFY: [u16; 2] = [200, 304];
 
 pub(crate) type Timestamp = Int;
@@ -77,23 +71,6 @@ impl AssetEncoding {
                     path.hash_tree_path(ce, &RequestHash::default(), response_hash.into())
                 })
             })
-        })
-    }
-
-    fn not_found_hash_path(&self) -> Option<HashTreePath> {
-        self.certificate_expression.as_ref().and_then(|ce| {
-            self.response_hashes
-                .as_ref()
-                .and_then(|hashes| hashes.get(&200))
-                .map(|response_hash| {
-                    HashTreePath::from(Vec::<NestedTreeKey>::from([
-                        "http_expr".into(),
-                        "<*>".into(), // 404 not found wildcard segment
-                        ce.expression_hash.as_slice().into(),
-                        "".into(), // no request certification - use empty node
-                        response_hash.as_slice().into(),
-                    ]))
-                })
         })
     }
 
@@ -141,7 +118,6 @@ pub struct Asset {
     pub encodings: HashMap<String, AssetEncoding>,
     pub max_age: Option<u64>,
     pub headers: Option<BTreeMap<String, String>>,
-    pub is_aliased: Option<bool>,
     pub allow_raw_access: Option<bool>,
 }
 
@@ -360,7 +336,7 @@ pub(crate) fn on_asset_change(
 
     // Add ic_env cookie for html files, if the cookie value (canister env) is provided
     if let Some(encoded_canister_env) = encoded_canister_env {
-        if is_html_key(key) {
+        if key.ends_with(".html") {
             let headers = asset.headers.get_or_insert_default();
             add_ic_env_cookie(headers, encoded_canister_env);
         }
@@ -392,9 +368,6 @@ fn delete_preexisting_asset_hashes(
 ) {
     for key in affected_keys.iter() {
         asset_hashes.remove_responses_for_path(key);
-        if key == FALLBACK_FILE {
-            asset_hashes.remove_fallback_responses();
-        }
     }
 }
 
@@ -415,46 +388,5 @@ fn insert_new_response_hashes_for_encoding(
                 );
             }
         }
-        if key == FALLBACK_FILE {
-            if let Some(not_found_hash_path) = enc.not_found_hash_path() {
-                asset_hashes.certify_response_precomputed(&not_found_hash_path);
-            }
-        }
     }
-}
-
-// path like /path/to/my/asset should also be valid for /path/to/my/asset.html or /path/to/my/asset/index.html
-pub(crate) fn aliases_of(key: &AssetKey) -> Vec<AssetKey> {
-    if key.ends_with('/') {
-        vec![format!("{}index.html", key)]
-    } else if !is_html_key(key) {
-        vec![format!("{}.html", key), format!("{}/index.html", key)]
-    } else {
-        Vec::new()
-    }
-}
-
-// Determines possible original keys in case the supplied key is being aliaseded to.
-// Sort-of a reverse operation of `alias_of`
-pub(crate) fn aliased_by(key: &AssetKey) -> Vec<AssetKey> {
-    if key == "/index.html" {
-        vec![
-            key[..(key.len() - 5)].into(),
-            key[..(key.len() - 10)].into(),
-        ]
-    } else if key.ends_with("/index.html") {
-        vec![
-            key[..(key.len() - 5)].into(),
-            key[..(key.len() - 10)].into(),
-            key[..(key.len() - 11)].to_string(),
-        ]
-    } else if is_html_key(key) {
-        vec![key[..(key.len() - 5)].to_string()]
-    } else {
-        Vec::new()
-    }
-}
-
-pub(crate) fn is_html_key<T: AsRef<str>>(key: T) -> bool {
-    key.as_ref().ends_with(".html")
 }

--- a/ic-certified-assets/src/batch.rs
+++ b/ic-certified-assets/src/batch.rs
@@ -10,7 +10,7 @@
 //! helpers they rely on. State methods unrelated to batches stay in the
 //! state machine module.
 
-use crate::asset::{is_html_key, on_asset_change, Timestamp};
+use crate::asset::{on_asset_change, Timestamp};
 use crate::certification::{AssetKey, HashTreePath};
 use crate::http::HttpResponse;
 use crate::rc_bytes::RcBytes;
@@ -267,7 +267,7 @@ impl State {
                         let html_keys: Vec<_> = self
                             .assets
                             .keys()
-                            .filter(|key| is_html_key(key))
+                            .filter(|key| key.ends_with(".html"))
                             .cloned()
                             .collect();
 

--- a/ic-certified-assets/src/batch.rs
+++ b/ic-certified-assets/src/batch.rs
@@ -256,6 +256,11 @@ impl State {
                     // All operations processed
                     self.batches.remove(&batch_id);
                     self.certify_404_if_required();
+                    // Asset ops in this batch may have clobbered tree entries
+                    // that redirect rules own (any rule whose source path
+                    // collides with an asset's `<$>` slot). Re-cert them so
+                    // the batch ends with a consistent rule tree.
+                    self.on_redirect_rules_change();
 
                     // Move to cookie update phase if needed
                     if needs_cookie_update {
@@ -352,6 +357,7 @@ impl State {
                         }
                         validation.map(|_| {
                             self.redirect_rules = arg.rules.clone();
+                            self.on_redirect_rules_change();
                         })
                     }
                 };

--- a/ic-certified-assets/src/batch.rs
+++ b/ic-certified-assets/src/batch.rs
@@ -14,6 +14,7 @@ use crate::asset::{is_html_key, on_asset_change, Timestamp};
 use crate::certification::{AssetKey, HashTreePath};
 use crate::http::HttpResponse;
 use crate::rc_bytes::RcBytes;
+use crate::redirect;
 use crate::state::State;
 use crate::system_context::SystemContext;
 use crate::types::{
@@ -338,6 +339,20 @@ impl State {
                     }
                     BatchOperation::SetAssetProperties(arg) => {
                         self.set_asset_properties(arg.clone())
+                    }
+                    BatchOperation::SetRedirectRules(arg) => {
+                        // Validate every rule before mutating state so a single
+                        // bad rule fails the whole op with no partial update.
+                        let mut validation: Result<(), String> = Ok(());
+                        for rule in &arg.rules {
+                            if let Err(e) = redirect::validate(rule) {
+                                validation = Err(e);
+                                break;
+                            }
+                        }
+                        validation.map(|_| {
+                            self.redirect_rules = arg.rules.clone();
+                        })
                     }
                 };
                 if let Err(e) = result {

--- a/ic-certified-assets/src/certification.rs
+++ b/ic-certified-assets/src/certification.rs
@@ -502,6 +502,35 @@ impl CertifiedResponses {
         }
     }
 
+    /// Builds an `IC-Certificate` header for a response served from a specific
+    /// tree location. Unlike `witness_to_header`, which infers `expr_path` from
+    /// the request URL (and only knows about the root `<*>` fallback), this
+    /// helper takes the location explicitly so callers serving a non-root
+    /// subtree response can point the witness at the right `<*>` ancestor.
+    pub fn witness_to_header_with_location(
+        &self,
+        request_path: &str,
+        location: &HashTreePath,
+        certificate: &[u8],
+    ) -> (String, String) {
+        let (witness, _) = self.witness_path(request_path);
+        let mut serializer = serde_cbor::ser::Serializer::new(vec![]);
+        serializer.self_describe().unwrap();
+        witness.serialize(&mut serializer).unwrap();
+
+        (
+            "IC-Certificate".to_string(),
+            String::from("version=2, ")
+                + "certificate=:"
+                + &BASE64.encode(certificate)
+                + ":, tree=:"
+                + &BASE64.encode(serializer.into_inner())
+                + ":, expr_path=:"
+                + &location.expr_path()
+                + ":",
+        )
+    }
+
     /// Same as `witness_path`, but produces a header that can be returned as a `HttpResponse` header instead of a witness `HashTree`.
     pub fn witness_to_header(
         &self,

--- a/ic-certified-assets/src/certification.rs
+++ b/ic-certified-assets/src/certification.rs
@@ -272,7 +272,6 @@ where
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WitnessResult {
     PathFound,
-    FallbackFound,
     NoneFound,
 }
 
@@ -445,24 +444,16 @@ impl CertifiedResponses {
         self.delete(path.as_vec());
     }
 
-    /// If the path has certified responses this function creates a hash tree that proves...
-    /// * The path is part of the CertifiedResponses hash tree
+    /// Builds a witness `HashTree` for the given request path.
     ///
-    /// The hash tree then includes certification for all valid responses for this path.
-    ///
-    /// If the path has no certified responses this function creates a hash tree that proves...
-    /// * The absence of the path in the CertifiedResponses hash tree
-    /// * The presence/absence of a 404 response
-    ///
-    /// The hash tree then includes certification for all valid responses for a 404 response.
-    ///
-    /// # Return Value
-    /// `(found, tree)`
-    /// * `found`:
-    ///   * WitnessResult::Found if `path` has a certified response.
-    ///   * `WitnessResult::FallbackFound` if the path has no certified response, but the fallback path has.
-    ///   * `WitnessResult::NoneFound` if both `path` and the fallback path have no certified response.
-    /// * `tree`: The `HashTree` as described above.
+    /// * If `path` has a certified response, returns `(witness, PathFound)`
+    ///   where the witness proves that response.
+    /// * Otherwise returns `(absence proof + every `<*>` ancestor's subtree,
+    ///   NoneFound)`. The combined proof is enough for the verifier to
+    ///   match on a subtree-fallback response (e.g. a `Subtree` redirect
+    ///   rule) — callers that serve such a response use
+    ///   `witness_to_header_with_location` to point `expr_path` at the
+    ///   right `<*>` ancestor.
     pub fn witness_path(&self, path: &str) -> (HashTree, WitnessResult) {
         let path = AssetPath::from(path);
         let hash_tree_path_root = path.asset_hash_path_root();
@@ -483,12 +474,7 @@ impl CertifiedResponses {
                         merge_hash_trees(accumulator, new_proof)
                     });
 
-            let fallback_path = HashTreePath::not_found_base_path();
-            if self.contains_path(fallback_path.as_vec()) {
-                (combined_proof, WitnessResult::FallbackFound)
-            } else {
-                (combined_proof, WitnessResult::NoneFound)
-            }
+            (combined_proof, WitnessResult::NoneFound)
         }
     }
 

--- a/ic-certified-assets/src/http.rs
+++ b/ic-certified-assets/src/http.rs
@@ -5,9 +5,6 @@ use crate::rc_bytes::RcBytes;
 use candid::{define_function, CandidType, Deserialize, Nat};
 use serde_bytes::ByteBuf;
 
-/// The file to serve if the requested file wasn't found.
-pub const FALLBACK_FILE: &str = "/index.html";
-
 const HTTP_REDIRECT_PERMANENT: u16 = 308;
 
 pub type HeaderField = (String, String);

--- a/ic-certified-assets/src/lib.rs
+++ b/ic-certified-assets/src/lib.rs
@@ -6,6 +6,7 @@ mod cookies;
 pub mod http;
 pub mod nested_tree;
 pub mod rc_bytes;
+pub mod redirect;
 pub mod stable;
 pub mod state;
 pub mod state_hash;
@@ -223,6 +224,10 @@ pub fn get_chunk(arg: GetChunkArg) -> GetChunkResponse {
 
 pub fn list(request: ListRequest) -> Vec<AssetDetails> {
     with_state(|s| s.list_assets(request))
+}
+
+pub fn get_redirect_rules() -> Vec<crate::redirect::RedirectRule> {
+    with_state(|s| s.get_redirect_rules())
 }
 
 pub fn certified_tree() -> CertifiedTree {

--- a/ic-certified-assets/src/lib.rs
+++ b/ic-certified-assets/src/lib.rs
@@ -111,6 +111,7 @@ pub fn store(arg: StoreArg) {
         if let Err(msg) = s.store(arg, &system_context) {
             trap(&msg);
         }
+        s.on_redirect_rules_change();
         certified_data_set(s.root_hash());
     });
 }
@@ -138,6 +139,7 @@ pub fn create_asset(arg: CreateAssetArguments) {
         if let Err(msg) = s.create_asset(arg) {
             trap(&msg);
         }
+        s.on_redirect_rules_change();
         certified_data_set(s.root_hash());
     })
 }
@@ -149,6 +151,7 @@ pub fn set_asset_content(arg: SetAssetContentArguments) {
         if let Err(msg) = s.set_asset_content(arg, &system_context) {
             trap(&msg);
         }
+        s.on_redirect_rules_change();
         certified_data_set(s.root_hash());
     })
 }
@@ -158,6 +161,7 @@ pub fn unset_asset_content(arg: UnsetAssetContentArguments) {
         if let Err(msg) = s.unset_asset_content(arg) {
             trap(&msg);
         }
+        s.on_redirect_rules_change();
         certified_data_set(s.root_hash());
     })
 }
@@ -165,6 +169,7 @@ pub fn unset_asset_content(arg: UnsetAssetContentArguments) {
 pub fn delete_asset(arg: DeleteAssetArguments) {
     with_state_mut(|s| {
         s.delete_asset(arg);
+        s.on_redirect_rules_change();
         certified_data_set(s.root_hash());
     });
 }
@@ -172,6 +177,7 @@ pub fn delete_asset(arg: DeleteAssetArguments) {
 pub fn clear() {
     with_state_mut(|s| {
         s.clear();
+        s.on_redirect_rules_change();
         certified_data_set(s.root_hash());
     });
 }
@@ -274,6 +280,8 @@ pub fn set_asset_properties(arg: SetAssetPropertiesArguments) {
         if let Err(msg) = s.set_asset_properties(arg) {
             trap(&msg);
         }
+        s.on_redirect_rules_change();
+        certified_data_set(s.root_hash());
     })
 }
 

--- a/ic-certified-assets/src/redirect.rs
+++ b/ic-certified-assets/src/redirect.rs
@@ -1,11 +1,4 @@
 //! User-supplied redirect/rewrite/error rules expressed as `_redirects` entries.
-//!
-//! Step 1.1: types, validation, and storage only — rules are accepted by
-//! `commit_batch`, persist across upgrades, and round-trip through
-//! `get_redirect_rules`, but they don't yet affect certification or
-//! `http_request` resolution. Later steps in Part 1 wire the rules into the
-//! certified tree (1.2: 3xx/4xx; 1.3: status-200 rewrites) and remove the
-//! canister's built-in aliasing (1.4).
 
 use crate::certification::{
     build_ic_certificate_expression_from_headers, build_ic_certificate_expression_header,
@@ -55,8 +48,7 @@ const SUPPORTED_STATUS_CODES: &[StatusCode] = &[
     StatusCode::GONE,
 ];
 
-/// Shape-checks a rule. Step 1.1 only checks invariants that don't need rule
-/// semantics — later steps grow this with header/target rules.
+/// Shape-checks a rule.
 pub fn validate(rule: &RedirectRule) -> Result<(), String> {
     let from_path = match &rule.from {
         RulePattern::Exact(p) => p,
@@ -321,8 +313,7 @@ mod tests {
 
     #[test]
     fn validate_rejects_subtree_without_trailing_slash() {
-        let err =
-            validate(&rule(RulePattern::Subtree("/blog".into()), "/b", 301)).unwrap_err();
+        let err = validate(&rule(RulePattern::Subtree("/blog".into()), "/b", 301)).unwrap_err();
         assert!(err.contains("must end with '/'"), "got: {err}");
     }
 
@@ -379,7 +370,10 @@ mod tests {
         let mut r = rule(RulePattern::Exact("/a".into()), "/b", 301);
         r.headers = Some(vec![("Location".into(), "/other".into())]);
         let err = validate(&r).unwrap_err();
-        assert!(err.contains("derives it from the rule's 'to' field"), "got: {err}");
+        assert!(
+            err.contains("derives it from the rule's 'to' field"),
+            "got: {err}"
+        );
     }
 
     #[test]
@@ -487,10 +481,7 @@ mod tests {
         // `_redirects` always provides a target — empty `to` is a misuse.
         for status in [404, 410] {
             let err = validate(&rule(RulePattern::Exact("/x".into()), "", status)).unwrap_err();
-            assert!(
-                err.contains("must be an absolute asset path"),
-                "got: {err}"
-            );
+            assert!(err.contains("must be an absolute asset path"), "got: {err}");
         }
     }
 

--- a/ic-certified-assets/src/redirect.rs
+++ b/ic-certified-assets/src/redirect.rs
@@ -1,0 +1,228 @@
+//! User-supplied redirect/rewrite/error rules expressed as `_redirects` entries.
+//!
+//! Step 1.1: types, validation, and storage only — rules are accepted by
+//! `commit_batch`, persist across upgrades, and round-trip through
+//! `get_redirect_rules`, but they don't yet affect certification or
+//! `http_request` resolution. Later steps in Part 1 wire the rules into the
+//! certified tree (1.2: 3xx/4xx; 1.3: status-200 rewrites) and remove the
+//! canister's built-in aliasing (1.4).
+
+use candid::{CandidType, Deserialize};
+use serde::Serialize;
+
+/// A single rule, mirroring one line of a Netlify-style `_redirects` file.
+#[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize, Serialize)]
+pub struct RedirectRule {
+    /// Request-side pattern.
+    pub from: RulePattern,
+    /// Target. Interpretation depends on `status`:
+    /// - 200: absolute asset path
+    /// - 3xx: absolute URL or absolute path (sent as `Location`)
+    /// - 4xx: ignored (no target needed for an error response)
+    pub to: String,
+    /// One of 200, 301, 302, 307, 308, 404, 410.
+    pub status: u16,
+    /// Extra response headers on top of status-intrinsic ones.
+    pub headers: Option<Vec<(String, String)>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize, Serialize)]
+pub enum RulePattern {
+    /// Matches a single absolute path, e.g. `/old-page`.
+    Exact(String),
+    /// Matches any URL whose path starts with this prefix. The prefix must end
+    /// with `/` so the subtree boundary is unambiguous.
+    Subtree(String),
+}
+
+const SUPPORTED_STATUS_CODES: [u16; 7] = [200, 301, 302, 307, 308, 404, 410];
+
+/// Shape-checks a rule. Step 1.1 only checks invariants that don't need rule
+/// semantics — later steps grow this with header/target rules.
+pub fn validate(rule: &RedirectRule) -> Result<(), String> {
+    let from_path = match &rule.from {
+        RulePattern::Exact(p) => p,
+        RulePattern::Subtree(p) => {
+            if !p.ends_with('/') {
+                return Err(format!(
+                    "subtree pattern '{p}' must end with '/' for unambiguous prefix semantics"
+                ));
+            }
+            p
+        }
+    };
+    if !from_path.starts_with('/') {
+        return Err(format!(
+            "'from' pattern '{from_path}' must be an absolute path (start with '/')"
+        ));
+    }
+
+    if !SUPPORTED_STATUS_CODES.contains(&rule.status) {
+        return Err(format!(
+            "unsupported status code {} (expected one of 200, 301, 302, 307, 308, 404, 410)",
+            rule.status
+        ));
+    }
+
+    if rule.to.contains(":splat") || rule.to.contains(":placeholder") {
+        return Err(
+            "dynamic substitution (:splat / :placeholder) is not supported in this version, \
+             see follow-up plan"
+                .to_string(),
+        );
+    }
+
+    if let Some(headers) = &rule.headers {
+        for (k, v) in headers {
+            if k.is_empty() {
+                return Err("header name must not be empty".to_string());
+            }
+            if v.is_empty() {
+                return Err(format!("header '{k}' has empty value"));
+            }
+            if !k.bytes().all(is_valid_header_name_byte) {
+                return Err(format!("header name '{k}' contains invalid characters"));
+            }
+            if !v.bytes().all(is_valid_header_value_byte) {
+                return Err(format!("header '{k}' value contains invalid characters"));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn is_valid_header_name_byte(b: u8) -> bool {
+    // RFC 7230 token characters.
+    matches!(b,
+        b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9'
+        | b'!' | b'#' | b'$' | b'%' | b'&' | b'\'' | b'*' | b'+' | b'-' | b'.'
+        | b'^' | b'_' | b'`' | b'|' | b'~'
+    )
+}
+
+fn is_valid_header_value_byte(b: u8) -> bool {
+    // Visible ASCII plus space/tab — matches RFC 7230 `field-value` for the
+    // common single-line case. We deliberately reject CR/LF so a rule can't
+    // smuggle header injection through the canister.
+    b == b'\t' || (0x20..=0x7e).contains(&b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candid::{decode_one, encode_one};
+
+    fn rule(from: RulePattern, to: &str, status: u16) -> RedirectRule {
+        RedirectRule {
+            from,
+            to: to.to_string(),
+            status,
+            headers: None,
+        }
+    }
+
+    #[test]
+    fn validate_accepts_supported_shapes() {
+        for status in [200, 301, 302, 307, 308, 404, 410] {
+            validate(&rule(RulePattern::Exact("/a".into()), "/b", status)).unwrap();
+            validate(&rule(RulePattern::Subtree("/a/".into()), "/b", status)).unwrap();
+        }
+    }
+
+    #[test]
+    fn validate_rejects_relative_from() {
+        let err = validate(&rule(RulePattern::Exact("relative".into()), "/b", 301)).unwrap_err();
+        assert!(err.contains("absolute"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_subtree_without_trailing_slash() {
+        let err =
+            validate(&rule(RulePattern::Subtree("/blog".into()), "/b", 301)).unwrap_err();
+        assert!(err.contains("must end with '/'"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_unsupported_status() {
+        let err = validate(&rule(RulePattern::Exact("/a".into()), "/b", 418)).unwrap_err();
+        assert!(err.contains("unsupported status code 418"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_splat_in_target() {
+        let err =
+            validate(&rule(RulePattern::Subtree("/a/".into()), "/b/:splat", 301)).unwrap_err();
+        assert!(err.contains("dynamic substitution"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_placeholder_in_target() {
+        let err = validate(&rule(
+            RulePattern::Subtree("/a/".into()),
+            "/b/:placeholder",
+            301,
+        ))
+        .unwrap_err();
+        assert!(err.contains("dynamic substitution"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_empty_header_name() {
+        let mut r = rule(RulePattern::Exact("/a".into()), "/b", 301);
+        r.headers = Some(vec![("".into(), "v".into())]);
+        let err = validate(&r).unwrap_err();
+        assert!(err.contains("header name must not be empty"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_empty_header_value() {
+        let mut r = rule(RulePattern::Exact("/a".into()), "/b", 301);
+        r.headers = Some(vec![("X-Foo".into(), "".into())]);
+        let err = validate(&r).unwrap_err();
+        assert!(err.contains("empty value"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_crlf_in_header_value() {
+        let mut r = rule(RulePattern::Exact("/a".into()), "/b", 301);
+        r.headers = Some(vec![("X-Foo".into(), "bar\r\nX-Evil: 1".into())]);
+        let err = validate(&r).unwrap_err();
+        assert!(err.contains("invalid characters"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_non_token_header_name() {
+        let mut r = rule(RulePattern::Exact("/a".into()), "/b", 301);
+        r.headers = Some(vec![("X Foo".into(), "bar".into())]);
+        let err = validate(&r).unwrap_err();
+        assert!(err.contains("invalid characters"), "got: {err}");
+    }
+
+    #[test]
+    fn candid_roundtrip_preserves_rule() {
+        let r = RedirectRule {
+            from: RulePattern::Subtree("/blog/".into()),
+            to: "/home".into(),
+            status: 308,
+            headers: Some(vec![("X-Trace".into(), "1".into())]),
+        };
+        let bytes = encode_one(&r).unwrap();
+        let back: RedirectRule = decode_one(&bytes).unwrap();
+        assert_eq!(r, back);
+    }
+
+    #[test]
+    fn serde_roundtrip_preserves_rule() {
+        // The stable-state serializer uses serde, not Candid.
+        let r = RedirectRule {
+            from: RulePattern::Exact("/old".into()),
+            to: "/new".into(),
+            status: 301,
+            headers: None,
+        };
+        let bytes = serde_cbor::to_vec(&r).unwrap();
+        let back: RedirectRule = serde_cbor::from_slice(&bytes).unwrap();
+        assert_eq!(r, back);
+    }
+}

--- a/ic-certified-assets/src/redirect.rs
+++ b/ic-certified-assets/src/redirect.rs
@@ -9,7 +9,7 @@
 
 use crate::certification::{
     build_ic_certificate_expression_from_headers, build_ic_certificate_expression_header,
-    response_hash, CertificateExpression, HashTreePath, NestedTreeKey,
+    response_hash, AssetPath, CertificateExpression, HashTreePath, NestedTreeKey,
 };
 use candid::{CandidType, Deserialize};
 use ic_representation_independent_hash::Value;
@@ -162,16 +162,23 @@ impl RedirectRule {
     /// terminator (`<$>` for exact matches, `<*>` for subtrees), without the
     /// per-response (expr_hash, req_hash, resp_hash) tail.
     pub fn tree_location(&self) -> HashTreePath {
-        let (path, sentinel) = match &self.from {
-            RulePattern::Exact(p) => (p.as_str(), "<$>"),
-            RulePattern::Subtree(p) => (p.trim_end_matches('/'), "<*>"),
-        };
-        let mut segs: Vec<NestedTreeKey> = vec!["http_expr".into()];
-        for s in path.split('/').filter(|s| !s.is_empty()) {
-            segs.push(NestedTreeKey::String(s.to_string()));
+        match &self.from {
+            // Mirror `AssetPath::from(path).asset_hash_path_root()` so a rule
+            // at `/old` lives in the same `<$>` slot the asset at `/old`
+            // would occupy.
+            RulePattern::Exact(p) => AssetPath::from(p.as_str()).asset_hash_path_root(),
+            RulePattern::Subtree(p) => {
+                let trimmed = p.trim_matches('/');
+                let mut segs: Vec<NestedTreeKey> = vec!["http_expr".into()];
+                if !trimmed.is_empty() {
+                    for s in trimmed.split('/') {
+                        segs.push(NestedTreeKey::String(s.to_string()));
+                    }
+                }
+                segs.push("<*>".into());
+                HashTreePath::from(segs)
+            }
         }
-        segs.push(NestedTreeKey::String(sentinel.to_string()));
-        HashTreePath::from(segs)
     }
 
     /// Headers that are part of the certified response for this rule. The
@@ -416,6 +423,23 @@ mod tests {
             })
             .collect();
         assert_eq!(names, vec!["http_expr", "<*>"]);
+    }
+
+    #[test]
+    fn tree_location_root_exact_matches_asset_path() {
+        // An exact rule at `/` must share the same `<$>` slot the asset at
+        // `/` would occupy, including the empty segment that
+        // `AssetPath::from("/")` produces.
+        let r = rule(RulePattern::Exact("/".into()), "/index.html", 200);
+        let segs = r.tree_location().0;
+        let names: Vec<&str> = segs
+            .iter()
+            .map(|k| match k {
+                NestedTreeKey::String(s) => s.as_str(),
+                _ => panic!("expected string segment"),
+            })
+            .collect();
+        assert_eq!(names, vec!["http_expr", "", "<$>"]);
     }
 
     #[test]

--- a/ic-certified-assets/src/redirect.rs
+++ b/ic-certified-assets/src/redirect.rs
@@ -22,9 +22,10 @@ pub struct RedirectRule {
     /// Request-side pattern.
     pub from: RulePattern,
     /// Target. Interpretation depends on `status`:
-    /// - 200: absolute asset path
+    /// - 200: absolute asset path (rewrite — serve target's body)
     /// - 3xx: absolute URL or absolute path (sent as `Location`)
-    /// - 4xx: ignored (no target needed for an error response)
+    /// - 4xx: empty for a synthesized body, or an absolute asset path to
+    ///   serve as the custom error page (e.g. `/404.html`)
     pub to: String,
     /// One of 200, 301, 302, 307, 308, 404, 410.
     pub status: u16,
@@ -85,6 +86,14 @@ pub fn validate(rule: &RedirectRule) -> Result<(), String> {
         ));
     }
 
+    if matches!(rule.status, 404 | 410) && !rule.to.is_empty() && !rule.to.starts_with('/') {
+        return Err(format!(
+            "'to' for a 4xx rule must be empty or an absolute asset path \
+             (e.g. '/404.html'); got '{}'",
+            rule.to
+        ));
+    }
+
     if let Some(headers) = &rule.headers {
         let is_redirect = (301..=308).contains(&rule.status);
         for (k, v) in headers {
@@ -112,10 +121,16 @@ pub fn validate(rule: &RedirectRule) -> Result<(), String> {
                     )
                 });
             }
-            if rule.status == 200 && k.eq_ignore_ascii_case("content-type") {
+            // For rules that borrow a body from a target asset (200 rewrites
+            // and 4xx custom error pages), the content-type comes from the
+            // target — overriding it would split it from the certified
+            // headers the verifier checks.
+            let borrows_from_target = rule.status == 200
+                || (matches!(rule.status, 404 | 410) && !rule.to.is_empty());
+            if borrows_from_target && k.eq_ignore_ascii_case("content-type") {
                 return Err(
-                    "'content-type' header must not be overridden on a status-200 rewrite; \
-                     the canister takes it from the target asset"
+                    "'content-type' header must not be overridden when the rule serves an \
+                     asset body; the canister takes 'content-type' from the target asset"
                         .to_string(),
                 );
             }
@@ -228,10 +243,18 @@ pub struct CertifiedRuleEntry {
 
 #[derive(Clone, Debug)]
 pub enum CertifiedRuleEntryKind {
-    /// 3xx / 4xx rule: response body and headers are synthesized by the rule.
+    /// 3xx rule, or 4xx rule with no `to` target: response body and headers
+    /// are synthesized by the rule.
     Synthetic { expression: CertificateExpression },
-    /// Status-200 rule: response borrows everything from the target asset.
-    AliasOf { target_key: String },
+    /// Rule borrows its body from a target asset.
+    ///
+    /// `status == 200`: pure rewrite — the rule re-uses each encoding's
+    /// existing certified response hash verbatim.
+    ///
+    /// `status` is 404 or 410: custom error page — the rule serves the
+    /// target asset's body but re-certifies each encoding with the override
+    /// status (different response_hash than the asset's own 200 entry).
+    AliasOf { target_key: String, status: u16 },
 }
 
 /// Build the certified-tree entries for a non-status-200 rule. The rule's

--- a/ic-certified-assets/src/redirect.rs
+++ b/ic-certified-assets/src/redirect.rs
@@ -24,8 +24,10 @@ pub struct RedirectRule {
     /// Target. Interpretation depends on `status`:
     /// - 200: absolute asset path (rewrite — serve target's body)
     /// - 3xx: absolute URL or absolute path (sent as `Location`)
-    /// - 4xx: empty for a synthesized body, or an absolute asset path to
-    ///   serve as the custom error page (e.g. `/404.html`)
+    /// - 4xx: absolute asset path to serve as the custom error page
+    ///   (e.g. `/404.html`); if the asset doesn't exist the rule stays
+    ///   inert and unmatched paths fall through to the canister's
+    ///   built-in 404
     pub to: String,
     /// One of 200, 301, 302, 307, 308, 404, 410.
     pub status: u16,
@@ -86,9 +88,9 @@ pub fn validate(rule: &RedirectRule) -> Result<(), String> {
         ));
     }
 
-    if matches!(rule.status, 404 | 410) && !rule.to.is_empty() && !rule.to.starts_with('/') {
+    if matches!(rule.status, 404 | 410) && !rule.to.starts_with('/') {
         return Err(format!(
-            "'to' for a 4xx rule must be empty or an absolute asset path \
+            "'to' for a 4xx rule must be an absolute asset path \
              (e.g. '/404.html'); got '{}'",
             rule.to
         ));
@@ -125,8 +127,7 @@ pub fn validate(rule: &RedirectRule) -> Result<(), String> {
             // and 4xx custom error pages), the content-type comes from the
             // target — overriding it would split it from the certified
             // headers the verifier checks.
-            let borrows_from_target = rule.status == 200
-                || (matches!(rule.status, 404 | 410) && !rule.to.is_empty());
+            let borrows_from_target = matches!(rule.status, 200 | 404 | 410);
             if borrows_from_target && k.eq_ignore_ascii_case("content-type") {
                 return Err(
                     "'content-type' header must not be overridden when the rule serves an \
@@ -196,13 +197,10 @@ impl RedirectRule {
         }
     }
 
-    /// Headers that are part of the certified response for this rule. The
-    /// `ic-certificateexpression` header is appended at certification time and
-    /// is not included here.
-    ///
-    /// Step 1.2: 3xx rules carry `content-type` + `Location`, 4xx rules carry
-    /// `content-type`. Status-200 rules (step 1.3) borrow their headers from
-    /// the target asset; this method is not used in that path.
+    /// Headers that the rule itself synthesizes (used only by 3xx rules; 200
+    /// and 4xx rules borrow their headers from the target asset). The
+    /// `ic-certificateexpression` header is appended at certification time
+    /// and is not included here.
     pub fn certified_headers(&self) -> Vec<(String, String)> {
         let mut headers: Vec<(String, String)> =
             vec![("content-type".to_string(), "text/plain".to_string())];
@@ -215,15 +213,6 @@ impl RedirectRule {
             }
         }
         headers
-    }
-
-    /// Synthesized response body for the rule's status.
-    pub fn body(&self) -> Vec<u8> {
-        match self.status {
-            404 => b"Not Found".to_vec(),
-            410 => b"Gone".to_vec(),
-            _ => Vec::new(),
-        }
     }
 }
 
@@ -257,8 +246,9 @@ pub enum CertifiedRuleEntryKind {
     AliasOf { target_key: String, status: u16 },
 }
 
-/// Build the certified-tree entries for a non-status-200 rule. The rule's
-/// body and headers come from the rule itself.
+/// Build the certified-tree entries for a 3xx redirect rule. The response
+/// has an empty body; only the headers (content-type, Location, and any
+/// rule-supplied extras) are certified.
 pub(crate) fn build_synthetic_entry(rule: &RedirectRule) -> CertifiedRuleEntry {
     let headers = rule.certified_headers();
     let header_values: Vec<(String, Value)> = headers
@@ -266,8 +256,7 @@ pub(crate) fn build_synthetic_entry(rule: &RedirectRule) -> CertifiedRuleEntry {
         .map(|(k, v)| (k.clone(), Value::String(v.clone())))
         .collect();
 
-    let body = rule.body();
-    let body_hash: [u8; 32] = sha2::Sha256::digest(&body).into();
+    let body_hash: [u8; 32] = sha2::Sha256::digest([]).into();
 
     let expression = build_ic_certificate_expression_from_headers(&header_values);
 
@@ -474,41 +463,17 @@ mod tests {
     }
 
     #[test]
-    fn certified_headers_4xx_no_location() {
-        let r = rule(RulePattern::Exact("/missing".into()), "", 404);
-        let headers = r.certified_headers();
-        assert!(headers.iter().all(|(k, _)| k != "location"));
-        assert!(headers.iter().any(|(k, _)| k == "content-type"));
-    }
-
-    #[test]
-    fn body_4xx_nonempty() {
-        let r404 = rule(RulePattern::Exact("/missing".into()), "", 404);
-        let r410 = rule(RulePattern::Exact("/gone".into()), "", 410);
-        assert_eq!(r404.body(), b"Not Found");
-        assert_eq!(r410.body(), b"Gone");
-    }
-
-    #[test]
-    fn body_3xx_empty() {
-        let r = rule(RulePattern::Exact("/old".into()), "/new", 301);
-        assert!(r.body().is_empty());
-    }
-
-    #[test]
     fn build_synthetic_entry_distinct_per_status() {
-        // Different status codes must yield different response hashes so the
-        // tree can disambiguate identical paths.
+        // Different 3xx status codes must yield different response hashes so
+        // the tree can disambiguate identical paths.
         let exact = RulePattern::Exact("/x".into());
         let e301 = build_synthetic_entry(&rule(exact.clone(), "/y", 301));
         let e302 = build_synthetic_entry(&rule(exact.clone(), "/y", 302));
-        let e404 = build_synthetic_entry(&rule(exact, "", 404));
-        // All three sit at the same tree location prefix.
+        let e307 = build_synthetic_entry(&rule(exact, "/y", 307));
         assert_eq!(e301.location.0, e302.location.0);
-        assert_eq!(e301.location.0, e404.location.0);
-        // ...but their full tree paths differ in expr_hash / resp_hash.
+        assert_eq!(e301.location.0, e307.location.0);
         assert_ne!(e301.tree_paths[0].0, e302.tree_paths[0].0);
-        assert_ne!(e301.tree_paths[0].0, e404.tree_paths[0].0);
+        assert_ne!(e301.tree_paths[0].0, e307.tree_paths[0].0);
     }
 
     #[test]
@@ -520,6 +485,18 @@ mod tests {
         );
         let err = validate(&r).unwrap_err();
         assert!(err.contains("absolute asset path"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_4xx_empty_target() {
+        // `_redirects` always provides a target — empty `to` is a misuse.
+        for status in [404, 410] {
+            let err = validate(&rule(RulePattern::Exact("/x".into()), "", status)).unwrap_err();
+            assert!(
+                err.contains("must be an absolute asset path"),
+                "got: {err}"
+            );
+        }
     }
 
     #[test]

--- a/ic-certified-assets/src/redirect.rs
+++ b/ic-certified-assets/src/redirect.rs
@@ -78,6 +78,13 @@ pub fn validate(rule: &RedirectRule) -> Result<(), String> {
         );
     }
 
+    if rule.status == 200 && !rule.to.starts_with('/') {
+        return Err(format!(
+            "'to' for a status-200 rewrite must be an absolute asset path (got '{}')",
+            rule.to
+        ));
+    }
+
     if let Some(headers) = &rule.headers {
         let is_redirect = (301..=308).contains(&rule.status);
         for (k, v) in headers {
@@ -104,6 +111,13 @@ pub fn validate(rule: &RedirectRule) -> Result<(), String> {
                         rule.status
                     )
                 });
+            }
+            if rule.status == 200 && k.eq_ignore_ascii_case("content-type") {
+                return Err(
+                    "'content-type' header must not be overridden on a status-200 rewrite; \
+                     the canister takes it from the target asset"
+                        .to_string(),
+                );
             }
         }
     }
@@ -191,21 +205,31 @@ impl RedirectRule {
     }
 }
 
-/// Precomputed certified-tree entry for a single rule.
+/// Precomputed certified-tree entries for a single rule.
+///
+/// `tree_paths` holds every leaf the rule owns — one for a synthetic
+/// (3xx/4xx) response, or one per encoding for a status-200 rewrite that
+/// mirrors a multi-encoding target asset.
 #[derive(Clone, Debug)]
 pub struct CertifiedRuleEntry {
-    /// Full path including the per-response tail — used to insert/remove the
-    /// entry in the asset_hashes tree.
-    pub tree_path: HashTreePath,
+    pub tree_paths: Vec<HashTreePath>,
     /// Location prefix (`["http_expr", segs.., "<$>"|"<*>"]`) — used as the
     /// `expr_path` field of the `IC-Certificate` response header.
     pub location: HashTreePath,
-    /// The certificate expression listing the certified header names.
-    pub expression: CertificateExpression,
+    pub kind: CertifiedRuleEntryKind,
 }
 
-/// Build the certified-tree entry for a non-status-200 rule.
-pub(crate) fn build_certified_entry(rule: &RedirectRule) -> CertifiedRuleEntry {
+#[derive(Clone, Debug)]
+pub enum CertifiedRuleEntryKind {
+    /// 3xx / 4xx rule: response body and headers are synthesized by the rule.
+    Synthetic { expression: CertificateExpression },
+    /// Status-200 rule: response borrows everything from the target asset.
+    AliasOf { target_key: String },
+}
+
+/// Build the certified-tree entries for a non-status-200 rule. The rule's
+/// body and headers come from the rule itself.
+pub(crate) fn build_synthetic_entry(rule: &RedirectRule) -> CertifiedRuleEntry {
     let headers = rule.certified_headers();
     let header_values: Vec<(String, Value)> = headers
         .iter()
@@ -232,10 +256,25 @@ pub(crate) fn build_certified_entry(rule: &RedirectRule) -> CertifiedRuleEntry {
     full_segs.push(NestedTreeKey::Hash(resp_hash.0));
 
     CertifiedRuleEntry {
-        tree_path: HashTreePath::from(full_segs),
+        tree_paths: vec![HashTreePath::from(full_segs)],
         location,
-        expression,
+        kind: CertifiedRuleEntryKind::Synthetic { expression },
     }
+}
+
+/// Build a tree path slot for the rule's location with the given expression
+/// hash and response hash. Used by the status-200 path to mirror each
+/// encoding of a target asset.
+pub(crate) fn alias_tree_path(
+    location: &HashTreePath,
+    expression_hash: [u8; 32],
+    response_hash: [u8; 32],
+) -> HashTreePath {
+    let mut segs = location.0.clone();
+    segs.push(NestedTreeKey::Hash(expression_hash));
+    segs.push(NestedTreeKey::String(String::new()));
+    segs.push(NestedTreeKey::Hash(response_hash));
+    HashTreePath::from(segs)
 }
 
 #[cfg(test)]
@@ -410,19 +449,38 @@ mod tests {
     }
 
     #[test]
-    fn build_certified_entry_distinct_per_status() {
+    fn build_synthetic_entry_distinct_per_status() {
         // Different status codes must yield different response hashes so the
         // tree can disambiguate identical paths.
         let exact = RulePattern::Exact("/x".into());
-        let e301 = build_certified_entry(&rule(exact.clone(), "/y", 301));
-        let e302 = build_certified_entry(&rule(exact.clone(), "/y", 302));
-        let e404 = build_certified_entry(&rule(exact, "", 404));
+        let e301 = build_synthetic_entry(&rule(exact.clone(), "/y", 301));
+        let e302 = build_synthetic_entry(&rule(exact.clone(), "/y", 302));
+        let e404 = build_synthetic_entry(&rule(exact, "", 404));
         // All three sit at the same tree location prefix.
         assert_eq!(e301.location.0, e302.location.0);
         assert_eq!(e301.location.0, e404.location.0);
         // ...but their full tree paths differ in expr_hash / resp_hash.
-        assert_ne!(e301.tree_path.0, e302.tree_path.0);
-        assert_ne!(e301.tree_path.0, e404.tree_path.0);
+        assert_ne!(e301.tree_paths[0].0, e302.tree_paths[0].0);
+        assert_ne!(e301.tree_paths[0].0, e404.tree_paths[0].0);
+    }
+
+    #[test]
+    fn validate_rejects_status_200_to_external_url() {
+        let r = rule(
+            RulePattern::Exact("/foo".into()),
+            "https://example.com/",
+            200,
+        );
+        let err = validate(&r).unwrap_err();
+        assert!(err.contains("absolute asset path"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_content_type_override_on_200() {
+        let mut r = rule(RulePattern::Exact("/foo".into()), "/target.html", 200);
+        r.headers = Some(vec![("Content-Type".into(), "text/plain".into())]);
+        let err = validate(&r).unwrap_err();
+        assert!(err.contains("content-type"), "got: {err}");
     }
 
     #[test]

--- a/ic-certified-assets/src/redirect.rs
+++ b/ic-certified-assets/src/redirect.rs
@@ -12,6 +12,7 @@ use crate::certification::{
     response_hash, AssetPath, CertificateExpression, HashTreePath, NestedTreeKey,
 };
 use candid::{CandidType, Deserialize};
+use http::{HeaderName, HeaderValue, StatusCode};
 use ic_representation_independent_hash::Value;
 use serde::Serialize;
 use sha2::Digest;
@@ -44,7 +45,15 @@ pub enum RulePattern {
     Subtree(String),
 }
 
-const SUPPORTED_STATUS_CODES: [u16; 7] = [200, 301, 302, 307, 308, 404, 410];
+const SUPPORTED_STATUS_CODES: &[StatusCode] = &[
+    StatusCode::OK,
+    StatusCode::MOVED_PERMANENTLY,
+    StatusCode::FOUND,
+    StatusCode::TEMPORARY_REDIRECT,
+    StatusCode::PERMANENT_REDIRECT,
+    StatusCode::NOT_FOUND,
+    StatusCode::GONE,
+];
 
 /// Shape-checks a rule. Step 1.1 only checks invariants that don't need rule
 /// semantics — later steps grow this with header/target rules.
@@ -66,12 +75,15 @@ pub fn validate(rule: &RedirectRule) -> Result<(), String> {
         ));
     }
 
-    if !SUPPORTED_STATUS_CODES.contains(&rule.status) {
-        return Err(format!(
-            "unsupported status code {} (expected one of 200, 301, 302, 307, 308, 404, 410)",
-            rule.status
-        ));
-    }
+    let status = StatusCode::from_u16(rule.status)
+        .ok()
+        .filter(|s| SUPPORTED_STATUS_CODES.contains(s))
+        .ok_or_else(|| {
+            format!(
+                "unsupported status code {} (expected one of 200, 301, 302, 307, 308, 404, 410)",
+                rule.status
+            )
+        })?;
 
     if rule.to.contains(":splat") || rule.to.contains(":placeholder") {
         return Err(
@@ -81,14 +93,14 @@ pub fn validate(rule: &RedirectRule) -> Result<(), String> {
         );
     }
 
-    if rule.status == 200 && !rule.to.starts_with('/') {
+    if status == StatusCode::OK && !rule.to.starts_with('/') {
         return Err(format!(
             "'to' for a status-200 rewrite must be an absolute asset path (got '{}')",
             rule.to
         ));
     }
 
-    if matches!(rule.status, 404 | 410) && !rule.to.starts_with('/') {
+    if status.is_client_error() && !rule.to.starts_with('/') {
         return Err(format!(
             "'to' for a 4xx rule must be an absolute asset path \
              (e.g. '/404.html'); got '{}'",
@@ -97,7 +109,6 @@ pub fn validate(rule: &RedirectRule) -> Result<(), String> {
     }
 
     if let Some(headers) = &rule.headers {
-        let is_redirect = (301..=308).contains(&rule.status);
         for (k, v) in headers {
             if k.is_empty() {
                 return Err("header name must not be empty".to_string());
@@ -105,14 +116,14 @@ pub fn validate(rule: &RedirectRule) -> Result<(), String> {
             if v.is_empty() {
                 return Err(format!("header '{k}' has empty value"));
             }
-            if !k.bytes().all(is_valid_header_name_byte) {
-                return Err(format!("header name '{k}' contains invalid characters"));
-            }
-            if !v.bytes().all(is_valid_header_value_byte) {
-                return Err(format!("header '{k}' value contains invalid characters"));
-            }
-            if k.eq_ignore_ascii_case("location") {
-                return Err(if is_redirect {
+            let name = HeaderName::from_bytes(k.as_bytes())
+                .map_err(|_| format!("header name '{k}' contains invalid characters"))?;
+            // `HeaderValue` rejects CR/LF, so a rule can't smuggle header
+            // injection through the canister.
+            HeaderValue::from_str(v)
+                .map_err(|_| format!("header '{k}' value contains invalid characters"))?;
+            if name == http::header::LOCATION {
+                return Err(if status.is_redirection() {
                     "'Location' header must not be set on a 3xx rule; \
                      the canister derives it from the rule's 'to' field"
                         .to_string()
@@ -127,8 +138,8 @@ pub fn validate(rule: &RedirectRule) -> Result<(), String> {
             // and 4xx custom error pages), the content-type comes from the
             // target — overriding it would split it from the certified
             // headers the verifier checks.
-            let borrows_from_target = matches!(rule.status, 200 | 404 | 410);
-            if borrows_from_target && k.eq_ignore_ascii_case("content-type") {
+            let borrows_from_target = status == StatusCode::OK || status.is_client_error();
+            if borrows_from_target && name == http::header::CONTENT_TYPE {
                 return Err(
                     "'content-type' header must not be overridden when the rule serves an \
                      asset body; the canister takes 'content-type' from the target asset"
@@ -139,22 +150,6 @@ pub fn validate(rule: &RedirectRule) -> Result<(), String> {
     }
 
     Ok(())
-}
-
-fn is_valid_header_name_byte(b: u8) -> bool {
-    // RFC 7230 token characters.
-    matches!(b,
-        b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9'
-        | b'!' | b'#' | b'$' | b'%' | b'&' | b'\'' | b'*' | b'+' | b'-' | b'.'
-        | b'^' | b'_' | b'`' | b'|' | b'~'
-    )
-}
-
-fn is_valid_header_value_byte(b: u8) -> bool {
-    // Visible ASCII plus space/tab — matches RFC 7230 `field-value` for the
-    // common single-line case. We deliberately reject CR/LF so a rule can't
-    // smuggle header injection through the canister.
-    b == b'\t' || (0x20..=0x7e).contains(&b)
 }
 
 impl RedirectRule {
@@ -204,7 +199,7 @@ impl RedirectRule {
     pub fn certified_headers(&self) -> Vec<(String, String)> {
         let mut headers: Vec<(String, String)> =
             vec![("content-type".to_string(), "text/plain".to_string())];
-        if (301..=308).contains(&self.status) {
+        if StatusCode::from_u16(self.status).is_ok_and(|s| s.is_redirection()) {
             headers.push(("location".to_string(), self.to.clone()));
         }
         if let Some(extras) = &self.headers {

--- a/ic-certified-assets/src/redirect.rs
+++ b/ic-certified-assets/src/redirect.rs
@@ -7,8 +7,14 @@
 //! certified tree (1.2: 3xx/4xx; 1.3: status-200 rewrites) and remove the
 //! canister's built-in aliasing (1.4).
 
+use crate::certification::{
+    build_ic_certificate_expression_from_headers, build_ic_certificate_expression_header,
+    response_hash, CertificateExpression, HashTreePath, NestedTreeKey,
+};
 use candid::{CandidType, Deserialize};
+use ic_representation_independent_hash::Value;
 use serde::Serialize;
+use sha2::Digest;
 
 /// A single rule, mirroring one line of a Netlify-style `_redirects` file.
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Deserialize, Serialize)]
@@ -73,6 +79,7 @@ pub fn validate(rule: &RedirectRule) -> Result<(), String> {
     }
 
     if let Some(headers) = &rule.headers {
+        let is_redirect = (301..=308).contains(&rule.status);
         for (k, v) in headers {
             if k.is_empty() {
                 return Err("header name must not be empty".to_string());
@@ -85,6 +92,18 @@ pub fn validate(rule: &RedirectRule) -> Result<(), String> {
             }
             if !v.bytes().all(is_valid_header_value_byte) {
                 return Err(format!("header '{k}' value contains invalid characters"));
+            }
+            if k.eq_ignore_ascii_case("location") {
+                return Err(if is_redirect {
+                    "'Location' header must not be set on a 3xx rule; \
+                     the canister derives it from the rule's 'to' field"
+                        .to_string()
+                } else {
+                    format!(
+                        "'Location' header is only valid on 3xx rules (status {})",
+                        rule.status
+                    )
+                });
             }
         }
     }
@@ -106,6 +125,117 @@ fn is_valid_header_value_byte(b: u8) -> bool {
     // common single-line case. We deliberately reject CR/LF so a rule can't
     // smuggle header injection through the canister.
     b == b'\t' || (0x20..=0x7e).contains(&b)
+}
+
+impl RedirectRule {
+    /// Does this rule's `from` pattern match the given request path?
+    pub fn matches(&self, request_path: &str) -> bool {
+        match &self.from {
+            RulePattern::Exact(p) => p == request_path,
+            RulePattern::Subtree(prefix) => request_path.starts_with(prefix.as_str()),
+        }
+    }
+
+    /// Source path the rule is anchored at (the `from` pattern, without the
+    /// trailing `/` for subtrees).
+    pub fn source(&self) -> &str {
+        match &self.from {
+            RulePattern::Exact(p) | RulePattern::Subtree(p) => p.as_str(),
+        }
+    }
+
+    /// Tree location for this rule's certified entry — segments through the
+    /// terminator (`<$>` for exact matches, `<*>` for subtrees), without the
+    /// per-response (expr_hash, req_hash, resp_hash) tail.
+    pub fn tree_location(&self) -> HashTreePath {
+        let (path, sentinel) = match &self.from {
+            RulePattern::Exact(p) => (p.as_str(), "<$>"),
+            RulePattern::Subtree(p) => (p.trim_end_matches('/'), "<*>"),
+        };
+        let mut segs: Vec<NestedTreeKey> = vec!["http_expr".into()];
+        for s in path.split('/').filter(|s| !s.is_empty()) {
+            segs.push(NestedTreeKey::String(s.to_string()));
+        }
+        segs.push(NestedTreeKey::String(sentinel.to_string()));
+        HashTreePath::from(segs)
+    }
+
+    /// Headers that are part of the certified response for this rule. The
+    /// `ic-certificateexpression` header is appended at certification time and
+    /// is not included here.
+    ///
+    /// Step 1.2: 3xx rules carry `content-type` + `Location`, 4xx rules carry
+    /// `content-type`. Status-200 rules (step 1.3) borrow their headers from
+    /// the target asset; this method is not used in that path.
+    pub fn certified_headers(&self) -> Vec<(String, String)> {
+        let mut headers: Vec<(String, String)> =
+            vec![("content-type".to_string(), "text/plain".to_string())];
+        if (301..=308).contains(&self.status) {
+            headers.push(("location".to_string(), self.to.clone()));
+        }
+        if let Some(extras) = &self.headers {
+            for (k, v) in extras {
+                headers.push((k.to_lowercase(), v.clone()));
+            }
+        }
+        headers
+    }
+
+    /// Synthesized response body for the rule's status.
+    pub fn body(&self) -> Vec<u8> {
+        match self.status {
+            404 => b"Not Found".to_vec(),
+            410 => b"Gone".to_vec(),
+            _ => Vec::new(),
+        }
+    }
+}
+
+/// Precomputed certified-tree entry for a single rule.
+#[derive(Clone, Debug)]
+pub struct CertifiedRuleEntry {
+    /// Full path including the per-response tail — used to insert/remove the
+    /// entry in the asset_hashes tree.
+    pub tree_path: HashTreePath,
+    /// Location prefix (`["http_expr", segs.., "<$>"|"<*>"]`) — used as the
+    /// `expr_path` field of the `IC-Certificate` response header.
+    pub location: HashTreePath,
+    /// The certificate expression listing the certified header names.
+    pub expression: CertificateExpression,
+}
+
+/// Build the certified-tree entry for a non-status-200 rule.
+pub(crate) fn build_certified_entry(rule: &RedirectRule) -> CertifiedRuleEntry {
+    let headers = rule.certified_headers();
+    let header_values: Vec<(String, Value)> = headers
+        .iter()
+        .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+        .collect();
+
+    let body = rule.body();
+    let body_hash: [u8; 32] = sha2::Sha256::digest(&body).into();
+
+    let expression = build_ic_certificate_expression_from_headers(&header_values);
+
+    // Mirror `certify_fallback_response`: the synthesized
+    // `ic-certificateexpression` header is itself part of the certified
+    // response.
+    let cert_expr_header = build_ic_certificate_expression_header(&expression);
+    let mut certified = header_values.clone();
+    certified.push((cert_expr_header.0, Value::String(cert_expr_header.1)));
+    let resp_hash = response_hash(&certified, rule.status, &body_hash);
+
+    let location = rule.tree_location();
+    let mut full_segs = location.0.clone();
+    full_segs.push(NestedTreeKey::Hash(expression.expression_hash));
+    full_segs.push(NestedTreeKey::String(String::new())); // empty request hash sentinel
+    full_segs.push(NestedTreeKey::Hash(resp_hash.0));
+
+    CertifiedRuleEntry {
+        tree_path: HashTreePath::from(full_segs),
+        location,
+        expression,
+    }
 }
 
 #[cfg(test)]
@@ -189,6 +319,110 @@ mod tests {
         r.headers = Some(vec![("X-Foo".into(), "bar\r\nX-Evil: 1".into())]);
         let err = validate(&r).unwrap_err();
         assert!(err.contains("invalid characters"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_location_header_on_3xx() {
+        let mut r = rule(RulePattern::Exact("/a".into()), "/b", 301);
+        r.headers = Some(vec![("Location".into(), "/other".into())]);
+        let err = validate(&r).unwrap_err();
+        assert!(err.contains("derives it from the rule's 'to' field"), "got: {err}");
+    }
+
+    #[test]
+    fn validate_rejects_location_header_on_4xx() {
+        let mut r = rule(RulePattern::Exact("/a".into()), "/b", 404);
+        r.headers = Some(vec![("Location".into(), "/other".into())]);
+        let err = validate(&r).unwrap_err();
+        assert!(err.contains("only valid on 3xx rules"), "got: {err}");
+    }
+
+    #[test]
+    fn tree_location_exact() {
+        let r = rule(RulePattern::Exact("/old".into()), "/new", 301);
+        let segs = r.tree_location().0;
+        let names: Vec<&str> = segs
+            .iter()
+            .map(|k| match k {
+                NestedTreeKey::String(s) => s.as_str(),
+                _ => panic!("expected string segment"),
+            })
+            .collect();
+        assert_eq!(names, vec!["http_expr", "old", "<$>"]);
+    }
+
+    #[test]
+    fn tree_location_subtree() {
+        let r = rule(RulePattern::Subtree("/blog/".into()), "/home", 308);
+        let segs = r.tree_location().0;
+        let names: Vec<&str> = segs
+            .iter()
+            .map(|k| match k {
+                NestedTreeKey::String(s) => s.as_str(),
+                _ => panic!("expected string segment"),
+            })
+            .collect();
+        assert_eq!(names, vec!["http_expr", "blog", "<*>"]);
+    }
+
+    #[test]
+    fn tree_location_root_subtree() {
+        let r = rule(RulePattern::Subtree("/".into()), "/home", 308);
+        let segs = r.tree_location().0;
+        let names: Vec<&str> = segs
+            .iter()
+            .map(|k| match k {
+                NestedTreeKey::String(s) => s.as_str(),
+                _ => panic!("expected string segment"),
+            })
+            .collect();
+        assert_eq!(names, vec!["http_expr", "<*>"]);
+    }
+
+    #[test]
+    fn certified_headers_3xx_includes_location() {
+        let r = rule(RulePattern::Exact("/old".into()), "/new", 301);
+        let headers = r.certified_headers();
+        assert!(headers.iter().any(|(k, v)| k == "location" && v == "/new"));
+        assert!(headers.iter().any(|(k, _)| k == "content-type"));
+    }
+
+    #[test]
+    fn certified_headers_4xx_no_location() {
+        let r = rule(RulePattern::Exact("/missing".into()), "", 404);
+        let headers = r.certified_headers();
+        assert!(headers.iter().all(|(k, _)| k != "location"));
+        assert!(headers.iter().any(|(k, _)| k == "content-type"));
+    }
+
+    #[test]
+    fn body_4xx_nonempty() {
+        let r404 = rule(RulePattern::Exact("/missing".into()), "", 404);
+        let r410 = rule(RulePattern::Exact("/gone".into()), "", 410);
+        assert_eq!(r404.body(), b"Not Found");
+        assert_eq!(r410.body(), b"Gone");
+    }
+
+    #[test]
+    fn body_3xx_empty() {
+        let r = rule(RulePattern::Exact("/old".into()), "/new", 301);
+        assert!(r.body().is_empty());
+    }
+
+    #[test]
+    fn build_certified_entry_distinct_per_status() {
+        // Different status codes must yield different response hashes so the
+        // tree can disambiguate identical paths.
+        let exact = RulePattern::Exact("/x".into());
+        let e301 = build_certified_entry(&rule(exact.clone(), "/y", 301));
+        let e302 = build_certified_entry(&rule(exact.clone(), "/y", 302));
+        let e404 = build_certified_entry(&rule(exact, "", 404));
+        // All three sit at the same tree location prefix.
+        assert_eq!(e301.location.0, e302.location.0);
+        assert_eq!(e301.location.0, e404.location.0);
+        // ...but their full tree paths differ in expr_hash / resp_hash.
+        assert_ne!(e301.tree_path.0, e302.tree_path.0);
+        assert_ne!(e301.tree_path.0, e404.tree_path.0);
     }
 
     #[test]

--- a/ic-certified-assets/src/stable.rs
+++ b/ic-certified-assets/src/stable.rs
@@ -5,7 +5,8 @@ use num_traits::ToPrimitive;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    asset::Timestamp, certification::CertificateExpression, rc_bytes::RcBytes, types::BatchId,
+    asset::Timestamp, certification::CertificateExpression, rc_bytes::RcBytes,
+    redirect::RedirectRule, types::BatchId,
 };
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -17,6 +18,11 @@ pub struct StableState {
     pub(crate) next_batch_id: Option<u64>,
     pub(crate) configuration: Option<StableConfiguration>,
     pub(crate) last_state_update_timestamp: Option<u64>,
+
+    /// Optional so a `StableState` serialized before this field existed still
+    /// deserializes cleanly (yields `None`, which we treat as "no rules").
+    #[serde(default)]
+    pub(crate) redirect_rules: Option<Vec<RedirectRule>>,
 }
 
 impl From<crate::state::State> for StableState {
@@ -37,6 +43,7 @@ impl From<crate::state::State> for StableState {
             next_batch_id: Some(batch_id_to_u64(state.next_batch_id)),
             configuration: Some(state.configuration.into()),
             last_state_update_timestamp: Some(state.last_state_update_timestamp_ns),
+            redirect_rules: Some(state.redirect_rules),
         }
     }
 }

--- a/ic-certified-assets/src/stable.rs
+++ b/ic-certified-assets/src/stable.rs
@@ -83,13 +83,18 @@ impl From<StableConfiguration> for crate::state::Configuration {
     }
 }
 
-/// Same as [crate::asset::Asset] but serde-serializable
+/// Same as [crate::asset::Asset] but serde-serializable.
+///
+/// `is_aliased` is kept as an optional ignored field so stable-memory blobs
+/// written before built-in aliasing was removed still deserialize. Newly
+/// written blobs always set it to `None`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StableAsset {
     pub content_type: String,
     pub encodings: HashMap<String, StableAssetEncoding>,
     pub max_age: Option<u64>,
     pub headers: Option<BTreeMap<String, String>>,
+    #[serde(default)]
     pub is_aliased: Option<bool>,
     pub allow_raw_access: Option<bool>,
 }
@@ -105,7 +110,7 @@ impl From<crate::asset::Asset> for StableAsset {
                 .collect(),
             max_age: asset.max_age,
             headers: asset.headers,
-            is_aliased: asset.is_aliased,
+            is_aliased: None,
             allow_raw_access: asset.allow_raw_access,
         }
     }
@@ -122,7 +127,6 @@ impl From<StableAsset> for crate::asset::Asset {
                 .collect(),
             max_age: stable_asset.max_age,
             headers: stable_asset.headers,
-            is_aliased: stable_asset.is_aliased,
             allow_raw_access: stable_asset.allow_raw_access,
         }
     }

--- a/ic-certified-assets/src/state.rs
+++ b/ic-certified-assets/src/state.rs
@@ -514,8 +514,7 @@ impl State {
             // 4xx custom error page) honor the target's `allow_raw_access`
             // setting — checked even before the rule has a certified entry
             // because the target may not yet have an encoding.
-            let borrows_from_target =
-                rule.status == 200 || (matches!(rule.status, 404 | 410) && !rule.to.is_empty());
+            let borrows_from_target = matches!(rule.status, 200 | 404 | 410);
             if borrows_from_target {
                 if let Some(target) = self.assets.get(&rule.to) {
                     if !target.allow_raw_access() && req.is_raw_domain() {
@@ -565,6 +564,7 @@ impl State {
         );
         match &entry.kind {
             crate::redirect::CertifiedRuleEntryKind::Synthetic { expression } => {
+                // Synthetic entries only cover 3xx redirects — empty body.
                 let cert_expr_header =
                     crate::certification::build_ic_certificate_expression_header(expression);
                 let mut headers = rule.certified_headers();
@@ -574,7 +574,7 @@ impl State {
                 HttpResponse {
                     status_code: rule.status,
                     headers,
-                    body: RcBytes::from(ByteBuf::from(rule.body())),
+                    body: RcBytes::from(ByteBuf::new()),
                     upgrade: None,
                     streaming_strategy: None,
                 }
@@ -780,10 +780,12 @@ impl State {
             }
         }
         match rule.status {
-            200 => self.build_alias_rule_entry(rule, rule.status),
-            // 4xx with a non-empty `to` becomes a custom error page borrowing
-            // the target asset's body and certified header set.
-            404 | 410 if !rule.to.is_empty() => self.build_alias_rule_entry(rule, rule.status),
+            // 200 rewrites and 4xx custom error pages both borrow body +
+            // headers from the target asset (4xx re-certifies with the
+            // override status; see `build_alias_rule_entry`).
+            200 | 404 | 410 => self.build_alias_rule_entry(rule, rule.status),
+            // 3xx redirects synthesize an empty body; only the headers
+            // (content-type, Location) are certified.
             _ => {
                 let entry = crate::redirect::build_synthetic_entry(rule);
                 for tp in &entry.tree_paths {

--- a/ic-certified-assets/src/state.rs
+++ b/ic-certified-assets/src/state.rs
@@ -6,14 +6,13 @@
 
 use crate::{
     asset::{
-        aliased_by, aliases_of, on_asset_change, Asset, AssetDetails, AssetEncoding,
-        AssetEncodingDetails, EncodedAsset, DEFAULT_ALIAS_ENABLED,
+        on_asset_change, Asset, AssetDetails, AssetEncoding, AssetEncodingDetails, EncodedAsset,
     },
     batch::{Batch, Chunk, ComputationStatus},
-    certification::{AssetKey, CertifiedResponses, WitnessResult},
+    certification::{AssetKey, CertifiedResponses},
     http::{
         CallbackFunc, HttpRequest, HttpResponse, StreamingCallbackHttpResponse,
-        StreamingCallbackToken, FALLBACK_FILE,
+        StreamingCallbackToken,
     },
     rc_bytes::RcBytes,
     stable::StableState,
@@ -80,20 +79,6 @@ impl State {
     fn get_asset(&self, key: &AssetKey) -> Result<&Asset, String> {
         self.assets
             .get(key)
-            .or_else(|| {
-                let aliased = aliases_of(key)
-                    .into_iter()
-                    .find_map(|alias_key| self.assets.get(&alias_key));
-                if let Some(asset) = aliased {
-                    if asset.is_aliased.unwrap_or(DEFAULT_ALIAS_ENABLED) {
-                        aliased
-                    } else {
-                        None
-                    }
-                } else {
-                    None
-                }
-            })
             .ok_or_else(|| "asset not found".to_string())
     }
 
@@ -145,6 +130,10 @@ impl State {
             return Err("asset already exists".to_string());
         }
 
+        // `arg.enable_aliasing` is accepted for backward compatibility but
+        // ignored — the canister no longer aliases on its own; users express
+        // aliasing as an explicit status-200 rule in `_redirects`.
+        let _ = arg.enable_aliasing;
         self.assets.insert(
             arg.key,
             Asset {
@@ -152,7 +141,6 @@ impl State {
                 encodings: HashMap::new(),
                 max_age: arg.max_age,
                 headers: arg.headers,
-                is_aliased: arg.enable_aliasing,
                 allow_raw_access: arg.allow_raw_access,
             },
         );
@@ -261,22 +249,8 @@ impl State {
 
     pub fn delete_asset(&mut self, arg: DeleteAssetArguments) {
         if self.assets.contains_key(&arg.key) {
-            for dependent in self.dependent_keys(&arg.key) {
-                self.asset_hashes.remove_responses_for_path(&dependent);
-                if dependent == FALLBACK_FILE {
-                    self.asset_hashes.remove_fallback_responses();
-                }
-            }
+            self.asset_hashes.remove_responses_for_path(&arg.key);
             self.assets.remove(&arg.key);
-        }
-        for key in aliases_of(&arg.key) {
-            // if an existing file can be aliased to the deleted file it has to become a valid alias again
-            if self.assets.contains_key(&key) {
-                let dependent_keys = self.dependent_keys(&key);
-                if let Some(asset) = self.assets.get_mut(&key) {
-                    on_asset_change(&mut self.asset_hashes, &key, asset, dependent_keys, None);
-                }
-            }
         }
     }
 
@@ -334,7 +308,8 @@ impl State {
         let dependent_keys = self.dependent_keys(&arg.key);
         let asset = self.assets.entry(arg.key.clone()).or_default();
         asset.content_type = arg.content_type;
-        asset.is_aliased = arg.aliased;
+        // `arg.aliased` is accepted for backward compatibility but ignored.
+        let _ = arg.aliased;
 
         let hash = sha2::Sha256::digest(&arg.content).into();
         if let Some(provided_hash) = arg.sha256 {
@@ -441,7 +416,7 @@ impl State {
                         max_age: asset.max_age,
                         headers: asset.headers.clone(),
                         allow_raw_access: asset.allow_raw_access,
-                        is_aliased: asset.is_aliased,
+                        is_aliased: None,
                     }
                 })
             })
@@ -511,18 +486,11 @@ impl State {
         etags: Vec<Hash>,
         req: HttpRequest,
     ) -> HttpResponse {
-        if let Ok(asset) = self.get_asset(&path.into()) {
-            if !asset.allow_raw_access() && req.is_raw_domain() {
-                return req.redirect_from_raw_to_certified_domain();
-            }
-        } else if let Ok(asset) = self.get_asset(&FALLBACK_FILE.to_string()) {
-            if !asset.allow_raw_access() && req.is_raw_domain() {
-                return req.redirect_from_raw_to_certified_domain();
-            }
-        }
-
         // Asset at the requested path wins.
         if let Ok(asset) = self.get_asset(&path.into()) {
+            if !asset.allow_raw_access() && req.is_raw_domain() {
+                return req.redirect_from_raw_to_certified_domain();
+            }
             let (cert_header, _) = self.asset_hashes.witness_to_header(path, certificate);
             if let Some(response) = asset.build_http_response_for_encodings(
                 &requested_encodings,
@@ -540,6 +508,17 @@ impl State {
         for (idx, rule) in self.redirect_rules.iter().enumerate() {
             if !rule.matches(path) {
                 continue;
+            }
+            // Status-200 rules borrow from a target asset — honor that
+            // asset's `allow_raw_access` rule before serving (or even before
+            // the rule has a certified entry — the target may not yet have
+            // an encoding).
+            if rule.status == 200 {
+                if let Some(target) = self.assets.get(&rule.to) {
+                    if !target.allow_raw_access() && req.is_raw_domain() {
+                        return req.redirect_from_raw_to_certified_domain();
+                    }
+                }
             }
             let Some(entry) = self
                 .rule_certified_entries
@@ -560,23 +539,7 @@ impl State {
             );
         }
 
-        let (certificate_header, witness_result) =
-            self.asset_hashes.witness_to_header(path, certificate);
-
-        if witness_result == WitnessResult::FallbackFound {
-            if let Ok(asset) = self.get_asset(&FALLBACK_FILE.to_string()) {
-                if let Some(response) = asset.build_http_response_for_encodings(
-                    &requested_encodings,
-                    path,
-                    chunk_index,
-                    Some(&certificate_header),
-                    &callback,
-                    &etags,
-                ) {
-                    return response;
-                }
-            }
-        }
+        let (certificate_header, _) = self.asset_hashes.witness_to_header(path, certificate);
         HttpResponse::build_404(certificate_header)
     }
 
@@ -716,7 +679,7 @@ impl State {
             max_age: asset.max_age,
             headers: asset.headers.clone(),
             allow_raw_access: asset.allow_raw_access,
-            is_aliased: asset.is_aliased,
+            is_aliased: None,
         })
     }
 
@@ -737,9 +700,8 @@ impl State {
             asset.allow_raw_access = allow_raw_access
         }
 
-        if let Some(is_aliased) = arg.is_aliased {
-            asset.is_aliased = is_aliased
-        }
+        // `arg.is_aliased` is accepted for backward compatibility but ignored.
+        let _ = arg.is_aliased;
 
         on_asset_change(
             &mut self.asset_hashes,
@@ -752,21 +714,14 @@ impl State {
         Ok(())
     }
 
-    // Returns keys that needs to be updated if the supplied key is changed.
-    pub(crate) fn dependent_keys(&self, key: &AssetKey) -> Vec<AssetKey> {
-        if self
-            .assets
-            .get(key)
-            .and_then(|asset| asset.is_aliased)
-            .unwrap_or(DEFAULT_ALIAS_ENABLED)
-        {
-            aliased_by(key)
-                .into_iter()
-                .filter(|k| !self.assets.contains_key(k))
-                .collect()
-        } else {
-            Vec::new()
-        }
+    // Returns keys that need to be updated if the supplied key is changed.
+    //
+    // The built-in aliasing this used to fan out to is gone; nothing pulls
+    // sibling keys today. The hook is kept in the signature of
+    // `on_asset_change` so a future feature can repopulate it without
+    // touching all the call sites.
+    pub(crate) fn dependent_keys(&self, _key: &AssetKey) -> Vec<AssetKey> {
+        Vec::new()
     }
 
     pub fn get_configuration(&self) -> ConfigurationResponse {

--- a/ic-certified-assets/src/state.rs
+++ b/ic-certified-assets/src/state.rs
@@ -536,12 +536,8 @@ impl State {
             }
         }
 
-        // Step 1.2: scan non-200 rules in declaration order, first match wins.
-        // Status-200 rules are skipped here (step 1.3 wires them in).
+        // Scan redirect rules in declaration order; first match wins.
         for (idx, rule) in self.redirect_rules.iter().enumerate() {
-            if rule.status == 200 {
-                continue;
-            }
             if !rule.matches(path) {
                 continue;
             }
@@ -552,7 +548,16 @@ impl State {
             else {
                 continue;
             };
-            return self.build_redirect_rule_response(rule, entry, path, certificate);
+            return self.build_redirect_rule_response(
+                rule,
+                entry,
+                path,
+                certificate,
+                &requested_encodings,
+                chunk_index,
+                &callback,
+                &etags,
+            );
         }
 
         let (certificate_header, witness_result) =
@@ -575,30 +580,54 @@ impl State {
         HttpResponse::build_404(certificate_header)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn build_redirect_rule_response(
         &self,
         rule: &crate::redirect::RedirectRule,
         entry: &crate::redirect::CertifiedRuleEntry,
         path: &str,
         certificate: &[u8],
+        requested_encodings: &[String],
+        chunk_index: usize,
+        callback: &CallbackFunc,
+        etags: &[Hash],
     ) -> HttpResponse {
         let cert_header = self.asset_hashes.witness_to_header_with_location(
             path,
             &entry.location,
             certificate,
         );
-        let cert_expr_header =
-            crate::certification::build_ic_certificate_expression_header(&entry.expression);
-        let mut headers = rule.certified_headers();
-        headers.push((cert_expr_header.0, cert_expr_header.1));
-        headers.push(cert_header);
+        match &entry.kind {
+            crate::redirect::CertifiedRuleEntryKind::Synthetic { expression } => {
+                let cert_expr_header =
+                    crate::certification::build_ic_certificate_expression_header(expression);
+                let mut headers = rule.certified_headers();
+                headers.push((cert_expr_header.0, cert_expr_header.1));
+                headers.push(cert_header);
 
-        HttpResponse {
-            status_code: rule.status,
-            headers,
-            body: RcBytes::from(ByteBuf::from(rule.body())),
-            upgrade: None,
-            streaming_strategy: None,
+                HttpResponse {
+                    status_code: rule.status,
+                    headers,
+                    body: RcBytes::from(ByteBuf::from(rule.body())),
+                    upgrade: None,
+                    streaming_strategy: None,
+                }
+            }
+            crate::redirect::CertifiedRuleEntryKind::AliasOf { target_key } => {
+                let Some(asset) = self.assets.get(target_key) else {
+                    return HttpResponse::build_404(cert_header);
+                };
+                asset
+                    .build_http_response_for_encodings(
+                        requested_encodings,
+                        path,
+                        chunk_index,
+                        Some(&cert_header),
+                        callback,
+                        etags,
+                    )
+                    .unwrap_or_else(|| HttpResponse::build_404(cert_header))
+            }
         }
     }
 
@@ -760,34 +789,74 @@ impl State {
     /// stable memory (in `From<StableState>`). Caller must refresh
     /// `certified_data` after this — `commit_batch` already does so via the
     /// `certified_data_set(s.root_hash())` it runs after each batch.
+    ///
+    /// Status-200 rules borrow each encoding's certificate expression and
+    /// response hash from the target asset, so this also has to run after any
+    /// asset change that could affect those values.
     pub(crate) fn on_redirect_rules_change(&mut self) {
         for entry in self.rule_certified_entries.drain(..).flatten() {
-            self.asset_hashes
-                .remove_response_precomputed(&entry.tree_path);
+            for tp in &entry.tree_paths {
+                self.asset_hashes.remove_response_precomputed(tp);
+            }
         }
 
+        let rules = self.redirect_rules.clone();
         let mut new_entries: Vec<Option<crate::redirect::CertifiedRuleEntry>> =
-            Vec::with_capacity(self.redirect_rules.len());
-        for rule in &self.redirect_rules {
-            if rule.status == 200 {
-                // TODO(step 1.3): build a certified entry that mirrors the
-                // target asset's response.
-                new_entries.push(None);
-                continue;
-            }
-            if let crate::redirect::RulePattern::Exact(src) = &rule.from {
-                if self.assets.contains_key(src) {
-                    // Asset at the source path shadows the rule.
-                    new_entries.push(None);
-                    continue;
-                }
-            }
-            let entry = crate::redirect::build_certified_entry(rule);
-            self.asset_hashes
-                .certify_response_precomputed(&entry.tree_path);
-            new_entries.push(Some(entry));
+            Vec::with_capacity(rules.len());
+        for rule in &rules {
+            new_entries.push(self.build_rule_entry(rule));
         }
         self.rule_certified_entries = new_entries;
+    }
+
+    fn build_rule_entry(
+        &mut self,
+        rule: &crate::redirect::RedirectRule,
+    ) -> Option<crate::redirect::CertifiedRuleEntry> {
+        if let crate::redirect::RulePattern::Exact(src) = &rule.from {
+            if self.assets.contains_key(src) {
+                // Asset at the source path shadows the rule.
+                return None;
+            }
+        }
+        if rule.status == 200 {
+            self.build_alias_rule_entry(rule)
+        } else {
+            let entry = crate::redirect::build_synthetic_entry(rule);
+            for tp in &entry.tree_paths {
+                self.asset_hashes.certify_response_precomputed(tp);
+            }
+            Some(entry)
+        }
+    }
+
+    fn build_alias_rule_entry(
+        &mut self,
+        rule: &crate::redirect::RedirectRule,
+    ) -> Option<crate::redirect::CertifiedRuleEntry> {
+        let target_key = rule.to.clone();
+        let target = self.assets.get(&target_key)?;
+        let location = rule.tree_location();
+        let mut tree_paths = Vec::new();
+        for enc in target.encodings.values() {
+            let Some(expr) = enc.certificate_expression.as_ref() else {
+                continue;
+            };
+            let Some(resp_hash) = enc.response_hashes.as_ref().and_then(|m| m.get(&200)) else {
+                continue;
+            };
+            let tp = crate::redirect::alias_tree_path(&location, expr.expression_hash, *resp_hash);
+            self.asset_hashes.certify_response_precomputed(&tp);
+            tree_paths.push(tp);
+        }
+        if tree_paths.is_empty() {
+            return None;
+        }
+        Some(crate::redirect::CertifiedRuleEntry {
+            tree_paths,
+            location,
+            kind: crate::redirect::CertifiedRuleEntryKind::AliasOf { target_key },
+        })
     }
 
     pub fn configure(&mut self, args: ConfigureArguments) {

--- a/ic-certified-assets/src/state.rs
+++ b/ic-certified-assets/src/state.rs
@@ -63,9 +63,9 @@ pub struct State {
 
     pub(crate) redirect_rules: Vec<crate::redirect::RedirectRule>,
     /// Per-rule certified-tree entries, parallel to `redirect_rules`. A
-    /// `None` slot means the rule has no certified entry — either because it
-    /// is a status-200 rule (step 1.3 will wire those) or because an asset
-    /// shadows an exact rule at the same path.
+    /// `None` slot means the rule has no certified entry — either because an
+    /// asset shadows an exact rule at the same path, or because an alias rule
+    /// (200/4xx) points at a target asset that doesn't exist yet.
     pub(crate) rule_certified_entries: Vec<Option<crate::redirect::CertifiedRuleEntry>>,
 
     pub(crate) encoded_canister_env: String,
@@ -557,11 +557,9 @@ impl State {
         callback: &CallbackFunc,
         etags: &[Hash],
     ) -> HttpResponse {
-        let cert_header = self.asset_hashes.witness_to_header_with_location(
-            path,
-            &entry.location,
-            certificate,
-        );
+        let cert_header =
+            self.asset_hashes
+                .witness_to_header_with_location(path, &entry.location, certificate);
         match &entry.kind {
             crate::redirect::CertifiedRuleEntryKind::Synthetic { expression } => {
                 // Synthetic entries only cover 3xx redirects — empty body.
@@ -818,14 +816,11 @@ impl State {
             } else {
                 // 4xx custom error page: re-certify with the override status
                 // using the same headers and body the asset would serve at 200.
-                let base_headers: Vec<(String, ic_representation_independent_hash::Value)> =
-                    target
-                        .get_headers_for_asset(enc_name)
-                        .into_iter()
-                        .map(|(k, v)| {
-                            (k, ic_representation_independent_hash::Value::String(v))
-                        })
-                        .collect();
+                let base_headers: Vec<(String, ic_representation_independent_hash::Value)> = target
+                    .get_headers_for_asset(enc_name)
+                    .into_iter()
+                    .map(|(k, v)| (k, ic_representation_independent_hash::Value::String(v)))
+                    .collect();
                 crate::certification::response_hash(&base_headers, status, &enc.sha256).0
             };
             let tp = crate::redirect::alias_tree_path(&location, expr.expression_hash, resp_hash);

--- a/ic-certified-assets/src/state.rs
+++ b/ic-certified-assets/src/state.rs
@@ -63,6 +63,11 @@ pub struct State {
     pub(crate) asset_hashes: CertifiedResponses,
 
     pub(crate) redirect_rules: Vec<crate::redirect::RedirectRule>,
+    /// Per-rule certified-tree entries, parallel to `redirect_rules`. A
+    /// `None` slot means the rule has no certified entry — either because it
+    /// is a status-200 rule (step 1.3 will wire those) or because an asset
+    /// shadows an exact rule at the same path.
+    pub(crate) rule_certified_entries: Vec<Option<crate::redirect::CertifiedRuleEntry>>,
 
     pub(crate) encoded_canister_env: String,
 
@@ -516,6 +521,40 @@ impl State {
             }
         }
 
+        // Asset at the requested path wins.
+        if let Ok(asset) = self.get_asset(&path.into()) {
+            let (cert_header, _) = self.asset_hashes.witness_to_header(path, certificate);
+            if let Some(response) = asset.build_http_response_for_encodings(
+                &requested_encodings,
+                path,
+                chunk_index,
+                Some(&cert_header),
+                &callback,
+                &etags,
+            ) {
+                return response;
+            }
+        }
+
+        // Step 1.2: scan non-200 rules in declaration order, first match wins.
+        // Status-200 rules are skipped here (step 1.3 wires them in).
+        for (idx, rule) in self.redirect_rules.iter().enumerate() {
+            if rule.status == 200 {
+                continue;
+            }
+            if !rule.matches(path) {
+                continue;
+            }
+            let Some(entry) = self
+                .rule_certified_entries
+                .get(idx)
+                .and_then(|e| e.as_ref())
+            else {
+                continue;
+            };
+            return self.build_redirect_rule_response(rule, entry, path, certificate);
+        }
+
         let (certificate_header, witness_result) =
             self.asset_hashes.witness_to_header(path, certificate);
 
@@ -532,24 +571,35 @@ impl State {
                     return response;
                 }
             }
-        } else if witness_result == WitnessResult::PathFound {
-            if let Ok(asset) = self.get_asset(&path.into()) {
-                if !asset.allow_raw_access() && req.is_raw_domain() {
-                    return req.redirect_from_raw_to_certified_domain();
-                }
-                if let Some(response) = asset.build_http_response_for_encodings(
-                    &requested_encodings,
-                    path,
-                    chunk_index,
-                    Some(&certificate_header),
-                    &callback,
-                    &etags,
-                ) {
-                    return response;
-                }
-            }
         }
         HttpResponse::build_404(certificate_header)
+    }
+
+    fn build_redirect_rule_response(
+        &self,
+        rule: &crate::redirect::RedirectRule,
+        entry: &crate::redirect::CertifiedRuleEntry,
+        path: &str,
+        certificate: &[u8],
+    ) -> HttpResponse {
+        let cert_header = self.asset_hashes.witness_to_header_with_location(
+            path,
+            &entry.location,
+            certificate,
+        );
+        let cert_expr_header =
+            crate::certification::build_ic_certificate_expression_header(&entry.expression);
+        let mut headers = rule.certified_headers();
+        headers.push((cert_expr_header.0, cert_expr_header.1));
+        headers.push(cert_header);
+
+        HttpResponse {
+            status_code: rule.status,
+            headers,
+            body: RcBytes::from(ByteBuf::from(rule.body())),
+            upgrade: None,
+            streaming_strategy: None,
+        }
     }
 
     pub fn http_request(
@@ -705,6 +755,41 @@ impl State {
         self.redirect_rules.clone()
     }
 
+    /// Rebuild the certified-tree entries for `redirect_rules`. Called whenever
+    /// the rule list changes (in `commit_batch`) or assets are restored from
+    /// stable memory (in `From<StableState>`). Caller must refresh
+    /// `certified_data` after this — `commit_batch` already does so via the
+    /// `certified_data_set(s.root_hash())` it runs after each batch.
+    pub(crate) fn on_redirect_rules_change(&mut self) {
+        for entry in self.rule_certified_entries.drain(..).flatten() {
+            self.asset_hashes
+                .remove_response_precomputed(&entry.tree_path);
+        }
+
+        let mut new_entries: Vec<Option<crate::redirect::CertifiedRuleEntry>> =
+            Vec::with_capacity(self.redirect_rules.len());
+        for rule in &self.redirect_rules {
+            if rule.status == 200 {
+                // TODO(step 1.3): build a certified entry that mirrors the
+                // target asset's response.
+                new_entries.push(None);
+                continue;
+            }
+            if let crate::redirect::RulePattern::Exact(src) = &rule.from {
+                if self.assets.contains_key(src) {
+                    // Asset at the source path shadows the rule.
+                    new_entries.push(None);
+                    continue;
+                }
+            }
+            let entry = crate::redirect::build_certified_entry(rule);
+            self.asset_hashes
+                .certify_response_precomputed(&entry.tree_path);
+            new_entries.push(Some(entry));
+        }
+        self.rule_certified_entries = new_entries;
+    }
+
     pub fn configure(&mut self, args: ConfigureArguments) {
         if let Some(max_batches) = args.max_batches {
             self.configuration.max_batches = max_batches;
@@ -769,6 +854,7 @@ impl From<StableState> for State {
                 // shouldn't reach this
             }
         }
+        state.on_redirect_rules_change();
         state
     }
 }

--- a/ic-certified-assets/src/state.rs
+++ b/ic-certified-assets/src/state.rs
@@ -499,6 +499,7 @@ impl State {
                 Some(&cert_header),
                 &callback,
                 &etags,
+                None,
             ) {
                 return response;
             }
@@ -509,11 +510,13 @@ impl State {
             if !rule.matches(path) {
                 continue;
             }
-            // Status-200 rules borrow from a target asset — honor that
-            // asset's `allow_raw_access` rule before serving (or even before
-            // the rule has a certified entry — the target may not yet have
-            // an encoding).
-            if rule.status == 200 {
+            // Rules that borrow a body from a target asset (200 rewrite or
+            // 4xx custom error page) honor the target's `allow_raw_access`
+            // setting — checked even before the rule has a certified entry
+            // because the target may not yet have an encoding.
+            let borrows_from_target =
+                rule.status == 200 || (matches!(rule.status, 404 | 410) && !rule.to.is_empty());
+            if borrows_from_target {
                 if let Some(target) = self.assets.get(&rule.to) {
                     if !target.allow_raw_access() && req.is_raw_domain() {
                         return req.redirect_from_raw_to_certified_domain();
@@ -576,10 +579,11 @@ impl State {
                     streaming_strategy: None,
                 }
             }
-            crate::redirect::CertifiedRuleEntryKind::AliasOf { target_key } => {
+            crate::redirect::CertifiedRuleEntryKind::AliasOf { target_key, status } => {
                 let Some(asset) = self.assets.get(target_key) else {
                     return HttpResponse::build_404(cert_header);
                 };
+                let status_override = (*status != 200).then_some(*status);
                 asset
                     .build_http_response_for_encodings(
                         requested_encodings,
@@ -588,6 +592,7 @@ impl State {
                         Some(&cert_header),
                         callback,
                         etags,
+                        status_override,
                     )
                     .unwrap_or_else(|| HttpResponse::build_404(cert_header))
             }
@@ -774,33 +779,54 @@ impl State {
                 return None;
             }
         }
-        if rule.status == 200 {
-            self.build_alias_rule_entry(rule)
-        } else {
-            let entry = crate::redirect::build_synthetic_entry(rule);
-            for tp in &entry.tree_paths {
-                self.asset_hashes.certify_response_precomputed(tp);
+        match rule.status {
+            200 => self.build_alias_rule_entry(rule, rule.status),
+            // 4xx with a non-empty `to` becomes a custom error page borrowing
+            // the target asset's body and certified header set.
+            404 | 410 if !rule.to.is_empty() => self.build_alias_rule_entry(rule, rule.status),
+            _ => {
+                let entry = crate::redirect::build_synthetic_entry(rule);
+                for tp in &entry.tree_paths {
+                    self.asset_hashes.certify_response_precomputed(tp);
+                }
+                Some(entry)
             }
-            Some(entry)
         }
     }
 
     fn build_alias_rule_entry(
         &mut self,
         rule: &crate::redirect::RedirectRule,
+        status: u16,
     ) -> Option<crate::redirect::CertifiedRuleEntry> {
         let target_key = rule.to.clone();
         let target = self.assets.get(&target_key)?;
         let location = rule.tree_location();
         let mut tree_paths = Vec::new();
-        for enc in target.encodings.values() {
+        for (enc_name, enc) in &target.encodings {
             let Some(expr) = enc.certificate_expression.as_ref() else {
                 continue;
             };
-            let Some(resp_hash) = enc.response_hashes.as_ref().and_then(|m| m.get(&200)) else {
-                continue;
+            let resp_hash = if status == 200 {
+                // Borrow the asset's already-certified 200 response hash.
+                let Some(h) = enc.response_hashes.as_ref().and_then(|m| m.get(&200)) else {
+                    continue;
+                };
+                *h
+            } else {
+                // 4xx custom error page: re-certify with the override status
+                // using the same headers and body the asset would serve at 200.
+                let base_headers: Vec<(String, ic_representation_independent_hash::Value)> =
+                    target
+                        .get_headers_for_asset(enc_name)
+                        .into_iter()
+                        .map(|(k, v)| {
+                            (k, ic_representation_independent_hash::Value::String(v))
+                        })
+                        .collect();
+                crate::certification::response_hash(&base_headers, status, &enc.sha256).0
             };
-            let tp = crate::redirect::alias_tree_path(&location, expr.expression_hash, *resp_hash);
+            let tp = crate::redirect::alias_tree_path(&location, expr.expression_hash, resp_hash);
             self.asset_hashes.certify_response_precomputed(&tp);
             tree_paths.push(tp);
         }
@@ -810,7 +836,7 @@ impl State {
         Some(crate::redirect::CertifiedRuleEntry {
             tree_paths,
             location,
-            kind: crate::redirect::CertifiedRuleEntryKind::AliasOf { target_key },
+            kind: crate::redirect::CertifiedRuleEntryKind::AliasOf { target_key, status },
         })
     }
 

--- a/ic-certified-assets/src/state.rs
+++ b/ic-certified-assets/src/state.rs
@@ -62,6 +62,8 @@ pub struct State {
 
     pub(crate) asset_hashes: CertifiedResponses,
 
+    pub(crate) redirect_rules: Vec<crate::redirect::RedirectRule>,
+
     pub(crate) encoded_canister_env: String,
 
     pub(crate) state_hash_computation: Option<StateHashComputation>,
@@ -699,6 +701,10 @@ impl State {
         }
     }
 
+    pub fn get_redirect_rules(&self) -> Vec<crate::redirect::RedirectRule> {
+        self.redirect_rules.clone()
+    }
+
     pub fn configure(&mut self, args: ConfigureArguments) {
         if let Some(max_batches) = args.max_batches {
             self.configuration.max_batches = max_batches;
@@ -746,6 +752,7 @@ impl From<StableState> for State {
                 .map(Into::into)
                 .unwrap_or_default(),
             last_state_update_timestamp_ns: stable_state.last_state_update_timestamp.unwrap_or(0),
+            redirect_rules: stable_state.redirect_rules.unwrap_or_default(),
             ..Self::default()
         };
 

--- a/ic-certified-assets/src/state_hash.rs
+++ b/ic-certified-assets/src/state_hash.rs
@@ -85,7 +85,7 @@ fn next_step(
                 content_type: asset.content_type.clone(),
                 max_age: asset.max_age,
                 headers: asset.headers.clone(),
-                enable_aliasing: asset.is_aliased,
+                enable_aliasing: None,
                 allow_raw_access: asset.allow_raw_access,
             };
             hash_create_asset(&mut hasher, &args);

--- a/ic-certified-assets/src/tests.rs
+++ b/ic-certified-assets/src/tests.rs
@@ -3602,6 +3602,189 @@ mod redirect_rules {
     }
 
     #[test]
+    fn custom_404_page_serves_target_with_4xx_status() {
+        let mut state = State::default();
+        let system_context = mock_system_context();
+        const PAGE_BODY: &[u8] =
+            b"<!DOCTYPE html><html><body>This page is not found.</body></html>";
+        create_assets(
+            &mut state,
+            &system_context,
+            vec![AssetBuilder::new("/404.html", "text/html")
+                .with_encoding("identity", vec![PAGE_BODY])],
+        );
+        commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: vec![RedirectRule {
+                    from: RulePattern::Subtree("/legacy/".into()),
+                    to: "/404.html".into(),
+                    status: 404,
+                    headers: None,
+                }],
+            })],
+        )
+        .unwrap();
+
+        let response =
+            certified_http_request(&state, RequestBuilder::get("/legacy/anything").build());
+        assert_eq!(response.status_code, 404);
+        assert_eq!(response.body.as_ref(), PAGE_BODY);
+        // The target's content-type carries over verbatim.
+        assert_eq!(lookup_header(&response, "Content-Type"), Some("text/html"));
+    }
+
+    #[test]
+    fn custom_410_page_serves_target_with_4xx_status() {
+        let mut state = State::default();
+        let system_context = mock_system_context();
+        const PAGE_BODY: &[u8] =
+            b"<!DOCTYPE html><html><body>The content here has been removed.</body></html>";
+        create_assets(
+            &mut state,
+            &system_context,
+            vec![AssetBuilder::new("/410.html", "text/html")
+                .with_encoding("identity", vec![PAGE_BODY])],
+        );
+        commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: vec![RedirectRule {
+                    from: RulePattern::Exact("/retired".into()),
+                    to: "/410.html".into(),
+                    status: 410,
+                    headers: None,
+                }],
+            })],
+        )
+        .unwrap();
+
+        let response = certified_http_request(&state, RequestBuilder::get("/retired").build());
+        assert_eq!(response.status_code, 410);
+        assert_eq!(response.body.as_ref(), PAGE_BODY);
+    }
+
+    #[test]
+    fn rule_4xx_without_target_keeps_synthesized_body() {
+        // Backwards-compat: a 4xx rule with empty `to` still produces the
+        // canister-synthesized "Not Found" / "Gone" body.
+        let mut state = State::default();
+        commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: vec![RedirectRule {
+                    from: RulePattern::Exact("/missing".into()),
+                    to: String::new(),
+                    status: 404,
+                    headers: None,
+                }],
+            })],
+        )
+        .unwrap();
+        let response = certified_http_request(&state, RequestBuilder::get("/missing").build());
+        assert_eq!(response.status_code, 404);
+        assert_eq!(response.body.as_ref(), b"Not Found");
+    }
+
+    #[test]
+    fn rule_4xx_with_missing_target_stays_inert() {
+        // Matches the 200 behavior: pointing `to` at an asset that doesn't
+        // exist yet leaves the rule inert until the asset shows up.
+        let mut state = State::default();
+        commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: vec![RedirectRule {
+                    from: RulePattern::Exact("/missing".into()),
+                    to: "/404.html".into(),
+                    status: 404,
+                    headers: None,
+                }],
+            })],
+        )
+        .unwrap();
+        // Target doesn't exist → rule inert → built-in fall-through 404.
+        let inert =
+            state.http_request(RequestBuilder::get("/missing").build(), &[], unused_callback());
+        assert_eq!(inert.status_code, 404);
+        // The body is the built-in "not found", not the (missing) /404.html.
+        assert_eq!(inert.body.as_ref(), b"not found");
+
+        // Now create the target — the rule starts firing.
+        const PAGE: &[u8] = b"<html>Custom 404</html>";
+        create_assets(
+            &mut state,
+            &mock_system_context(),
+            vec![AssetBuilder::new("/404.html", "text/html")
+                .with_encoding("identity", vec![PAGE])],
+        );
+        let response = certified_http_request(&state, RequestBuilder::get("/missing").build());
+        assert_eq!(response.status_code, 404);
+        assert_eq!(response.body.as_ref(), PAGE);
+    }
+
+    #[test]
+    fn custom_4xx_target_updates_refresh_the_rule() {
+        let mut state = State::default();
+        let system_context = mock_system_context();
+        const V1: &[u8] = b"<html>404 v1</html>";
+        const V2: &[u8] = b"<html>404 v2 redesigned</html>";
+        create_assets(
+            &mut state,
+            &system_context,
+            vec![AssetBuilder::new("/404.html", "text/html")
+                .with_encoding("identity", vec![V1])],
+        );
+        commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: vec![RedirectRule {
+                    from: RulePattern::Subtree("/old/".into()),
+                    to: "/404.html".into(),
+                    status: 404,
+                    headers: None,
+                }],
+            })],
+        )
+        .unwrap();
+        let v1 = certified_http_request(&state, RequestBuilder::get("/old/x").build());
+        assert_eq!(v1.body.as_ref(), V1);
+        assert_eq!(v1.status_code, 404);
+
+        // Update the target page — the rule keeps firing with the new content.
+        create_assets(
+            &mut state,
+            &system_context,
+            vec![AssetBuilder::new("/404.html", "text/html")
+                .with_encoding("identity", vec![V2])],
+        );
+        let v2 = certified_http_request(&state, RequestBuilder::get("/old/x").build());
+        assert_eq!(v2.body.as_ref(), V2);
+        assert_eq!(v2.status_code, 404);
+    }
+
+    #[test]
+    fn validate_rejects_4xx_relative_target() {
+        let mut state = State::default();
+        let err = commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: vec![RedirectRule {
+                    from: RulePattern::Exact("/missing".into()),
+                    to: "404.html".into(), // missing leading '/'
+                    status: 404,
+                    headers: None,
+                }],
+            })],
+        )
+        .unwrap_err();
+        assert!(
+            err.contains("must be empty or an absolute asset path"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
     fn subtree_200_rule_fires_for_unshadowed_children() {
         let mut state = State::default();
         let system_context = mock_system_context();

--- a/ic-certified-assets/src/tests.rs
+++ b/ic-certified-assets/src/tests.rs
@@ -3407,40 +3407,6 @@ mod redirect_rules {
     }
 
     #[test]
-    fn rule_4xx_404_and_410_serve_certified_bodies() {
-        let mut state = State::default();
-        commit(
-            &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: vec![
-                    RedirectRule {
-                        from: RulePattern::Exact("/missing.html".into()),
-                        to: String::new(),
-                        status: 404,
-                        headers: None,
-                    },
-                    RedirectRule {
-                        from: RulePattern::Exact("/gone".into()),
-                        to: String::new(),
-                        status: 410,
-                        headers: None,
-                    },
-                ],
-            })],
-        )
-        .unwrap();
-
-        let not_found =
-            certified_http_request(&state, RequestBuilder::get("/missing.html").build());
-        assert_eq!(not_found.status_code, 404);
-        assert_eq!(not_found.body.as_ref(), b"Not Found");
-
-        let gone = certified_http_request(&state, RequestBuilder::get("/gone").build());
-        assert_eq!(gone.status_code, 410);
-        assert_eq!(gone.body.as_ref(), b"Gone");
-    }
-
-    #[test]
     fn first_match_wins_across_multiple_3xx_rules() {
         let mut state = State::default();
         commit(
@@ -3665,11 +3631,11 @@ mod redirect_rules {
     }
 
     #[test]
-    fn rule_4xx_without_target_keeps_synthesized_body() {
-        // Backwards-compat: a 4xx rule with empty `to` still produces the
-        // canister-synthesized "Not Found" / "Gone" body.
+    fn validate_rejects_4xx_with_empty_target() {
+        // `_redirects` always supplies a target — the canister rejects 4xx
+        // rules without one (the catch-all 404 covers the empty case).
         let mut state = State::default();
-        commit(
+        let err = commit(
             &mut state,
             vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
                 rules: vec![RedirectRule {
@@ -3680,10 +3646,30 @@ mod redirect_rules {
                 }],
             })],
         )
-        .unwrap();
+        .unwrap_err();
+        assert!(
+            err.contains("must be an absolute asset path"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn no_rules_falls_through_to_builtin_404() {
+        // No `_redirects` rules at all: missing paths return the canister's
+        // built-in certified 404 ("not found" body).
+        let mut state = State::default();
+        let system_context = mock_system_context();
+        const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
+        create_assets(
+            &mut state,
+            &system_context,
+            vec![AssetBuilder::new("/index.html", "text/html")
+                .with_encoding("identity", vec![BODY])],
+        );
+
         let response = certified_http_request(&state, RequestBuilder::get("/missing").build());
         assert_eq!(response.status_code, 404);
-        assert_eq!(response.body.as_ref(), b"Not Found");
+        assert_eq!(response.body.as_ref(), b"not found");
     }
 
     #[test]
@@ -3779,7 +3765,7 @@ mod redirect_rules {
         )
         .unwrap_err();
         assert!(
-            err.contains("must be empty or an absolute asset path"),
+            err.contains("must be an absolute asset path"),
             "got: {err}"
         );
     }

--- a/ic-certified-assets/src/tests.rs
+++ b/ic-certified-assets/src/tests.rs
@@ -182,11 +182,6 @@ impl AssetBuilder {
         self
     }
 
-    fn with_aliasing(mut self, aliasing: bool) -> Self {
-        self.aliasing = Some(aliasing);
-        self
-    }
-
     fn with_allow_raw_access(mut self, allow_raw_access: Option<bool>) -> Self {
         self.allow_raw_access = allow_raw_access;
         self
@@ -428,7 +423,7 @@ fn serve_correct_encoding() {
 }
 
 #[test]
-fn serve_fallback() {
+fn serve_fallback_via_rule() {
     let mut state = State::default();
     let system_context = mock_system_context();
 
@@ -452,6 +447,10 @@ fn serve_fallback() {
         ],
     );
 
+    // SPA-style catch-all: a single root subtree rule replaces what used to
+    // be the built-in `FALLBACK_FILE` mechanism.
+    set_root_spa_rule(&mut state, "/index.html");
+
     let identity_response = certified_http_request(
         &state,
         RequestBuilder::get("/index.html")
@@ -460,7 +459,6 @@ fn serve_fallback() {
             .build(),
     );
     let certificate_header = lookup_header(&identity_response, "IC-Certificate").unwrap();
-    println!("certificate_header: {certificate_header}");
 
     assert_eq!(identity_response.status_code, 200);
     assert_eq!(identity_response.body.as_ref(), INDEX_BODY);
@@ -476,6 +474,8 @@ fn serve_fallback() {
     let certificate_header = lookup_header(&fallback_response, "IC-Certificate").unwrap();
     assert_eq!(fallback_response.status_code, 200);
     assert_eq!(fallback_response.body.as_ref(), INDEX_BODY);
+    // The rule lives at the root `<*>`, matching the previous built-in
+    // fallback's expr_path.
     assert!(certificate_header.contains("expr_path=:2dn3gmlodHRwX2V4cHJjPCo+:"));
 
     let valid_response = certified_http_request(
@@ -497,6 +497,66 @@ fn serve_fallback() {
     );
     assert_eq!(fallback_response.status_code, 200);
     assert_eq!(fallback_response.body.as_ref(), INDEX_BODY);
+}
+
+fn set_root_spa_rule(state: &mut State, target: &str) {
+    use crate::redirect::{RedirectRule, RulePattern};
+    use crate::types::SetRedirectRulesArguments;
+    let system_context = mock_system_context();
+    let batch_id = state.create_batch(&system_context).unwrap();
+    let ops = vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+        rules: vec![RedirectRule {
+            from: RulePattern::Subtree("/".into()),
+            to: target.into(),
+            status: 200,
+            headers: None,
+        }],
+    })];
+    run_computation_until_completion(|progress| {
+        state.commit_batch(
+            &CommitBatchArguments {
+                batch_id: batch_id.clone(),
+                operations: ops.clone(),
+            },
+            progress,
+            &system_context,
+        )
+    })
+    .unwrap();
+}
+
+fn set_exact_rewrite_rule(state: &mut State, from: &str, to: &str) {
+    set_exact_rewrite_rules(state, &[(from, to)]);
+}
+
+fn set_exact_rewrite_rules(state: &mut State, pairs: &[(&str, &str)]) {
+    use crate::redirect::{RedirectRule, RulePattern};
+    use crate::types::SetRedirectRulesArguments;
+    let system_context = mock_system_context();
+    let batch_id = state.create_batch(&system_context).unwrap();
+    let rules = pairs
+        .iter()
+        .map(|(from, to)| RedirectRule {
+            from: RulePattern::Exact((*from).into()),
+            to: (*to).into(),
+            status: 200,
+            headers: None,
+        })
+        .collect();
+    let ops = vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+        rules,
+    })];
+    run_computation_until_completion(|progress| {
+        state.commit_batch(
+            &CommitBatchArguments {
+                batch_id: batch_id.clone(),
+                operations: ops.clone(),
+            },
+            progress,
+            &system_context,
+        )
+    })
+    .unwrap();
 }
 
 #[test]
@@ -561,7 +621,7 @@ fn can_delete_batch_with_chunks() {
 }
 
 #[test]
-fn returns_index_file_for_missing_assets() {
+fn returns_index_file_for_missing_assets_via_rule() {
     let mut state = State::default();
     let system_context = mock_system_context();
 
@@ -578,6 +638,8 @@ fn returns_index_file_for_missing_assets() {
                 .with_encoding("identity", vec![OTHER_BODY]),
         ],
     );
+    // Without a rule the canister no longer auto-falls-back to /index.html.
+    set_root_spa_rule(&mut state, "/index.html");
 
     let response = certified_http_request(
         &state,
@@ -588,6 +650,87 @@ fn returns_index_file_for_missing_assets() {
 
     assert_eq!(response.status_code, 200);
     assert_eq!(response.body.as_ref(), INDEX_BODY);
+}
+
+#[test]
+fn old_stable_assets_with_is_aliased_load_cleanly() {
+    // Mirrors the plan's "guard against accidental data loss" test: a
+    // StableAsset record serialized when built-in aliasing was a real
+    // canister feature must still deserialize and serve correctly after
+    // the in-memory `Asset` lost the `is_aliased` field.
+    use crate::stable::{StableAsset, StableAssetEncoding};
+
+    let mut stable_assets = std::collections::HashMap::new();
+    stable_assets.insert(
+        "/foo.html".to_string(),
+        StableAsset {
+            content_type: "text/html".into(),
+            encodings: HashMap::from([(
+                "identity".into(),
+                StableAssetEncoding {
+                    modified: 0,
+                    content_chunks: vec![],
+                    total_length: 0,
+                    certified: false,
+                    sha256: [0u8; 32],
+                    certificate_expression: None,
+                    response_hashes: None,
+                },
+            )]),
+            max_age: None,
+            headers: None,
+            // Pretend this came from an older serialized blob.
+            is_aliased: Some(true),
+            allow_raw_access: None,
+        },
+    );
+    let stable_state = StableState {
+        authorized: vec![],
+        permissions: None,
+        stable_assets,
+        next_batch_id: None,
+        configuration: None,
+        last_state_update_timestamp: None,
+        redirect_rules: None,
+    };
+    // Round-trip through serde_cbor (the format stable memory uses).
+    let bytes = serde_cbor::to_vec(&stable_state).unwrap();
+    let restored: StableState = serde_cbor::from_slice(&bytes).unwrap();
+    let state: State = restored.into();
+    // The asset survives; the in-memory shape no longer carries the flag.
+    assert!(state.assets.contains_key("/foo.html"));
+}
+
+#[test]
+fn no_implicit_aliasing_without_rules() {
+    let mut state = State::default();
+    let system_context = mock_system_context();
+    const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
+    create_assets(
+        &mut state,
+        &system_context,
+        vec![
+            AssetBuilder::new("/foo.html", "text/html")
+                .with_encoding("identity", vec![BODY]),
+            AssetBuilder::new("/blog/index.html", "text/html")
+                .with_encoding("identity", vec![BODY]),
+        ],
+    );
+
+    for missing in &["/foo", "/foo/", "/blog", "/blog/"] {
+        let response = state.http_request(
+            RequestBuilder::get(*missing).build(),
+            &[],
+            unused_callback(),
+        );
+        assert_eq!(
+            response.status_code, 404,
+            "expected 404 for {missing}, got {}",
+            response.status_code
+        );
+    }
+    let response = certified_http_request(&state, RequestBuilder::get("/foo.html").build());
+    assert_eq!(response.status_code, 200);
 }
 
 #[test]
@@ -1066,7 +1209,9 @@ fn supports_getting_and_setting_asset_properties() {
                 ("new-header".into(), "value".into())
             ])),
             allow_raw_access: None,
-            is_aliased: Some(false)
+            // `is_aliased` is accepted on the candid surface but ignored —
+            // the canister no longer aliases on its own.
+            is_aliased: None
         })
     );
 
@@ -1502,7 +1647,9 @@ fn create_asset_fails_if_asset_exists() {
 }
 
 #[test]
-fn support_aliases() {
+fn aliases_via_explicit_rules() {
+    // Migrated from `support_aliases`: what used to be built-in `.html` /
+    // `index.html` aliasing is now expressed as user-supplied 200 rules.
     let mut state = State::default();
     let system_context = mock_system_context();
     const INDEX_BODY: &[u8] = b"<!DOCTYPE html><html>index</html>";
@@ -1521,6 +1668,16 @@ fn support_aliases() {
                 .with_encoding("identity", vec![SUBDIR_INDEX_BODY]),
         ],
     );
+    set_exact_rewrite_rules(
+        &mut state,
+        &[
+            ("/contents", "/contents.html"),
+            ("/", "/index.html"),
+            ("/subdirectory/index", "/subdirectory/index.html"),
+            ("/subdirectory/", "/subdirectory/index.html"),
+            ("/subdirectory", "/subdirectory/index.html"),
+        ],
+    );
 
     let normal_request =
         certified_http_request(&state, RequestBuilder::get("/contents.html").build());
@@ -1531,11 +1688,6 @@ fn support_aliases() {
 
     let root_alias = certified_http_request(&state, RequestBuilder::get("/").build());
     assert_eq!(root_alias.body.as_ref(), INDEX_BODY);
-
-    // cannot use certified request because this produces an invalid URL
-    let empty_path_alias =
-        state.http_request(RequestBuilder::get("").build(), &[], unused_callback());
-    assert_eq!(empty_path_alias.body.as_ref(), INDEX_BODY);
 
     let subdirectory_index_alias =
         certified_http_request(&state, RequestBuilder::get("/subdirectory/index").build());
@@ -1551,7 +1703,9 @@ fn support_aliases() {
 }
 
 #[test]
-fn alias_enable_and_disable() {
+fn rule_aliasing_persists_through_upgrade() {
+    // Migrated from `alias_behavior_persists_through_upgrade`: rules survive
+    // the upgrade and serve correctly afterward.
     let mut state = State::default();
     let system_context = mock_system_context();
     const SUBDIR_INDEX_BODY: &[u8] = b"<!DOCTYPE html><html>subdir index</html>";
@@ -1567,106 +1721,37 @@ fn alias_enable_and_disable() {
                 .with_encoding("identity", vec![SUBDIR_INDEX_BODY]),
         ],
     );
+    // No rule for /contents → no alias to /contents.html (used to be the
+    // "aliasing disabled" path); still install one for the subdirectory.
+    set_exact_rewrite_rule(&mut state, "/subdirectory", "/subdirectory/index.html");
 
-    let alias_add_html = certified_http_request(&state, RequestBuilder::get("/contents").build());
-    assert_eq!(alias_add_html.body.as_ref(), FILE_BODY);
-
-    assert!(state
-        .set_asset_properties(SetAssetPropertiesArguments {
-            key: "/contents.html".into(),
-            max_age: None,
-            headers: None,
-            allow_raw_access: None,
-            is_aliased: Some(Some(false)),
-        })
-        .is_ok());
-
-    let no_more_alias = state.http_request(
+    let no_alias = state.http_request(
         RequestBuilder::get("/contents").build(),
         &[],
         unused_callback(),
     );
-    assert_ne!(no_more_alias.body.as_ref(), FILE_BODY);
+    assert_eq!(no_alias.status_code, 404);
 
-    let other_alias_still_works =
-        certified_http_request(&state, RequestBuilder::get("/subdirectory/index").build());
-    assert_eq!(other_alias_still_works.body.as_ref(), SUBDIR_INDEX_BODY);
-
-    create_assets(
-        &mut state,
-        &system_context,
-        vec![AssetBuilder::new("/contents.html", "text/html")
-            .with_encoding("identity", vec![FILE_BODY])
-            .with_aliasing(true)],
-    );
-
-    assert!(state
-        .set_asset_properties(SetAssetPropertiesArguments {
-            key: "/contents.html".into(),
-            max_age: None,
-            headers: None,
-            allow_raw_access: None,
-            is_aliased: Some(Some(true)),
-        })
-        .is_ok());
-    let alias_add_html_again =
-        certified_http_request(&state, RequestBuilder::get("/contents").build());
-    assert_eq!(alias_add_html_again.body.as_ref(), FILE_BODY);
-}
-
-#[test]
-fn alias_behavior_persists_through_upgrade() {
-    let mut state = State::default();
-    let system_context = mock_system_context();
-    const SUBDIR_INDEX_BODY: &[u8] = b"<!DOCTYPE html><html>subdir index</html>";
-    const FILE_BODY: &[u8] = b"<!DOCTYPE html><html>file body</html>";
-
-    create_assets(
-        &mut state,
-        &system_context,
-        vec![
-            AssetBuilder::new("/contents.html", "text/html")
-                .with_encoding("identity", vec![FILE_BODY])
-                .with_aliasing(false),
-            AssetBuilder::new("/subdirectory/index.html", "text/html")
-                .with_encoding("identity", vec![SUBDIR_INDEX_BODY]),
-        ],
-    );
-
-    let alias_disabled = state.http_request(
-        RequestBuilder::get("/contents").build(),
-        &[],
-        unused_callback(),
-    );
-    assert_ne!(alias_disabled.body.as_ref(), FILE_BODY);
-
-    let alias_for_other_asset_still_works =
-        certified_http_request(&state, RequestBuilder::get("/subdirectory").build());
-    assert_eq!(
-        alias_for_other_asset_still_works.body.as_ref(),
-        SUBDIR_INDEX_BODY
-    );
+    let other = certified_http_request(&state, RequestBuilder::get("/subdirectory").build());
+    assert_eq!(other.body.as_ref(), SUBDIR_INDEX_BODY);
 
     let stable_state: StableState = state.into();
     let state: State = stable_state.into();
 
-    let alias_stays_turned_off = state.http_request(
+    let no_alias = state.http_request(
         RequestBuilder::get("/contents").build(),
         &[],
         unused_callback(),
     );
-    assert_ne!(alias_stays_turned_off.body.as_ref(), FILE_BODY);
-
-    let alias_for_other_asset_still_works =
-        certified_http_request(&state, RequestBuilder::get("/subdirectory").build());
-    assert_eq!(
-        alias_for_other_asset_still_works.body.as_ref(),
-        SUBDIR_INDEX_BODY
-    );
+    assert_eq!(no_alias.status_code, 404);
+    let other = certified_http_request(&state, RequestBuilder::get("/subdirectory").build());
+    assert_eq!(other.body.as_ref(), SUBDIR_INDEX_BODY);
 }
 
 #[test]
-fn aliasing_name_clash() {
+fn rule_aliasing_name_clash() {
+    // Migrated from `aliasing_name_clash`: an asset at the rule's source
+    // shadows the rule.
     let mut state = State::default();
     let system_context = mock_system_context();
     const FILE_BODY: &[u8] = b"<!DOCTYPE html><html>file body</html>";
@@ -1678,9 +1763,10 @@ fn aliasing_name_clash() {
         vec![AssetBuilder::new("/contents.html", "text/html")
             .with_encoding("identity", vec![FILE_BODY])],
     );
+    set_exact_rewrite_rule(&mut state, "/contents", "/contents.html");
 
-    let alias_add_html = certified_http_request(&state, RequestBuilder::get("/contents").build());
-    assert_eq!(alias_add_html.body.as_ref(), FILE_BODY);
+    let via_rule = certified_http_request(&state, RequestBuilder::get("/contents").build());
+    assert_eq!(via_rule.body.as_ref(), FILE_BODY);
 
     create_assets(
         &mut state,
@@ -1689,20 +1775,17 @@ fn aliasing_name_clash() {
             .with_encoding("identity", vec![FILE_BODY_2])],
     );
 
-    let alias_doesnt_overwrite_actual_file =
-        certified_http_request(&state, RequestBuilder::get("/contents").build());
-    assert_eq!(
-        alias_doesnt_overwrite_actual_file.body.as_ref(),
-        FILE_BODY_2
-    );
+    let asset_wins = certified_http_request(&state, RequestBuilder::get("/contents").build());
+    assert_eq!(asset_wins.body.as_ref(), FILE_BODY_2);
 
     state.delete_asset(DeleteAssetArguments {
         key: "/contents".to_string(),
     });
+    state.on_redirect_rules_change();
 
-    let alias_accessible_again =
+    let rule_visible_again =
         certified_http_request(&state, RequestBuilder::get("/contents").build());
-    assert_eq!(alias_accessible_again.body.as_ref(), FILE_BODY);
+    assert_eq!(rule_visible_again.body.as_ref(), FILE_BODY);
 }
 
 #[test]
@@ -1782,20 +1865,22 @@ mod allow_raw_access {
 
     #[test]
     fn redirects_from_raw_to_certified() {
+        // The raw-domain redirect now triggers for both direct asset hits and
+        // 200-rule aliases — explicit rules replace the canister's old
+        // built-in `.html` / `index.html` aliasing.
         let mut state = State::default();
 
         state.create_test_asset(
             AssetBuilder::new("/page.html", "text/html").with_allow_raw_access(Some(false)),
         );
+        set_exact_rewrite_rule(&mut state, "/page", "/page.html");
         let response = state.fake_http_request("a-b-c.raw.icp0.io", "/page");
-        dbg!(&response);
         assert_eq!(response.status_code, 308);
         assert_eq!(
             lookup_header(&response, "Location").unwrap(),
             "https://a-b-c.icp0.io/page"
         );
         let response = state.fake_http_request("a-b-c.raw.ic0.app", "/page");
-        dbg!(&response);
         assert_eq!(response.status_code, 308);
         assert_eq!(
             lookup_header(&response, "Location").unwrap(),
@@ -1805,8 +1890,11 @@ mod allow_raw_access {
         state.create_test_asset(
             AssetBuilder::new("/page2.html", "text/html").with_allow_raw_access(Some(false)),
         );
+        set_exact_rewrite_rules(
+            &mut state,
+            &[("/page", "/page.html"), ("/page2", "/page2.html")],
+        );
         let response = state.fake_http_request("a-b-c.raw.icp0.io", "/page2");
-        dbg!(&response);
         assert_eq!(response.status_code, 308);
         assert_eq!(
             lookup_header(&response, "Location").unwrap(),
@@ -1816,8 +1904,8 @@ mod allow_raw_access {
         state.create_test_asset(
             AssetBuilder::new("/index.html", "text/html").with_allow_raw_access(Some(false)),
         );
+        set_root_spa_rule(&mut state, "/index.html");
         let response = state.fake_http_request("a-b-c.raw.icp0.io", "/");
-        dbg!(&response);
         assert_eq!(response.status_code, 308);
         assert_eq!(
             lookup_header(&response, "Location").unwrap(),
@@ -1828,8 +1916,8 @@ mod allow_raw_access {
         state.create_test_asset(
             AssetBuilder::new("/index.html", "text/html").with_allow_raw_access(Some(false)),
         );
+        set_root_spa_rule(&mut state, "/index.html");
         let response = state.fake_http_request("a-b-c.raw.icp0.io", "/");
-        dbg!(&response);
         assert_eq!(response.status_code, 308);
         assert_eq!(
             lookup_header(&response, "Location").unwrap(),

--- a/ic-certified-assets/src/tests.rs
+++ b/ic-certified-assets/src/tests.rs
@@ -3130,3 +3130,174 @@ mod compute_state_hash {
         assert!(result.is_ok());
     }
 }
+
+mod redirect_rules {
+    use super::*;
+    use crate::redirect::{RedirectRule, RulePattern};
+    use crate::types::SetRedirectRulesArguments;
+
+    fn commit(state: &mut State, ops: Vec<BatchOperation>) -> Result<(), String> {
+        let system_context = mock_system_context();
+        let batch_id = state.create_batch(&system_context).unwrap();
+        run_computation_until_completion(|progress| {
+            state.commit_batch(
+                &CommitBatchArguments {
+                    batch_id: batch_id.clone(),
+                    operations: ops.clone(),
+                },
+                progress,
+                &system_context,
+            )
+        })
+    }
+
+    fn sample_rules() -> Vec<RedirectRule> {
+        vec![
+            RedirectRule {
+                from: RulePattern::Exact("/old".into()),
+                to: "/new".into(),
+                status: 301,
+                headers: None,
+            },
+            RedirectRule {
+                from: RulePattern::Subtree("/legacy/".into()),
+                to: "/home".into(),
+                status: 308,
+                headers: Some(vec![("X-Reason".into(), "moved".into())]),
+            },
+        ]
+    }
+
+    #[test]
+    fn commit_set_redirect_rules_round_trips_through_get() {
+        let mut state = State::default();
+        let rules = sample_rules();
+
+        commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: rules.clone(),
+            })],
+        )
+        .unwrap();
+
+        assert_eq!(state.get_redirect_rules(), rules);
+    }
+
+    #[test]
+    fn invalid_rule_fails_op_without_mutating_state() {
+        let mut state = State::default();
+        // Seed an initial valid set so we can confirm it is preserved.
+        let initial = vec![RedirectRule {
+            from: RulePattern::Exact("/seed".into()),
+            to: "/dest".into(),
+            status: 301,
+            headers: None,
+        }];
+        commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: initial.clone(),
+            })],
+        )
+        .unwrap();
+
+        // One valid + one invalid (status 418) — the whole op must fail.
+        let mixed = vec![
+            RedirectRule {
+                from: RulePattern::Exact("/a".into()),
+                to: "/b".into(),
+                status: 301,
+                headers: None,
+            },
+            RedirectRule {
+                from: RulePattern::Exact("/c".into()),
+                to: "/d".into(),
+                status: 418,
+                headers: None,
+            },
+        ];
+        let err = commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: mixed,
+            })],
+        )
+        .unwrap_err();
+        assert!(err.contains("unsupported status code"), "got: {err}");
+
+        assert_eq!(
+            state.get_redirect_rules(),
+            initial,
+            "rules must be unchanged after a failed SetRedirectRules"
+        );
+    }
+
+    #[test]
+    fn rules_persist_through_upgrade() {
+        let mut state = State::default();
+        let rules = sample_rules();
+
+        commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: rules.clone(),
+            })],
+        )
+        .unwrap();
+
+        let stable: StableState = state.into();
+        let state: State = stable.into();
+
+        assert_eq!(state.get_redirect_rules(), rules);
+    }
+
+    #[test]
+    fn empty_rules_replace_existing() {
+        let mut state = State::default();
+
+        commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: sample_rules(),
+            })],
+        )
+        .unwrap();
+        assert!(!state.get_redirect_rules().is_empty());
+
+        commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: vec![],
+            })],
+        )
+        .unwrap();
+        assert!(state.get_redirect_rules().is_empty());
+    }
+
+    #[test]
+    fn rules_are_inert_in_step_1_1() {
+        // Step 1.1 deliberately stores rules without affecting `http_request`.
+        // This test will need to change once step 1.2 / 1.3 wire them in.
+        let mut state = State::default();
+        commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: vec![RedirectRule {
+                    from: RulePattern::Exact("/old".into()),
+                    to: "/new".into(),
+                    status: 301,
+                    headers: None,
+                }],
+            })],
+        )
+        .unwrap();
+
+        let response = state.http_request(
+            RequestBuilder::get("/old").build(),
+            &[],
+            unused_callback(),
+        );
+        assert_eq!(response.status_code, 404);
+    }
+}

--- a/ic-certified-assets/src/tests.rs
+++ b/ic-certified-assets/src/tests.rs
@@ -3406,25 +3406,86 @@ mod redirect_rules {
     }
 
     #[test]
-    fn status_200_rules_remain_inert_until_step_1_3() {
-        // Step 1.2 deliberately skips wiring status-200 rules — they are
-        // visible in `get_redirect_rules` but `http_request` does not yet
-        // honor them. Remove this test once step 1.3 lands the rewrite path.
+    fn status_200_target_coupling() {
+        // Install rule before the target exists → rule is inert.
+        let mut state = State::default();
+        commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: vec![RedirectRule {
+                    from: RulePattern::Exact("/foo".into()),
+                    to: "/foo.html".into(),
+                    status: 200,
+                    headers: None,
+                }],
+            })],
+        )
+        .unwrap();
+        let inert =
+            state.http_request(RequestBuilder::get("/foo").build(), &[], unused_callback());
+        assert_eq!(inert.status_code, 404);
+
+        // Add the asset → rule fires.
+        const BODY_V1: &[u8] = b"<!DOCTYPE html><html>v1</html>";
+        create_assets(
+            &mut state,
+            &mock_system_context(),
+            vec![AssetBuilder::new("/foo.html", "text/html")
+                .with_encoding("identity", vec![BODY_V1])],
+        );
+        let v1 = certified_http_request(&state, RequestBuilder::get("/foo").build());
+        assert_eq!(v1.status_code, 200);
+        assert_eq!(v1.body.as_ref(), BODY_V1);
+
+        // Modify the asset → rule still fires with the new content.
+        const BODY_V2: &[u8] = b"<!DOCTYPE html><html>v2 different</html>";
+        create_assets(
+            &mut state,
+            &mock_system_context(),
+            vec![AssetBuilder::new("/foo.html", "text/html")
+                .with_encoding("identity", vec![BODY_V2])],
+        );
+        let v2 = certified_http_request(&state, RequestBuilder::get("/foo").build());
+        assert_eq!(v2.body.as_ref(), BODY_V2);
+
+        // Delete the target → rule goes inert again.
+        delete_asset_via_batch(&mut state, "/foo.html");
+        let after_delete = state.http_request(
+            RequestBuilder::get("/foo").build(),
+            &[],
+            unused_callback(),
+        );
+        assert_eq!(after_delete.status_code, 404);
+    }
+
+    fn delete_asset_via_batch(state: &mut State, key: &str) {
+        commit(
+            state,
+            vec![BatchOperation::DeleteAsset(DeleteAssetArguments {
+                key: key.to_string(),
+            })],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn asset_shadows_exact_rule_at_same_path() {
         let mut state = State::default();
         let system_context = mock_system_context();
-        const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
+        const RULE_TARGET: &[u8] = b"rule-target";
+        const SOURCE_ASSET: &[u8] = b"source-asset";
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/target.html", "text/html")
-                .with_encoding("identity", vec![BODY])],
+            vec![AssetBuilder::new("/bar.html", "text/html")
+                .with_encoding("identity", vec![RULE_TARGET])],
         );
         commit(
             &mut state,
             vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
                 rules: vec![RedirectRule {
                     from: RulePattern::Exact("/foo".into()),
-                    to: "/target.html".into(),
+                    to: "/bar.html".into(),
                     status: 200,
                     headers: None,
                 }],
@@ -3432,17 +3493,61 @@ mod redirect_rules {
         )
         .unwrap();
 
-        // The rule itself does not fire. (Built-in alias /foo → /foo.html
-        // still maps /foo to nothing, falling through to the built-in 404.
-        // Step 1.4 removes that built-in too; for now the response is a 404.)
-        let response = state.http_request(
-            RequestBuilder::get("/foo").build(),
-            &[],
-            unused_callback(),
-        );
-        assert_eq!(response.status_code, 404);
+        // Without an asset at /foo, the rule fires.
+        let via_rule = certified_http_request(&state, RequestBuilder::get("/foo").build());
+        assert_eq!(via_rule.body.as_ref(), RULE_TARGET);
 
-        // But the rule is stored.
-        assert_eq!(state.get_redirect_rules().len(), 1);
+        // Upload an asset at /foo → asset wins.
+        create_assets(
+            &mut state,
+            &system_context,
+            vec![AssetBuilder::new("/foo", "text/html")
+                .with_encoding("identity", vec![SOURCE_ASSET])],
+        );
+        let via_asset = certified_http_request(&state, RequestBuilder::get("/foo").build());
+        assert_eq!(via_asset.body.as_ref(), SOURCE_ASSET);
+
+        // Delete the source asset → rule reappears.
+        delete_asset_via_batch(&mut state, "/foo");
+        let back_to_rule = certified_http_request(&state, RequestBuilder::get("/foo").build());
+        assert_eq!(back_to_rule.body.as_ref(), RULE_TARGET);
+    }
+
+    #[test]
+    fn subtree_200_rule_fires_for_unshadowed_children() {
+        let mut state = State::default();
+        let system_context = mock_system_context();
+        const INDEX_BODY: &[u8] = b"<!DOCTYPE html><html>index</html>";
+        const REAL_BODY: &[u8] = b"<!DOCTYPE html><html>real</html>";
+        create_assets(
+            &mut state,
+            &system_context,
+            vec![
+                AssetBuilder::new("/index.html", "text/html")
+                    .with_encoding("identity", vec![INDEX_BODY]),
+                AssetBuilder::new("/real-page", "text/html")
+                    .with_encoding("identity", vec![REAL_BODY]),
+            ],
+        );
+        commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: vec![RedirectRule {
+                    from: RulePattern::Subtree("/".into()),
+                    to: "/index.html".into(),
+                    status: 200,
+                    headers: None,
+                }],
+            })],
+        )
+        .unwrap();
+
+        // Real asset still wins for its own path.
+        let real = certified_http_request(&state, RequestBuilder::get("/real-page").build());
+        assert_eq!(real.body.as_ref(), REAL_BODY);
+
+        // Unshadowed path falls back to the rule → /index.html content.
+        let fallback = certified_http_request(&state, RequestBuilder::get("/anything").build());
+        assert_eq!(fallback.body.as_ref(), INDEX_BODY);
     }
 }

--- a/ic-certified-assets/src/tests.rs
+++ b/ic-certified-assets/src/tests.rs
@@ -3276,9 +3276,7 @@ mod redirect_rules {
     }
 
     #[test]
-    fn rules_are_inert_in_step_1_1() {
-        // Step 1.1 deliberately stores rules without affecting `http_request`.
-        // This test will need to change once step 1.2 / 1.3 wire them in.
+    fn exact_3xx_rule_serves_redirect_with_certificate() {
         let mut state = State::default();
         commit(
             &mut state,
@@ -3293,11 +3291,158 @@ mod redirect_rules {
         )
         .unwrap();
 
+        let response = certified_http_request(&state, RequestBuilder::get("/old").build());
+        assert_eq!(response.status_code, 301);
+        assert_eq!(lookup_header(&response, "Location"), Some("/new"));
+    }
+
+    #[test]
+    fn subtree_3xx_rule_fires_for_descendants_and_verifies() {
+        let mut state = State::default();
+        commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: vec![RedirectRule {
+                    from: RulePattern::Subtree("/legacy/".into()),
+                    to: "/home".into(),
+                    status: 308,
+                    headers: None,
+                }],
+            })],
+        )
+        .unwrap();
+
+        let response =
+            certified_http_request(&state, RequestBuilder::get("/legacy/anything/here").build());
+        assert_eq!(response.status_code, 308);
+        assert_eq!(lookup_header(&response, "Location"), Some("/home"));
+    }
+
+    #[test]
+    fn rule_4xx_404_and_410_serve_certified_bodies() {
+        let mut state = State::default();
+        commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: vec![
+                    RedirectRule {
+                        from: RulePattern::Exact("/missing.html".into()),
+                        to: String::new(),
+                        status: 404,
+                        headers: None,
+                    },
+                    RedirectRule {
+                        from: RulePattern::Exact("/gone".into()),
+                        to: String::new(),
+                        status: 410,
+                        headers: None,
+                    },
+                ],
+            })],
+        )
+        .unwrap();
+
+        let not_found =
+            certified_http_request(&state, RequestBuilder::get("/missing.html").build());
+        assert_eq!(not_found.status_code, 404);
+        assert_eq!(not_found.body.as_ref(), b"Not Found");
+
+        let gone = certified_http_request(&state, RequestBuilder::get("/gone").build());
+        assert_eq!(gone.status_code, 410);
+        assert_eq!(gone.body.as_ref(), b"Gone");
+    }
+
+    #[test]
+    fn first_match_wins_across_multiple_3xx_rules() {
+        let mut state = State::default();
+        commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: vec![
+                    RedirectRule {
+                        from: RulePattern::Exact("/dup".into()),
+                        to: "/first".into(),
+                        status: 301,
+                        headers: None,
+                    },
+                    RedirectRule {
+                        from: RulePattern::Exact("/dup".into()),
+                        to: "/second".into(),
+                        status: 302,
+                        headers: None,
+                    },
+                ],
+            })],
+        )
+        .unwrap();
+
+        let response = certified_http_request(&state, RequestBuilder::get("/dup").build());
+        assert_eq!(response.status_code, 301);
+        assert_eq!(lookup_header(&response, "Location"), Some("/first"));
+    }
+
+    #[test]
+    fn rules_survive_post_upgrade_and_witnesses_still_validate() {
+        let mut state = State::default();
+        commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: sample_rules(),
+            })],
+        )
+        .unwrap();
+        // Sanity: rules fire pre-upgrade.
+        let pre =
+            certified_http_request(&state, RequestBuilder::get("/legacy/anything").build());
+        assert_eq!(pre.status_code, 308);
+
+        let stable: StableState = state.into();
+        let state: State = stable.into();
+
+        let post =
+            certified_http_request(&state, RequestBuilder::get("/legacy/anything").build());
+        assert_eq!(post.status_code, 308);
+        assert_eq!(lookup_header(&post, "Location"), Some("/home"));
+    }
+
+    #[test]
+    fn status_200_rules_remain_inert_until_step_1_3() {
+        // Step 1.2 deliberately skips wiring status-200 rules — they are
+        // visible in `get_redirect_rules` but `http_request` does not yet
+        // honor them. Remove this test once step 1.3 lands the rewrite path.
+        let mut state = State::default();
+        let system_context = mock_system_context();
+        const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
+        create_assets(
+            &mut state,
+            &system_context,
+            vec![AssetBuilder::new("/target.html", "text/html")
+                .with_encoding("identity", vec![BODY])],
+        );
+        commit(
+            &mut state,
+            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: vec![RedirectRule {
+                    from: RulePattern::Exact("/foo".into()),
+                    to: "/target.html".into(),
+                    status: 200,
+                    headers: None,
+                }],
+            })],
+        )
+        .unwrap();
+
+        // The rule itself does not fire. (Built-in alias /foo → /foo.html
+        // still maps /foo to nothing, falling through to the built-in 404.
+        // Step 1.4 removes that built-in too; for now the response is a 404.)
         let response = state.http_request(
-            RequestBuilder::get("/old").build(),
+            RequestBuilder::get("/foo").build(),
             &[],
             unused_callback(),
         );
         assert_eq!(response.status_code, 404);
+
+        // But the rule is stored.
+        assert_eq!(state.get_redirect_rules().len(), 1);
     }
 }

--- a/ic-certified-assets/src/tests.rs
+++ b/ic-certified-assets/src/tests.rs
@@ -504,14 +504,16 @@ fn set_root_spa_rule(state: &mut State, target: &str) {
     use crate::types::SetRedirectRulesArguments;
     let system_context = mock_system_context();
     let batch_id = state.create_batch(&system_context).unwrap();
-    let ops = vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-        rules: vec![RedirectRule {
-            from: RulePattern::Subtree("/".into()),
-            to: target.into(),
-            status: 200,
-            headers: None,
-        }],
-    })];
+    let ops = vec![BatchOperation::SetRedirectRules(
+        SetRedirectRulesArguments {
+            rules: vec![RedirectRule {
+                from: RulePattern::Subtree("/".into()),
+                to: target.into(),
+                status: 200,
+                headers: None,
+            }],
+        },
+    )];
     run_computation_until_completion(|progress| {
         state.commit_batch(
             &CommitBatchArguments {
@@ -543,9 +545,9 @@ fn set_exact_rewrite_rules(state: &mut State, pairs: &[(&str, &str)]) {
             headers: None,
         })
         .collect();
-    let ops = vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-        rules,
-    })];
+    let ops = vec![BatchOperation::SetRedirectRules(
+        SetRedirectRulesArguments { rules },
+    )];
     run_computation_until_completion(|progress| {
         state.commit_batch(
             &CommitBatchArguments {
@@ -710,8 +712,7 @@ fn no_implicit_aliasing_without_rules() {
         &mut state,
         &system_context,
         vec![
-            AssetBuilder::new("/foo.html", "text/html")
-                .with_encoding("identity", vec![BODY]),
+            AssetBuilder::new("/foo.html", "text/html").with_encoding("identity", vec![BODY]),
             AssetBuilder::new("/blog/index.html", "text/html")
                 .with_encoding("identity", vec![BODY]),
         ],
@@ -3263,9 +3264,11 @@ mod redirect_rules {
 
         commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: rules.clone(),
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments {
+                    rules: rules.clone(),
+                },
+            )],
         )
         .unwrap();
 
@@ -3284,9 +3287,11 @@ mod redirect_rules {
         }];
         commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: initial.clone(),
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments {
+                    rules: initial.clone(),
+                },
+            )],
         )
         .unwrap();
 
@@ -3307,9 +3312,9 @@ mod redirect_rules {
         ];
         let err = commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: mixed,
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments { rules: mixed },
+            )],
         )
         .unwrap_err();
         assert!(err.contains("unsupported status code"), "got: {err}");
@@ -3328,9 +3333,11 @@ mod redirect_rules {
 
         commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: rules.clone(),
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments {
+                    rules: rules.clone(),
+                },
+            )],
         )
         .unwrap();
 
@@ -3346,18 +3353,20 @@ mod redirect_rules {
 
         commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: sample_rules(),
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments {
+                    rules: sample_rules(),
+                },
+            )],
         )
         .unwrap();
         assert!(!state.get_redirect_rules().is_empty());
 
         commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: vec![],
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments { rules: vec![] },
+            )],
         )
         .unwrap();
         assert!(state.get_redirect_rules().is_empty());
@@ -3368,14 +3377,16 @@ mod redirect_rules {
         let mut state = State::default();
         commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: vec![RedirectRule {
-                    from: RulePattern::Exact("/old".into()),
-                    to: "/new".into(),
-                    status: 301,
-                    headers: None,
-                }],
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments {
+                    rules: vec![RedirectRule {
+                        from: RulePattern::Exact("/old".into()),
+                        to: "/new".into(),
+                        status: 301,
+                        headers: None,
+                    }],
+                },
+            )],
         )
         .unwrap();
 
@@ -3389,14 +3400,16 @@ mod redirect_rules {
         let mut state = State::default();
         commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: vec![RedirectRule {
-                    from: RulePattern::Subtree("/legacy/".into()),
-                    to: "/home".into(),
-                    status: 308,
-                    headers: None,
-                }],
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments {
+                    rules: vec![RedirectRule {
+                        from: RulePattern::Subtree("/legacy/".into()),
+                        to: "/home".into(),
+                        status: 308,
+                        headers: None,
+                    }],
+                },
+            )],
         )
         .unwrap();
 
@@ -3411,22 +3424,24 @@ mod redirect_rules {
         let mut state = State::default();
         commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: vec![
-                    RedirectRule {
-                        from: RulePattern::Exact("/dup".into()),
-                        to: "/first".into(),
-                        status: 301,
-                        headers: None,
-                    },
-                    RedirectRule {
-                        from: RulePattern::Exact("/dup".into()),
-                        to: "/second".into(),
-                        status: 302,
-                        headers: None,
-                    },
-                ],
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments {
+                    rules: vec![
+                        RedirectRule {
+                            from: RulePattern::Exact("/dup".into()),
+                            to: "/first".into(),
+                            status: 301,
+                            headers: None,
+                        },
+                        RedirectRule {
+                            from: RulePattern::Exact("/dup".into()),
+                            to: "/second".into(),
+                            status: 302,
+                            headers: None,
+                        },
+                    ],
+                },
+            )],
         )
         .unwrap();
 
@@ -3440,21 +3455,21 @@ mod redirect_rules {
         let mut state = State::default();
         commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: sample_rules(),
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments {
+                    rules: sample_rules(),
+                },
+            )],
         )
         .unwrap();
         // Sanity: rules fire pre-upgrade.
-        let pre =
-            certified_http_request(&state, RequestBuilder::get("/legacy/anything").build());
+        let pre = certified_http_request(&state, RequestBuilder::get("/legacy/anything").build());
         assert_eq!(pre.status_code, 308);
 
         let stable: StableState = state.into();
         let state: State = stable.into();
 
-        let post =
-            certified_http_request(&state, RequestBuilder::get("/legacy/anything").build());
+        let post = certified_http_request(&state, RequestBuilder::get("/legacy/anything").build());
         assert_eq!(post.status_code, 308);
         assert_eq!(lookup_header(&post, "Location"), Some("/home"));
     }
@@ -3465,18 +3480,19 @@ mod redirect_rules {
         let mut state = State::default();
         commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: vec![RedirectRule {
-                    from: RulePattern::Exact("/foo".into()),
-                    to: "/foo.html".into(),
-                    status: 200,
-                    headers: None,
-                }],
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments {
+                    rules: vec![RedirectRule {
+                        from: RulePattern::Exact("/foo".into()),
+                        to: "/foo.html".into(),
+                        status: 200,
+                        headers: None,
+                    }],
+                },
+            )],
         )
         .unwrap();
-        let inert =
-            state.http_request(RequestBuilder::get("/foo").build(), &[], unused_callback());
+        let inert = state.http_request(RequestBuilder::get("/foo").build(), &[], unused_callback());
         assert_eq!(inert.status_code, 404);
 
         // Add the asset → rule fires.
@@ -3504,11 +3520,8 @@ mod redirect_rules {
 
         // Delete the target → rule goes inert again.
         delete_asset_via_batch(&mut state, "/foo.html");
-        let after_delete = state.http_request(
-            RequestBuilder::get("/foo").build(),
-            &[],
-            unused_callback(),
-        );
+        let after_delete =
+            state.http_request(RequestBuilder::get("/foo").build(), &[], unused_callback());
         assert_eq!(after_delete.status_code, 404);
     }
 
@@ -3536,14 +3549,16 @@ mod redirect_rules {
         );
         commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: vec![RedirectRule {
-                    from: RulePattern::Exact("/foo".into()),
-                    to: "/bar.html".into(),
-                    status: 200,
-                    headers: None,
-                }],
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments {
+                    rules: vec![RedirectRule {
+                        from: RulePattern::Exact("/foo".into()),
+                        to: "/bar.html".into(),
+                        status: 200,
+                        headers: None,
+                    }],
+                },
+            )],
         )
         .unwrap();
 
@@ -3581,14 +3596,16 @@ mod redirect_rules {
         );
         commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: vec![RedirectRule {
-                    from: RulePattern::Subtree("/legacy/".into()),
-                    to: "/404.html".into(),
-                    status: 404,
-                    headers: None,
-                }],
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments {
+                    rules: vec![RedirectRule {
+                        from: RulePattern::Subtree("/legacy/".into()),
+                        to: "/404.html".into(),
+                        status: 404,
+                        headers: None,
+                    }],
+                },
+            )],
         )
         .unwrap();
 
@@ -3614,14 +3631,16 @@ mod redirect_rules {
         );
         commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: vec![RedirectRule {
-                    from: RulePattern::Exact("/retired".into()),
-                    to: "/410.html".into(),
-                    status: 410,
-                    headers: None,
-                }],
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments {
+                    rules: vec![RedirectRule {
+                        from: RulePattern::Exact("/retired".into()),
+                        to: "/410.html".into(),
+                        status: 410,
+                        headers: None,
+                    }],
+                },
+            )],
         )
         .unwrap();
 
@@ -3637,20 +3656,19 @@ mod redirect_rules {
         let mut state = State::default();
         let err = commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: vec![RedirectRule {
-                    from: RulePattern::Exact("/missing".into()),
-                    to: String::new(),
-                    status: 404,
-                    headers: None,
-                }],
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments {
+                    rules: vec![RedirectRule {
+                        from: RulePattern::Exact("/missing".into()),
+                        to: String::new(),
+                        status: 404,
+                        headers: None,
+                    }],
+                },
+            )],
         )
         .unwrap_err();
-        assert!(
-            err.contains("must be an absolute asset path"),
-            "got: {err}"
-        );
+        assert!(err.contains("must be an absolute asset path"), "got: {err}");
     }
 
     #[test]
@@ -3663,8 +3681,9 @@ mod redirect_rules {
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/index.html", "text/html")
-                .with_encoding("identity", vec![BODY])],
+            vec![
+                AssetBuilder::new("/index.html", "text/html").with_encoding("identity", vec![BODY])
+            ],
         );
 
         let response = certified_http_request(&state, RequestBuilder::get("/missing").build());
@@ -3679,19 +3698,24 @@ mod redirect_rules {
         let mut state = State::default();
         commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: vec![RedirectRule {
-                    from: RulePattern::Exact("/missing".into()),
-                    to: "/404.html".into(),
-                    status: 404,
-                    headers: None,
-                }],
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments {
+                    rules: vec![RedirectRule {
+                        from: RulePattern::Exact("/missing".into()),
+                        to: "/404.html".into(),
+                        status: 404,
+                        headers: None,
+                    }],
+                },
+            )],
         )
         .unwrap();
         // Target doesn't exist → rule inert → built-in fall-through 404.
-        let inert =
-            state.http_request(RequestBuilder::get("/missing").build(), &[], unused_callback());
+        let inert = state.http_request(
+            RequestBuilder::get("/missing").build(),
+            &[],
+            unused_callback(),
+        );
         assert_eq!(inert.status_code, 404);
         // The body is the built-in "not found", not the (missing) /404.html.
         assert_eq!(inert.body.as_ref(), b"not found");
@@ -3701,8 +3725,7 @@ mod redirect_rules {
         create_assets(
             &mut state,
             &mock_system_context(),
-            vec![AssetBuilder::new("/404.html", "text/html")
-                .with_encoding("identity", vec![PAGE])],
+            vec![AssetBuilder::new("/404.html", "text/html").with_encoding("identity", vec![PAGE])],
         );
         let response = certified_http_request(&state, RequestBuilder::get("/missing").build());
         assert_eq!(response.status_code, 404);
@@ -3718,19 +3741,20 @@ mod redirect_rules {
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/404.html", "text/html")
-                .with_encoding("identity", vec![V1])],
+            vec![AssetBuilder::new("/404.html", "text/html").with_encoding("identity", vec![V1])],
         );
         commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: vec![RedirectRule {
-                    from: RulePattern::Subtree("/old/".into()),
-                    to: "/404.html".into(),
-                    status: 404,
-                    headers: None,
-                }],
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments {
+                    rules: vec![RedirectRule {
+                        from: RulePattern::Subtree("/old/".into()),
+                        to: "/404.html".into(),
+                        status: 404,
+                        headers: None,
+                    }],
+                },
+            )],
         )
         .unwrap();
         let v1 = certified_http_request(&state, RequestBuilder::get("/old/x").build());
@@ -3741,8 +3765,7 @@ mod redirect_rules {
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/404.html", "text/html")
-                .with_encoding("identity", vec![V2])],
+            vec![AssetBuilder::new("/404.html", "text/html").with_encoding("identity", vec![V2])],
         );
         let v2 = certified_http_request(&state, RequestBuilder::get("/old/x").build());
         assert_eq!(v2.body.as_ref(), V2);
@@ -3754,20 +3777,19 @@ mod redirect_rules {
         let mut state = State::default();
         let err = commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: vec![RedirectRule {
-                    from: RulePattern::Exact("/missing".into()),
-                    to: "404.html".into(), // missing leading '/'
-                    status: 404,
-                    headers: None,
-                }],
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments {
+                    rules: vec![RedirectRule {
+                        from: RulePattern::Exact("/missing".into()),
+                        to: "404.html".into(), // missing leading '/'
+                        status: 404,
+                        headers: None,
+                    }],
+                },
+            )],
         )
         .unwrap_err();
-        assert!(
-            err.contains("must be an absolute asset path"),
-            "got: {err}"
-        );
+        assert!(err.contains("must be an absolute asset path"), "got: {err}");
     }
 
     #[test]
@@ -3788,14 +3810,16 @@ mod redirect_rules {
         );
         commit(
             &mut state,
-            vec![BatchOperation::SetRedirectRules(SetRedirectRulesArguments {
-                rules: vec![RedirectRule {
-                    from: RulePattern::Subtree("/".into()),
-                    to: "/index.html".into(),
-                    status: 200,
-                    headers: None,
-                }],
-            })],
+            vec![BatchOperation::SetRedirectRules(
+                SetRedirectRulesArguments {
+                    rules: vec![RedirectRule {
+                        from: RulePattern::Subtree("/".into()),
+                        to: "/index.html".into(),
+                        status: 200,
+                        headers: None,
+                    }],
+                },
+            )],
         )
         .unwrap();
 

--- a/ic-certified-assets/src/types.rs
+++ b/ic-certified-assets/src/types.rs
@@ -2,6 +2,7 @@
 //! endpoints.
 use crate::certification::AssetKey;
 use crate::rc_bytes::RcBytes;
+use crate::redirect::RedirectRule;
 use candid::{CandidType, Deserialize, Nat, Principal};
 use serde_bytes::ByteBuf;
 use std::collections::BTreeMap;
@@ -73,6 +74,12 @@ pub enum BatchOperation {
     DeleteAsset(DeleteAssetArguments),
     Clear(ClearArguments),
     SetAssetProperties(SetAssetPropertiesArguments),
+    SetRedirectRules(SetRedirectRulesArguments),
+}
+
+#[derive(Clone, Debug, CandidType, Deserialize)]
+pub struct SetRedirectRulesArguments {
+    pub rules: Vec<RedirectRule>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]


### PR DESCRIPTION
## Summary

Adds a first-class redirect/rewrite/error-page rule system to the asset canister, modeled on Netlify/Cloudflare `_redirects`. This is **Part 1** — the canister-side primitives. Part 2 (the plugin-side `_redirects` parser/uploader) ships separately.

## Design

A new `RedirectRule { from, to, status, headers }` type is added to the data model and candid surface, with a `BatchOperationKind::SetRedirectRules` variant (replace-all semantics) and a `get_redirect_rules` query. Rules are stored in `State.redirect_rules`, persisted across upgrades, and certified via a parallel `rule_certified_entries` cache that's rebuilt whenever rules — or assets a rule borrows from — change.

Three rule kinds are supported, all v2-certified:

- **3xx redirect** — response fully synthesized (`Location` from `to`, derived by the canister).
- **200 rewrite** — borrows the target asset's existing certified response verbatim; this is the mechanism that replaces the old built-in HTML-extension aliasing and SPA fallback.
- **4xx custom error page** — re-certifies the target asset's body with the override status.

`from` supports `Exact` and `Subtree` patterns; subtree rules use the v2 cert tree's `<*>` wildcard. Direct asset lookups shadow rules at the same path; if no asset or rule matches, the existing uncertified 404 fires.

The canister no longer synthesizes any implicit routing: `aliases_of` / `aliased_by` / `is_html_key` / `FALLBACK_FILE` / `WitnessResult::FallbackFound` are gone. Users express `.html` aliasing and SPA fallbacks as ordinary 200 rules. One coordinated holdover: `is_aliased` is still present on `StableAsset` / `Asset` / `SetAssetProperties` but ignored — kept so the existing plugin and stable-memory blobs continue to deserialize. It's removed in a follow-up canister PR once the plugin stops sending it.

Out of scope here: `:splat` / `:placeholder` substitution (tier 3, deferred to a future `http_request_update`-based design).

## Test plan

- [x] `cargo test -p ic-certified-assets` covers per-rule-kind certification, subtree wildcard behavior, asset-shadows-rule precedence, validation rejects, and upgrade round-trip of the rule set.
- [ ] End-to-end verification against the plugin lands with Part 2.