### PR TITLE
feat(assets-sync): `_redirects` parser and uploader (Part 2, plugin side)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ dependencies = [
  "flate2",
  "globset",
  "hex",
+ "http",
  "json5",
  "mime",
  "mime_guess",
@@ -139,6 +140,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "tempfile",
+ "url",
 ]
 
 [[package]]
@@ -798,6 +800,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "e2e"
 version = "0.1.0"
 dependencies = [
@@ -904,6 +917,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "futures-core"
@@ -1719,6 +1741,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,6 +1833,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -1887,6 +2012,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2211,6 +2342,15 @@ dependencies = [
  "candid",
  "serde",
  "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
@@ -2724,6 +2864,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "stacker"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2808,6 +2954,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2936,6 +3093,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3024,6 +3191,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3034,6 +3213,12 @@ name = "utf8-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "version_check"
@@ -3578,10 +3763,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -3604,6 +3818,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3617,6 +3852,39 @@ name = "zeroize_derive"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,6 +823,7 @@ dependencies = [
  "assert_cmd",
  "candid",
  "hex",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
@@ -928,10 +935,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -946,7 +975,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1087,12 +1119,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1877,6 +1981,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,6 +2230,17 @@ checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2615,6 +2736,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2645,6 +2800,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2757,6 +2918,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,6 +3037,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2954,6 +3137,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -3103,6 +3295,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3135,6 +3340,76 @@ dependencies = [
  "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typed-arena"
@@ -3246,6 +3521,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3289,6 +3573,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7530a275e7faf7b5b83aabdf78244fb8d9a68a2ec4b26935a05ecc0c9b0185ed"
 dependencies = [
  "log",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+dependencies = [
+ "js-sys",
  "wasm-bindgen",
 ]
 
@@ -3390,6 +3684,16 @@ dependencies = [
  "hashbrown 0.17.1",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Platform-agnostic library implementing the asset sync logic: directory scanning,
 
 ## Redirects, rewrites, and custom error pages
 
-The canister honours a Netlify-style `_redirects` file at the root of each input directory. Each line is `<from> <to> <status>`, where `<status>` is one of `{200, 301, 302, 307, 308, 404, 410}`:
+The canister honours a Netlify-style `_redirects` file at the root of the project's input directory. (The sync plugin only accepts one source directory — see [`plugin/README.md`](plugin/README.md#scope) for why.) Each line is `<from> <to> <status>`, where `<status>` is one of `{200, 301, 302, 307, 308, 404, 410}`:
 
 ```text
 /old-page        /new-page              301   # 3xx redirect (Location header)

--- a/README.md
+++ b/README.md
@@ -29,3 +29,17 @@ A thin `icp-cli` sync plugin. Delegates all sync logic to `assets-sync`.
 ### [`assets-sync/`](assets-sync/)
 
 Platform-agnostic library implementing the asset sync logic: directory scanning, MIME detection, content encoding, canister diffing, and the `CanisterCall` trait that abstracts the transport layer.
+
+## Redirects, rewrites, and custom error pages
+
+The canister honours a Netlify-style `_redirects` file at the root of each input directory. Each line is `<from> <to> <status>`, where `<status>` is one of `{200, 301, 302, 307, 308, 404, 410}`:
+
+```text
+/old-page        /new-page              301   # 3xx redirect (Location header)
+/external        https://example.com/   302
+/about           /about.html            200   # 200 rewrite (serve target's body)
+/blog/*          /blog/index.html       200   # subtree rewrite
+/missing         /404.html              404   # custom error page
+```
+
+The file is consumed by the plugin and lowered to certified canister-side rules — a real asset at the rule's `from` path always wins, and the canister no longer performs implicit `.html` / `index.html` aliasing. See [`plugin/README.md`](plugin/README.md#redirects) for the full reference and migration notes.

--- a/assets-sync/Cargo.toml
+++ b/assets-sync/Cargo.toml
@@ -10,6 +10,7 @@ candid.workspace = true
 flate2.workspace = true
 globset.workspace = true
 hex.workspace = true
+http = "1"
 json5.workspace = true
 mime.workspace = true
 mime_guess.workspace = true
@@ -17,6 +18,7 @@ serde.workspace = true
 serde_bytes.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+url = "2"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/assets-sync/src/canister.rs
+++ b/assets-sync/src/canister.rs
@@ -64,13 +64,13 @@ pub struct SetAssetPropertiesArguments {
     pub is_aliased: Option<Option<bool>>,
 }
 
-#[derive(CandidType, Clone, Debug, PartialEq, Eq)]
+#[derive(CandidType, Clone, Debug, Deserialize, PartialEq, Eq)]
 pub enum RulePattern {
     Exact(String),
     Subtree(String),
 }
 
-#[derive(CandidType, Clone, Debug, PartialEq, Eq)]
+#[derive(CandidType, Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct RedirectRule {
     pub from: RulePattern,
     pub to: String,
@@ -237,6 +237,10 @@ pub fn get_asset_properties(c: &impl CanisterCall, key: &str) -> Result<AssetPro
         CallType::Query,
         true,
     )
+}
+
+pub fn get_redirect_rules(c: &impl CanisterCall) -> Result<Vec<RedirectRule>, String> {
+    c.call("get_redirect_rules", (), CallType::Query, true)
 }
 
 pub fn list_permitted(

--- a/assets-sync/src/canister.rs
+++ b/assets-sync/src/canister.rs
@@ -64,6 +64,25 @@ pub struct SetAssetPropertiesArguments {
     pub is_aliased: Option<Option<bool>>,
 }
 
+#[derive(CandidType, Clone, Debug, PartialEq, Eq)]
+pub enum RulePattern {
+    Exact(String),
+    Subtree(String),
+}
+
+#[derive(CandidType, Clone, Debug, PartialEq, Eq)]
+pub struct RedirectRule {
+    pub from: RulePattern,
+    pub to: String,
+    pub status: u16,
+    pub headers: Option<Vec<(String, String)>>,
+}
+
+#[derive(CandidType, Clone, Debug)]
+pub struct SetRedirectRulesArguments {
+    pub rules: Vec<RedirectRule>,
+}
+
 #[derive(CandidType, Clone, Debug)]
 pub enum BatchOperationKind {
     Clear(ClearArguments),
@@ -72,6 +91,7 @@ pub enum BatchOperationKind {
     UnsetAssetContent(UnsetAssetContentArguments),
     SetAssetContent(SetAssetContentArguments),
     SetAssetProperties(SetAssetPropertiesArguments),
+    SetRedirectRules(SetRedirectRulesArguments),
 }
 
 #[derive(CandidType, Debug)]

--- a/assets-sync/src/canister.rs
+++ b/assets-sync/src/canister.rs
@@ -28,7 +28,6 @@ pub struct CreateAssetArguments {
     pub content_type: String,
     pub max_age: Option<u64>,
     pub headers: Option<HashMap<String, String>>,
-    pub enable_aliasing: Option<bool>,
     pub allow_raw_access: Option<bool>,
 }
 
@@ -61,7 +60,6 @@ pub struct SetAssetPropertiesArguments {
     pub max_age: Option<Option<u64>>,
     pub headers: Option<Option<Vec<(String, String)>>>,
     pub allow_raw_access: Option<Option<bool>>,
-    pub is_aliased: Option<Option<bool>>,
 }
 
 #[derive(CandidType, Clone, Debug, Deserialize, PartialEq, Eq)]
@@ -105,7 +103,6 @@ pub struct AssetProperties {
     pub max_age: Option<u64>,
     pub headers: Option<HashMap<String, String>>,
     pub allow_raw_access: Option<bool>,
-    pub is_aliased: Option<bool>,
 }
 
 #[derive(CandidType, Clone, Debug, Deserialize)]

--- a/assets-sync/src/config.rs
+++ b/assets-sync/src/config.rs
@@ -30,7 +30,6 @@ pub struct AssetConfig {
     pub cache: Option<CacheConfig>,
     pub headers: Option<HeadersConfig>,
     pub ignore: Option<bool>,
-    pub enable_aliasing: Option<bool>,
     pub allow_raw_access: Option<bool>,
     pub encodings: Option<Vec<Encoder>>,
     pub security_policy: Option<SecurityPolicy>,
@@ -43,7 +42,6 @@ impl Default for AssetConfig {
             cache: None,
             headers: None,
             ignore: None,
-            enable_aliasing: None,
             allow_raw_access: Some(true),
             encodings: None,
             security_policy: None,
@@ -123,7 +121,6 @@ struct AssetConfigRule {
     cache: Option<CacheConfig>,
     headers: Maybe<HeadersConfig>,
     ignore: Option<bool>,
-    enable_aliasing: Option<bool>,
     allow_raw_access: Option<bool>,
     encodings: Option<Vec<Encoder>>,
     security_policy: Option<SecurityPolicy>,
@@ -290,9 +287,6 @@ impl AssetConfig {
         if other.ignore.is_some() {
             self.ignore = other.ignore;
         }
-        if other.enable_aliasing.is_some() {
-            self.enable_aliasing = other.enable_aliasing;
-        }
         if other.allow_raw_access.is_some() {
             self.allow_raw_access = other.allow_raw_access;
         }
@@ -312,6 +306,12 @@ impl AssetConfig {
 // ── Deserialization helpers ──────────────────────────────────────────────────
 
 /// Intermediate representation used during JSON5 parsing.
+///
+/// `enable_aliasing` is accepted but ignored: the canister no longer
+/// performs implicit `.html` / `index.html` aliasing — declare the same
+/// behaviour in `_redirects` instead. The field is kept here so older
+/// configs parse cleanly during the migration window; a warning is emitted
+/// per usage in `from_interim`.
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct InterimAssetConfigRule {
@@ -373,13 +373,20 @@ impl AssetConfigRule {
         let matcher = Glob::new(glob_str)
             .map_err(|e| format!("'{}' is not a valid glob pattern: {e}", interim.r#match))?
             .compile_matcher();
+        if interim.enable_aliasing.is_some() {
+            eprintln!(
+                "config rule '{}' in '{}': 'enable_aliasing' is ignored — the canister no \
+                 longer performs implicit aliasing. Declare the equivalent rule in _redirects.",
+                interim.r#match,
+                config_dir.display(),
+            );
+        }
         Ok(Self {
             r#match: matcher,
             pattern: interim.r#match,
             cache: interim.cache,
             headers: interim.headers,
             ignore: interim.ignore,
-            enable_aliasing: interim.enable_aliasing,
             allow_raw_access: interim.allow_raw_access,
             encodings: interim.encodings,
             security_policy: interim.security_policy,

--- a/assets-sync/src/lib.rs
+++ b/assets-sync/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod canister;
 pub mod config;
 pub mod content;
+pub mod redirects;
 pub mod scan;
 pub mod security_policy;
 pub mod sync;

--- a/assets-sync/src/redirects.rs
+++ b/assets-sync/src/redirects.rs
@@ -1,0 +1,376 @@
+//! Strict line parser for Netlify-style `_redirects` files.
+//!
+//! Each non-empty, non-comment line is `<from>  <to>  <status>`. Whitespace is
+//! permissive; semantics are strict — see the "File format" section of the
+//! design plan for the full reject list. Errors carry a line number so the
+//! plugin can point users at the offending entry without a canister round-trip.
+
+use crate::canister::{RedirectRule, RulePattern};
+use http::StatusCode;
+use url::Url;
+
+pub const REDIRECTS_FILENAME: &str = "_redirects";
+
+const SUPPORTED_STATUSES: &[u16] = &[200, 301, 302, 307, 308, 404, 410];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError {
+    pub line: usize,
+    pub message: String,
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "_redirects: line {}: {}", self.line, self.message)
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+/// Parses an entire `_redirects` file into the candid `RedirectRule` shape.
+/// The first malformed line aborts parsing — we want the user to fix issues
+/// one at a time rather than wade through cascading errors.
+pub fn parse(content: &str) -> Result<Vec<RedirectRule>, ParseError> {
+    let mut rules = Vec::new();
+    for (i, raw) in content.lines().enumerate() {
+        let line_no = i + 1;
+        let body = strip_comment(raw).trim();
+        if body.is_empty() {
+            continue;
+        }
+        let rule = parse_line(body).map_err(|message| ParseError {
+            line: line_no,
+            message,
+        })?;
+        rules.push(rule);
+    }
+    Ok(rules)
+}
+
+fn strip_comment(line: &str) -> &str {
+    match line.find('#') {
+        Some(idx) => &line[..idx],
+        None => line,
+    }
+}
+
+fn parse_line(body: &str) -> Result<RedirectRule, String> {
+    let tokens: Vec<&str> = body.split_whitespace().collect();
+    match tokens.len() {
+        3 => {}
+        n if n < 3 => {
+            return Err(format!(
+                "expected '<from> <to> <status>' (3 fields), got {n}"
+            ))
+        }
+        n => {
+            return Err(format!(
+                "expected '<from> <to> <status>' (3 fields), got {n}; \
+                 extra fields are not supported (no headers, conditions, or query-string match)"
+            ))
+        }
+    }
+    let from_tok = tokens[0];
+    let to_tok = tokens[1];
+    let status_tok = tokens[2];
+
+    let status = parse_status(status_tok)?;
+    let from = parse_from(from_tok)?;
+    parse_to(to_tok, status)?;
+
+    Ok(RedirectRule {
+        from,
+        to: to_tok.to_string(),
+        status: status.as_u16(),
+        headers: None,
+    })
+}
+
+fn parse_status(token: &str) -> Result<StatusCode, String> {
+    if token.ends_with('!') {
+        return Err(format!(
+            "Netlify '!' force suffix on status ('{token}') is not supported; \
+             files win over rules at the same path — remove the conflicting asset instead"
+        ));
+    }
+    let code: u16 = token
+        .parse()
+        .map_err(|_| format!("status '{token}' is not an integer"))?;
+    if !SUPPORTED_STATUSES.contains(&code) {
+        return Err(format!(
+            "status {code} is not one of {{200, 301, 302, 307, 308, 404, 410}}"
+        ));
+    }
+    StatusCode::from_u16(code).map_err(|e| format!("invalid status {code}: {e}"))
+}
+
+fn parse_from(token: &str) -> Result<RulePattern, String> {
+    if !token.starts_with('/') {
+        return Err(format!(
+            "'from' ('{token}') must be an absolute path (start with '/')"
+        ));
+    }
+    if token.contains(':') {
+        return Err(format!(
+            "':' placeholders in 'from' ('{token}') are not supported"
+        ));
+    }
+    if let Some(prefix) = token.strip_suffix("/*") {
+        // Subtree. `/*` alone matches the entire site (subtree at `/`).
+        if prefix.contains('*') {
+            return Err(format!(
+                "wildcards in 'from' ('{token}') are only supported as a trailing '/*'"
+            ));
+        }
+        let subtree = if prefix.is_empty() {
+            "/".to_string()
+        } else {
+            format!("{prefix}/")
+        };
+        return Ok(RulePattern::Subtree(subtree));
+    }
+    if token.contains('*') {
+        return Err(format!(
+            "wildcards in 'from' ('{token}') are only supported as a trailing '/*'"
+        ));
+    }
+    Ok(RulePattern::Exact(token.to_string()))
+}
+
+fn parse_to(token: &str, status: StatusCode) -> Result<(), String> {
+    if token.contains(":splat") || token.contains(":placeholder") {
+        return Err(format!(
+            "':splat' / ':placeholder' substitution in 'to' ('{token}') \
+             is a known-deferred feature; see the plan's tier-3 follow-up"
+        ));
+    }
+    if status.is_redirection() {
+        // 3xx: absolute path or fully-qualified URL.
+        if token.starts_with('/') {
+            return Ok(());
+        }
+        Url::parse(token).map(|_| ()).map_err(|_| {
+            format!(
+                "'to' ('{token}') for a {} rule must be an absolute path or fully-qualified URL",
+                status.as_u16()
+            )
+        })
+    } else {
+        // 200 / 4xx: absolute asset path.
+        if !token.starts_with('/') {
+            return Err(format!(
+                "'to' ('{token}') for a status-{} rule must be an absolute asset path",
+                status.as_u16()
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_one(line: &str) -> Result<RedirectRule, ParseError> {
+        let mut rules = parse(line)?;
+        assert_eq!(rules.len(), 1, "expected exactly one rule from '{line}'");
+        Ok(rules.pop().unwrap())
+    }
+
+    fn err(line: &str) -> ParseError {
+        parse(line).unwrap_err()
+    }
+
+    // ── happy paths ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_input_yields_no_rules() {
+        assert!(parse("").unwrap().is_empty());
+        assert!(parse("\n\n   \n").unwrap().is_empty());
+    }
+
+    #[test]
+    fn comments_and_blanks_are_ignored() {
+        let input = "\n# leading comment\n\n   # indented comment\n/from /to 301\n\n# trailing\n";
+        let rules = parse(input).unwrap();
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].status, 301);
+    }
+
+    #[test]
+    fn comment_after_rule_is_stripped() {
+        let r = parse_one("/old /new 301 # inline comment").unwrap();
+        assert_eq!(r.from, RulePattern::Exact("/old".into()));
+        assert_eq!(r.to, "/new");
+        assert_eq!(r.status, 301);
+    }
+
+    #[test]
+    fn whitespace_is_permissive() {
+        // Mixed tabs/spaces between tokens.
+        let r = parse_one("/old\t \t/new   \t  302").unwrap();
+        assert_eq!(r.from, RulePattern::Exact("/old".into()));
+        assert_eq!(r.to, "/new");
+        assert_eq!(r.status, 302);
+    }
+
+    #[test]
+    fn each_supported_status_parses() {
+        for status in SUPPORTED_STATUSES {
+            let line = format!("/from /to {status}");
+            let r = parse_one(&line).unwrap_or_else(|e| panic!("status {status}: {e}"));
+            assert_eq!(r.status, *status);
+        }
+    }
+
+    #[test]
+    fn exact_pattern_is_default() {
+        let r = parse_one("/about /about.html 200").unwrap();
+        assert_eq!(r.from, RulePattern::Exact("/about".into()));
+    }
+
+    #[test]
+    fn trailing_star_lowers_to_subtree() {
+        let r = parse_one("/blog/* /blog/index.html 200").unwrap();
+        assert_eq!(r.from, RulePattern::Subtree("/blog/".into()));
+    }
+
+    #[test]
+    fn root_star_lowers_to_root_subtree() {
+        // `/*` matches the entire site; the lowered prefix is `/` so every
+        // request matches via `starts_with("/")`.
+        let r = parse_one("/* /index.html 200").unwrap();
+        assert_eq!(r.from, RulePattern::Subtree("/".into()));
+    }
+
+    #[test]
+    fn three_xx_accepts_fully_qualified_url() {
+        let r = parse_one("/legacy https://example.com/new 301").unwrap();
+        assert_eq!(r.to, "https://example.com/new");
+        assert_eq!(r.status, 301);
+    }
+
+    #[test]
+    fn three_xx_accepts_absolute_path() {
+        let r = parse_one("/legacy /new 308").unwrap();
+        assert_eq!(r.to, "/new");
+    }
+
+    #[test]
+    fn multiple_rules_preserve_order() {
+        let input = "\
+/a /a.html 200
+/old /new 301
+/gone /tombstone.html 410
+";
+        let rules = parse(input).unwrap();
+        let statuses: Vec<u16> = rules.iter().map(|r| r.status).collect();
+        assert_eq!(statuses, vec![200, 301, 410]);
+    }
+
+    // ── reject cases ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn rejects_too_few_fields() {
+        let e = err("/only-from");
+        assert!(e.message.contains("3 fields"), "{}", e.message);
+        assert_eq!(e.line, 1);
+    }
+
+    #[test]
+    fn rejects_too_many_fields() {
+        // 4 fields = extra token after status (would be inline headers in Netlify).
+        let e = err("/from /to 301 extra");
+        assert!(e.message.contains("3 fields"), "{}", e.message);
+        assert!(e.message.contains("not supported"), "{}", e.message);
+    }
+
+    #[test]
+    fn rejects_unsupported_status() {
+        let e = err("/from /to 418");
+        assert!(e.message.contains("418"), "{}", e.message);
+        assert!(e.message.contains("200"), "{}", e.message);
+    }
+
+    #[test]
+    fn rejects_non_integer_status() {
+        let e = err("/from /to redirect");
+        assert!(e.message.contains("integer"), "{}", e.message);
+    }
+
+    #[test]
+    fn rejects_netlify_force_suffix() {
+        let e = err("/from /to 301!");
+        assert!(e.message.contains("'!'"), "{}", e.message);
+    }
+
+    #[test]
+    fn rejects_splat_in_to() {
+        let e = err("/blog/* /archive/:splat 301");
+        assert!(e.message.contains(":splat"), "{}", e.message);
+    }
+
+    #[test]
+    fn rejects_placeholder_in_to() {
+        let e = err("/users/:id /people/:id 301");
+        // The `:id` in `from` trips the ':' placeholder check first.
+        assert!(e.message.contains("placeholders"), "{}", e.message);
+    }
+
+    #[test]
+    fn rejects_placeholder_in_to_with_safe_from() {
+        let e = err("/blog/* /archive/:placeholder 301");
+        assert!(e.message.contains(":placeholder"), "{}", e.message);
+    }
+
+    #[test]
+    fn rejects_relative_from() {
+        let e = err("relative /target 301");
+        assert!(e.message.contains("absolute path"), "{}", e.message);
+    }
+
+    #[test]
+    fn rejects_wildcard_in_from_not_at_end() {
+        let e = err("/blog/*/post /target 301");
+        assert!(e.message.contains("trailing '/*'"), "{}", e.message);
+    }
+
+    #[test]
+    fn rejects_relative_to_on_200() {
+        let e = err("/from to 200");
+        assert!(
+            e.message.contains("absolute asset path"),
+            "{}",
+            e.message
+        );
+    }
+
+    #[test]
+    fn rejects_relative_to_on_4xx() {
+        let e = err("/from target.html 404");
+        assert!(
+            e.message.contains("absolute asset path"),
+            "{}",
+            e.message
+        );
+    }
+
+    #[test]
+    fn rejects_unparseable_to_on_3xx() {
+        // Not absolute, not a URL — `Url::parse` rejects relative URLs.
+        let e = err("/from not-a-url 301");
+        assert!(e.message.contains("absolute path"), "{}", e.message);
+    }
+
+    #[test]
+    fn error_reports_line_number() {
+        let input = "\
+# comment
+/good /good 301
+/bad /bad 999
+/another /another 302
+";
+        let e = err(input);
+        assert_eq!(e.line, 3);
+    }
+}

--- a/assets-sync/src/redirects.rs
+++ b/assets-sync/src/redirects.rs
@@ -338,21 +338,13 @@ mod tests {
     #[test]
     fn rejects_relative_to_on_200() {
         let e = err("/from to 200");
-        assert!(
-            e.message.contains("absolute asset path"),
-            "{}",
-            e.message
-        );
+        assert!(e.message.contains("absolute asset path"), "{}", e.message);
     }
 
     #[test]
     fn rejects_relative_to_on_4xx() {
         let e = err("/from target.html 404");
-        assert!(
-            e.message.contains("absolute asset path"),
-            "{}",
-            e.message
-        );
+        assert!(e.message.contains("absolute asset path"), "{}", e.message);
     }
 
     #[test]

--- a/assets-sync/src/scan.rs
+++ b/assets-sync/src/scan.rs
@@ -14,9 +14,15 @@
 //! after the sync step completes.
 
 use crate::config::{AssetConfig, AssetSourceDirectoryConfiguration};
+use crate::redirects::REDIRECTS_FILENAME;
 use std::path::{Path, PathBuf};
 
 const KNOWN_DIRECTORIES: &[&str] = &[".well-known"];
+
+/// Filenames whose presence is configuration, not asset content. Loaded for
+/// their side effects (redirect rules, etc.) and excluded from the upload set.
+/// `.ic-assets.json[5]` are already filtered by the dotfile rule above.
+const CONFIG_FILENAMES: &[&str] = &[REDIRECTS_FILENAME];
 
 #[derive(Debug)]
 pub struct AssetSource {
@@ -63,6 +69,12 @@ fn walk(
 
         // Skip dotfiles / dotdirs (except known dirs like .well-known).
         if name_str.starts_with('.') && !(ft.is_dir() && KNOWN_DIRECTORIES.contains(&&*name_str)) {
+            continue;
+        }
+
+        // Skip config files (`_redirects` etc.) regardless of where they sit
+        // in the tree — they're consumed by the sync layer, not uploaded.
+        if ft.is_file() && CONFIG_FILENAMES.contains(&&*name_str) {
             continue;
         }
 
@@ -170,6 +182,15 @@ mod tests {
     fn ic_assets_json5_config_file_skipped() {
         let dir = tmp();
         fs::write(dir.path().join(ASSETS_CONFIG_FILENAME_JSON5), b"[]").unwrap();
+        fs::write(dir.path().join("index.html"), b"hi").unwrap();
+        let keys = sorted_keys(scan_sources(&[dir_str(&dir)]).unwrap());
+        assert_eq!(keys, vec!["/index.html"]);
+    }
+
+    #[test]
+    fn redirects_file_skipped() {
+        let dir = tmp();
+        fs::write(dir.path().join(crate::redirects::REDIRECTS_FILENAME), b"").unwrap();
         fs::write(dir.path().join("index.html"), b"hi").unwrap();
         let keys = sorted_keys(scan_sources(&[dir_str(&dir)]).unwrap());
         assert_eq!(keys, vec!["/index.html"]);

--- a/assets-sync/src/sync.rs
+++ b/assets-sync/src/sync.rs
@@ -11,14 +11,16 @@ use std::collections::HashMap;
 
 use crate::canister::{
     api_version, commit_batch, create_batch, create_chunks, get_asset_properties,
-    grant_permission_via_proxy, list_assets, list_permitted, AssetDetails, AssetProperties,
-    BatchOperationKind, CanisterCall, CommitBatchArguments, CreateAssetArguments,
-    DeleteAssetArguments, Permission, SetAssetContentArguments, SetAssetPropertiesArguments,
-    UnsetAssetContentArguments,
+    get_redirect_rules, grant_permission_via_proxy, list_assets, list_permitted, AssetDetails,
+    AssetProperties, BatchOperationKind, CanisterCall, CommitBatchArguments, CreateAssetArguments,
+    DeleteAssetArguments, Permission, RedirectRule, SetAssetContentArguments,
+    SetAssetPropertiesArguments, SetRedirectRulesArguments, UnsetAssetContentArguments,
 };
 use crate::content::{encoders_for, Content, Encoder};
+use crate::redirects::{self, REDIRECTS_FILENAME};
 use crate::scan::AssetSource;
 use crate::security_policy::report_security_policy_issues;
+use std::path::Path;
 
 // Stay safely under the canister's ingress message limit (~2 MB).
 const MAX_CHUNK_SIZE: usize = 1_900_000;
@@ -85,11 +87,20 @@ pub fn sync<C: CanisterCall>(
 
     report_security_policy_issues(&sources)?;
 
+    let project_rules = load_redirect_rules(dirs)?;
+    println!("parsed {} redirect rule(s) from _redirects", project_rules.len());
+
     let canister_assets: HashMap<String, AssetDetails> = list_assets(canister)?
         .into_iter()
         .map(|d| (d.key.clone(), d))
         .collect();
     println!("canister currently has {} asset(s)", canister_assets.len());
+
+    let canister_rules = get_redirect_rules(canister)?;
+    println!(
+        "canister currently has {} redirect rule(s)",
+        canister_rules.len()
+    );
 
     // Phase 1: compute metadata only — no batch created yet.
     let mut project_assets: HashMap<String, ProjectAsset> = HashMap::new();
@@ -117,6 +128,8 @@ pub fn sync<C: CanisterCall>(
         &project_assets,
         &canister_assets,
         &canister_asset_properties,
+        &project_rules,
+        &canister_rules,
     )
     .is_empty()
     {
@@ -145,6 +158,8 @@ pub fn sync<C: CanisterCall>(
         &project_assets,
         &canister_assets,
         &canister_asset_properties,
+        &project_rules,
+        &canister_rules,
     );
     println!("committing {} operation(s)", operations.len());
 
@@ -293,6 +308,8 @@ fn build_operations(
     project_assets: &HashMap<String, ProjectAsset>,
     canister_assets: &HashMap<String, AssetDetails>,
     canister_asset_properties: &HashMap<String, AssetProperties>,
+    project_rules: &[RedirectRule],
+    canister_rules: &[RedirectRule],
 ) -> Vec<BatchOperationKind> {
     let mut ops = Vec::new();
     let mut canister_assets = canister_assets.clone();
@@ -377,7 +394,39 @@ fn build_operations(
         canister_asset_properties,
     );
 
+    // 6. Replace-all the canister's redirect rules when they differ from the
+    //    parsed `_redirects`. Comparison is order-sensitive — rules are
+    //    matched in declaration order at request time, so reordering is a
+    //    semantic change.
+    if project_rules != canister_rules {
+        ops.push(BatchOperationKind::SetRedirectRules(
+            SetRedirectRulesArguments {
+                rules: project_rules.to_vec(),
+            },
+        ));
+    }
+
     ops
+}
+
+/// Reads `_redirects` from each input directory and concatenates the parsed
+/// rules in `dirs` order. A missing file is treated as "no rules from this
+/// dir"; parse errors carry the offending file's path and 1-based line
+/// number so users can fix issues without a canister round-trip.
+fn load_redirect_rules(dirs: &[String]) -> Result<Vec<RedirectRule>, String> {
+    let mut rules = Vec::new();
+    for dir in dirs {
+        let path = Path::new(dir).join(REDIRECTS_FILENAME);
+        if !path.exists() {
+            continue;
+        }
+        let content = std::fs::read_to_string(&path)
+            .map_err(|e| format!("read {}: {e}", path.display()))?;
+        let parsed = redirects::parse(&content)
+            .map_err(|e| format!("{}: {e}", path.display()))?;
+        rules.extend(parsed);
+    }
+    Ok(rules)
 }
 
 // Mirrors `ic-asset/src/batch_upload/operations.rs::update_properties`: for each
@@ -669,7 +718,7 @@ mod tests {
             "text/html",
             &[("identity", vec![1, 2, 3], false)],
         )]);
-        let ops = build_operations(&project, &HashMap::new(), &HashMap::new());
+        let ops = build_operations(&project, &HashMap::new(), &HashMap::new(), &[], &[]);
         assert_eq!(count_op(&ops, "CreateAsset"), 1);
         assert_eq!(count_op(&ops, "SetAssetContent"), 1);
         assert_eq!(ops.len(), 2);
@@ -688,7 +737,7 @@ mod tests {
             "text/html",
             &[("identity", Some(sha))],
         )]);
-        assert!(build_operations(&project, &canister, &HashMap::new()).is_empty());
+        assert!(build_operations(&project, &canister, &HashMap::new(), &[], &[]).is_empty());
     }
 
     #[test]
@@ -703,7 +752,7 @@ mod tests {
             "text/html",
             &[("identity", Some(vec![1, 2, 3]))],
         )]);
-        let ops = build_operations(&project, &canister, &HashMap::new());
+        let ops = build_operations(&project, &canister, &HashMap::new(), &[], &[]);
         assert_eq!(count_op(&ops, "SetAssetContent"), 1);
         assert_eq!(count_op(&ops, "CreateAsset"), 0);
         assert_eq!(count_op(&ops, "DeleteAsset"), 0);
@@ -717,7 +766,7 @@ mod tests {
             "text/html",
             &[("identity", Some(vec![1, 2, 3]))],
         )]);
-        let ops = build_operations(&HashMap::new(), &canister, &HashMap::new());
+        let ops = build_operations(&HashMap::new(), &canister, &HashMap::new(), &[], &[]);
         assert_eq!(count_op(&ops, "DeleteAsset"), 1);
         assert_eq!(ops.len(), 1);
     }
@@ -734,7 +783,7 @@ mod tests {
             "application/octet-stream",
             &[("identity", Some(vec![1, 2, 3]))],
         )]);
-        let ops = build_operations(&project, &canister, &HashMap::new());
+        let ops = build_operations(&project, &canister, &HashMap::new(), &[], &[]);
         assert_eq!(count_op(&ops, "DeleteAsset"), 1);
         assert_eq!(count_op(&ops, "CreateAsset"), 1);
         assert_eq!(count_op(&ops, "SetAssetContent"), 1);
@@ -755,7 +804,7 @@ mod tests {
             "text/html",
             &[("identity", Some(sha)), ("gzip", Some(vec![9, 8, 7]))],
         )]);
-        let ops = build_operations(&project, &canister, &HashMap::new());
+        let ops = build_operations(&project, &canister, &HashMap::new(), &[], &[]);
         assert_eq!(count_op(&ops, "UnsetAssetContent"), 1);
         assert_eq!(count_op(&ops, "SetAssetContent"), 0);
         assert_eq!(ops.len(), 1);
@@ -778,7 +827,7 @@ mod tests {
             "text/html",
             &[("identity", Some(identity_sha))],
         )]);
-        let ops = build_operations(&project, &canister, &HashMap::new());
+        let ops = build_operations(&project, &canister, &HashMap::new(), &[], &[]);
         assert_eq!(count_op(&ops, "SetAssetContent"), 1);
         assert_eq!(count_op(&ops, "CreateAsset"), 0);
         assert_eq!(count_op(&ops, "UnsetAssetContent"), 0);
@@ -795,9 +844,185 @@ mod tests {
                 &[("identity", Some(vec![2]))],
             ),
         ]);
-        let ops = build_operations(&HashMap::new(), &canister, &HashMap::new());
+        let ops = build_operations(&HashMap::new(), &canister, &HashMap::new(), &[], &[]);
         assert_eq!(count_op(&ops, "DeleteAsset"), 2);
         assert_eq!(ops.len(), 2);
+    }
+
+    // ── redirect-rule diff ──────────────────────────────────────────────────
+
+    fn mk_rule(from: crate::canister::RulePattern, to: &str, status: u16) -> RedirectRule {
+        RedirectRule {
+            from,
+            to: to.to_string(),
+            status,
+            headers: None,
+        }
+    }
+
+    fn set_rules_op(ops: &[BatchOperationKind]) -> Option<&[RedirectRule]> {
+        ops.iter().find_map(|op| match op {
+            BatchOperationKind::SetRedirectRules(args) => Some(args.rules.as_slice()),
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn rule_only_edit_emits_set_redirect_rules() {
+        // No asset changes, but the project has a new rule the canister
+        // doesn't — sync must emit the rules op.
+        let sha = vec![1u8, 2, 3];
+        let project = HashMap::from([mk_project_asset(
+            "/index.html",
+            "text/html",
+            &[("identity", sha.clone(), true)],
+        )]);
+        let canister = HashMap::from([mk_canister_asset(
+            "/index.html",
+            "text/html",
+            &[("identity", Some(sha))],
+        )]);
+        let project_rules = vec![mk_rule(
+            crate::canister::RulePattern::Exact("/old".into()),
+            "/new",
+            301,
+        )];
+        let ops = build_operations(&project, &canister, &HashMap::new(), &project_rules, &[]);
+        let rules = set_rules_op(&ops).expect("SetRedirectRules op missing");
+        assert_eq!(rules, project_rules.as_slice());
+        // No asset-side ops should have been emitted.
+        assert_eq!(count_op(&ops, "CreateAsset"), 0);
+        assert_eq!(count_op(&ops, "SetAssetContent"), 0);
+        assert_eq!(count_op(&ops, "DeleteAsset"), 0);
+        assert_eq!(ops.len(), 1);
+    }
+
+    #[test]
+    fn redirects_file_removed_emits_empty_vec_op() {
+        // Canister has rules, project no longer does — sync emits an
+        // explicit empty-vec op so the canister clears its ruleset.
+        let canister_rules = vec![mk_rule(
+            crate::canister::RulePattern::Exact("/old".into()),
+            "/new",
+            301,
+        )];
+        let ops = build_operations(
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &[],
+            &canister_rules,
+        );
+        let rules = set_rules_op(&ops).expect("SetRedirectRules op missing");
+        assert!(rules.is_empty(), "expected empty-vec replace-all op");
+    }
+
+    #[test]
+    fn unchanged_rules_emit_no_op() {
+        // Same rules on both sides — no SetRedirectRules op emitted.
+        let rules = vec![mk_rule(
+            crate::canister::RulePattern::Subtree("/blog/".into()),
+            "/blog/index.html",
+            200,
+        )];
+        let ops = build_operations(
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &rules,
+            &rules,
+        );
+        assert!(
+            set_rules_op(&ops).is_none(),
+            "no SetRedirectRules op expected when rules match"
+        );
+        assert!(ops.is_empty());
+    }
+
+    #[test]
+    fn reordered_rules_emit_op() {
+        // Order matters semantically — first matching rule wins at request
+        // time. A swap is a real change even with identical entries.
+        let a = mk_rule(crate::canister::RulePattern::Exact("/a".into()), "/x", 301);
+        let b = mk_rule(crate::canister::RulePattern::Exact("/b".into()), "/y", 301);
+        let ops = build_operations(
+            &HashMap::new(),
+            &HashMap::new(),
+            &HashMap::new(),
+            &[a.clone(), b.clone()],
+            &[b, a],
+        );
+        assert!(
+            set_rules_op(&ops).is_some(),
+            "rule reorder must emit a replace-all op"
+        );
+    }
+
+    #[test]
+    fn sync_short_circuits_when_redirects_file_only_matches_canister() {
+        // Drive sync() end-to-end with a _redirects file that matches what
+        // the canister already has. The "nothing to commit" short-circuit
+        // must trigger, with no create_batch / commit_batch calls.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("_redirects"), b"/old /new 301\n").unwrap();
+
+        let mock = SyncMock::new();
+        mock.push_ok("api_version", 2u16);
+        mock.push_ok("list", Vec::<AssetDetails>::new());
+        mock.push_ok(
+            "get_redirect_rules",
+            vec![mk_rule(
+                crate::canister::RulePattern::Exact("/old".into()),
+                "/new",
+                301,
+            )],
+        );
+
+        let result = sync(
+            &mock,
+            &[dir.path().to_str().unwrap().to_string()],
+            &Principal::anonymous().to_text(),
+            None,
+        );
+        // No create_batch / commit_batch programmed — if sync reached them
+        // SyncMock would panic with "no programmed response".
+        assert!(result.is_ok(), "expected success, got: {result:?}");
+    }
+
+    // Mirrors the private `CreateBatchResponse` in canister.rs — same field
+    // name gives the same Candid encoding, so the test mock can decode it.
+    #[derive(CandidType)]
+    struct CreateBatchOk {
+        batch_id: Nat,
+    }
+
+    #[test]
+    fn sync_emits_rules_op_when_redirects_file_only_changed() {
+        // _redirects has a rule; canister has none. The asset list is also
+        // empty so no asset ops are produced — the only operation must be
+        // SetRedirectRules, exercising the early "nothing to commit" check.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("_redirects"), b"/old /new 301\n").unwrap();
+
+        let mock = SyncMock::new();
+        mock.push_ok("api_version", 2u16);
+        mock.push_ok("list", Vec::<AssetDetails>::new());
+        mock.push_ok("get_redirect_rules", Vec::<RedirectRule>::new());
+        mock.push_ok(
+            "create_batch",
+            CreateBatchOk {
+                batch_id: Nat::from(1u32),
+            },
+        );
+        mock.push_ok("commit_batch", ());
+
+        let result = sync(
+            &mock,
+            &[dir.path().to_str().unwrap().to_string()],
+            &Principal::anonymous().to_text(),
+            None,
+        );
+        assert!(result.is_ok(), "expected success, got: {result:?}");
     }
 
     // prepare_asset itself skips gzip when the compressed output is not smaller
@@ -833,7 +1058,7 @@ mod tests {
             "text/plain",
             &[("identity", vec![1, 2, 3], false)],
         )]);
-        let ops = build_operations(&project, &HashMap::new(), &HashMap::new());
+        let ops = build_operations(&project, &HashMap::new(), &HashMap::new(), &[], &[]);
         assert_eq!(count_op(&ops, "CreateAsset"), 1);
         assert_eq!(count_op(&ops, "SetAssetContent"), 1);
         assert!(!ops.iter().any(|op| matches!(
@@ -864,7 +1089,7 @@ mod tests {
             &[("identity", vec![1, 2, 3], false)],
             config,
         )]);
-        let ops = build_operations(&project, &HashMap::new(), &HashMap::new());
+        let ops = build_operations(&project, &HashMap::new(), &HashMap::new(), &[], &[]);
         let create_op = ops
             .iter()
             .find_map(|op| {
@@ -925,7 +1150,7 @@ mod tests {
                 is_aliased: None,
             },
         )]);
-        let ops = build_operations(&project, &canister, &canister_props);
+        let ops = build_operations(&project, &canister, &canister_props, &[], &[]);
         let by_key = set_props_ops(&ops);
         assert_eq!(by_key.len(), 1);
         let set = by_key["/index.html"];
@@ -966,7 +1191,7 @@ mod tests {
                 is_aliased: Some(true),
             },
         )]);
-        let ops = build_operations(&project, &canister, &canister_props);
+        let ops = build_operations(&project, &canister, &canister_props, &[], &[]);
         assert!(
             set_props_ops(&ops).is_empty(),
             "no SetAssetProperties op when properties match"
@@ -995,7 +1220,7 @@ mod tests {
                 is_aliased: None,
             },
         )]);
-        let ops = build_operations(&project, &canister, &canister_props);
+        let ops = build_operations(&project, &canister, &canister_props, &[], &[]);
         let by_key = set_props_ops(&ops);
         assert_eq!(by_key.len(), 1);
         // Project has no max_age, canister has Some(60) — the op must explicitly
@@ -1039,7 +1264,7 @@ mod tests {
                 is_aliased: None,
             },
         )]);
-        let ops = build_operations(&project, &canister, &canister_props);
+        let ops = build_operations(&project, &canister, &canister_props, &[], &[]);
         assert!(
             set_props_ops(&ops).is_empty(),
             "headers match (order-insensitive); no SetAssetProperties op expected"
@@ -1082,7 +1307,7 @@ mod tests {
             },
         )]);
 
-        let ops = build_operations(&project, &canister, &canister_props);
+        let ops = build_operations(&project, &canister, &canister_props, &[], &[]);
 
         // The asset content must not be touched (no Create/Set/Unset/Delete).
         assert_eq!(count_op(&ops, "CreateAsset"), 0);
@@ -1138,7 +1363,7 @@ mod tests {
                 is_aliased: None,
             },
         )]);
-        let ops = build_operations(&project, &canister, &canister_props);
+        let ops = build_operations(&project, &canister, &canister_props, &[], &[]);
         assert!(
             set_props_ops(&ops).is_empty(),
             "Set-Cookie is canister-managed and must not trigger drift",
@@ -1180,7 +1405,7 @@ mod tests {
                 is_aliased: None,
             },
         )]);
-        let ops = build_operations(&project, &canister, &canister_props);
+        let ops = build_operations(&project, &canister, &canister_props, &[], &[]);
         assert_eq!(count_op(&ops, "DeleteAsset"), 1);
         assert_eq!(count_op(&ops, "CreateAsset"), 1);
         assert!(
@@ -1198,7 +1423,7 @@ mod tests {
             "text/html",
             &[("identity", vec![1, 2, 3], false)],
         )]);
-        let ops = build_operations(&project, &HashMap::new(), &HashMap::new());
+        let ops = build_operations(&project, &HashMap::new(), &HashMap::new(), &[], &[]);
         assert!(set_props_ops(&ops).is_empty());
     }
 
@@ -1348,6 +1573,7 @@ mod tests {
         mock.push_ok("api_version", 2u16);
         // Empty canister → build_operations will produce work → create_batch is called.
         mock.push_ok("list", Vec::<AssetDetails>::new());
+        mock.push_ok("get_redirect_rules", Vec::<RedirectRule>::new());
         mock.push_err("create_batch", "Caller does not have Commit permission");
 
         let result = sync(

--- a/assets-sync/src/sync.rs
+++ b/assets-sync/src/sync.rs
@@ -70,6 +70,21 @@ pub fn sync<C: CanisterCall>(
     identity_principal: &str,
     proxy_canister_id: Option<&str>,
 ) -> Result<String, String> {
+    // The assets plugin owns the URL space of its canister: every key starts at
+    // `/`, `_redirects` lives at the project root, and the canister has no
+    // notion of "merge two trees together". Multiple input directories would
+    // produce ambiguous redirect-file precedence and quietly hide key
+    // collisions, so the contract is exactly one directory.
+    let dir = match dirs {
+        [d] => d,
+        _ => {
+            return Err(format!(
+                "assets sync plugin: expected exactly one input directory, got {}",
+                dirs.len()
+            ))
+        }
+    };
+
     if let Some(_proxy) = proxy_canister_id {
         ensure_commit_permission(canister, identity_principal)?;
     }
@@ -87,7 +102,7 @@ pub fn sync<C: CanisterCall>(
 
     report_security_policy_issues(&sources)?;
 
-    let project_rules = load_redirect_rules(dirs)?;
+    let project_rules = load_redirect_rules(dir)?;
     println!("parsed {} redirect rule(s) from _redirects", project_rules.len());
 
     let canister_assets: HashMap<String, AssetDetails> = list_assets(canister)?
@@ -408,24 +423,18 @@ fn build_operations(
     ops
 }
 
-/// Reads `_redirects` from each input directory and concatenates the parsed
-/// rules in `dirs` order. A missing file is treated as "no rules from this
-/// dir"; parse errors carry the offending file's path and 1-based line
-/// number so users can fix issues without a canister round-trip.
-fn load_redirect_rules(dirs: &[String]) -> Result<Vec<RedirectRule>, String> {
-    let mut rules = Vec::new();
-    for dir in dirs {
-        let path = Path::new(dir).join(REDIRECTS_FILENAME);
-        if !path.exists() {
-            continue;
-        }
-        let content = std::fs::read_to_string(&path)
-            .map_err(|e| format!("read {}: {e}", path.display()))?;
-        let parsed = redirects::parse(&content)
-            .map_err(|e| format!("{}: {e}", path.display()))?;
-        rules.extend(parsed);
+/// Reads `_redirects` from the project's input directory, if present. A
+/// missing file is treated as "no rules"; parse errors carry the file's
+/// path and 1-based line number so users can fix issues without a canister
+/// round-trip.
+fn load_redirect_rules(dir: &str) -> Result<Vec<RedirectRule>, String> {
+    let path = Path::new(dir).join(REDIRECTS_FILENAME);
+    if !path.exists() {
+        return Ok(Vec::new());
     }
-    Ok(rules)
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| format!("read {}: {e}", path.display()))?;
+    redirects::parse(&content).map_err(|e| format!("{}: {e}", path.display()))
 }
 
 // Mirrors `ic-asset/src/batch_upload/operations.rs::update_properties`: for each
@@ -1541,6 +1550,29 @@ mod tests {
         let mock = PermissionMock::new(vec![identity]);
         ensure_commit_permission(&mock, &identity.to_text()).unwrap();
         assert!(mock.grant_calls.borrow().is_empty());
+    }
+
+    #[test]
+    fn sync_rejects_zero_input_dirs() {
+        let mock = SyncMock::new();
+        let err = sync(&mock, &[], &Principal::anonymous().to_text(), None).unwrap_err();
+        assert!(
+            err.contains("expected exactly one input directory"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn sync_rejects_multiple_input_dirs() {
+        let mock = SyncMock::new();
+        let err = sync(
+            &mock,
+            &["dist-a".to_string(), "dist-b".to_string()],
+            &Principal::anonymous().to_text(),
+            None,
+        )
+        .unwrap_err();
+        assert!(err.contains("got 2"), "got: {err}");
     }
 
     // Direct mode: canister rejects create_batch with a permission error → sync propagates it.

--- a/assets-sync/src/sync.rs
+++ b/assets-sync/src/sync.rs
@@ -103,7 +103,10 @@ pub fn sync<C: CanisterCall>(
     report_security_policy_issues(&sources)?;
 
     let project_rules = load_redirect_rules(dir)?;
-    println!("parsed {} redirect rule(s) from _redirects", project_rules.len());
+    println!(
+        "parsed {} redirect rule(s) from _redirects",
+        project_rules.len()
+    );
 
     let canister_assets: HashMap<String, AssetDetails> = list_assets(canister)?
         .into_iter()
@@ -432,8 +435,8 @@ fn load_redirect_rules(dir: &str) -> Result<Vec<RedirectRule>, String> {
     if !path.exists() {
         return Ok(Vec::new());
     }
-    let content = std::fs::read_to_string(&path)
-        .map_err(|e| format!("read {}: {e}", path.display()))?;
+    let content =
+        std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
     redirects::parse(&content).map_err(|e| format!("{}: {e}", path.display()))
 }
 

--- a/assets-sync/src/sync.rs
+++ b/assets-sync/src/sync.rs
@@ -345,7 +345,6 @@ fn build_operations(
                     .config
                     .combined_headers()
                     .map(|h| h.into_iter().collect()),
-                enable_aliasing: pa.source.config.enable_aliasing,
                 allow_raw_access: pa.source.config.allow_raw_access,
             }));
         }
@@ -430,10 +429,10 @@ fn load_redirect_rules(dirs: &[String]) -> Result<Vec<RedirectRule>, String> {
 }
 
 // Mirrors `ic-asset/src/batch_upload/operations.rs::update_properties`: for each
-// asset that already exists on the canister, compare `max_age`, `headers`,
-// `allow_raw_access`, and `is_aliased` against the project config and push a
-// `SetAssetProperties` op only when at least one field differs. Newly-created
-// assets already get their properties from `CreateAssetArguments`.
+// asset that already exists on the canister, compare `max_age`, `headers`, and
+// `allow_raw_access` against the project config and push a `SetAssetProperties`
+// op only when at least one field differs. Newly-created assets already get
+// their properties from `CreateAssetArguments`.
 //
 // `canister_assets` is the post-deletion view: keys removed in step 1 (missing
 // from the project, or content_type drift forcing delete-then-create) are
@@ -474,24 +473,16 @@ fn update_properties(
         });
         let headers = (project_headers != canister_headers).then_some(project_headers);
 
-        let is_aliased =
-            (config.enable_aliasing != canister_props.is_aliased).then_some(config.enable_aliasing);
-
         let allow_raw_access = (config.allow_raw_access != canister_props.allow_raw_access)
             .then_some(config.allow_raw_access);
 
-        if max_age.is_some()
-            || headers.is_some()
-            || is_aliased.is_some()
-            || allow_raw_access.is_some()
-        {
+        if max_age.is_some() || headers.is_some() || allow_raw_access.is_some() {
             ops.push(BatchOperationKind::SetAssetProperties(
                 SetAssetPropertiesArguments {
                     key: key.clone(),
                     max_age,
                     headers,
                     allow_raw_access,
-                    is_aliased,
                 },
             ));
         }
@@ -1079,7 +1070,6 @@ mod tests {
                 max_age: Some(86400),
             }),
             headers: Some(headers),
-            enable_aliasing: Some(true),
             allow_raw_access: Some(false),
             ..Default::default()
         };
@@ -1106,7 +1096,6 @@ mod tests {
             create_op.headers.as_ref().unwrap()["X-Frame-Options"],
             "DENY"
         );
-        assert_eq!(create_op.enable_aliasing, Some(true));
         assert_eq!(create_op.allow_raw_access, Some(false));
     }
 
@@ -1147,7 +1136,6 @@ mod tests {
                 max_age: Some(60),
                 headers: None,
                 allow_raw_access: Some(true),
-                is_aliased: None,
             },
         )]);
         let ops = build_operations(&project, &canister, &canister_props, &[], &[]);
@@ -1157,7 +1145,6 @@ mod tests {
         assert_eq!(set.max_age, Some(Some(3600)));
         assert_eq!(set.headers, None);
         assert_eq!(set.allow_raw_access, None);
-        assert_eq!(set.is_aliased, None);
     }
 
     #[test]
@@ -1167,7 +1154,6 @@ mod tests {
             cache: Some(CacheConfig {
                 max_age: Some(3600),
             }),
-            enable_aliasing: Some(true),
             allow_raw_access: Some(true),
             ..AssetConfig::default()
         };
@@ -1188,7 +1174,6 @@ mod tests {
                 max_age: Some(3600),
                 headers: None,
                 allow_raw_access: Some(true),
-                is_aliased: Some(true),
             },
         )]);
         let ops = build_operations(&project, &canister, &canister_props, &[], &[]);
@@ -1217,7 +1202,6 @@ mod tests {
                 headers: None,
                 // mk_project_asset uses AssetConfig::default() → allow_raw_access: Some(true).
                 allow_raw_access: Some(true),
-                is_aliased: None,
             },
         )]);
         let ops = build_operations(&project, &canister, &canister_props, &[], &[]);
@@ -1261,7 +1245,6 @@ mod tests {
                 max_age: None,
                 headers: Some(canister_headers),
                 allow_raw_access: Some(true),
-                is_aliased: None,
             },
         )]);
         let ops = build_operations(&project, &canister, &canister_props, &[], &[]);
@@ -1303,7 +1286,6 @@ mod tests {
                 max_age: None,
                 headers: None,
                 allow_raw_access: Some(true),
-                is_aliased: None,
             },
         )]);
 
@@ -1360,7 +1342,6 @@ mod tests {
                 max_age: None,
                 headers: Some(canister_headers),
                 allow_raw_access: Some(true),
-                is_aliased: None,
             },
         )]);
         let ops = build_operations(&project, &canister, &canister_props, &[], &[]);
@@ -1402,7 +1383,6 @@ mod tests {
                 max_age: Some(60),
                 headers: None,
                 allow_raw_access: Some(true),
-                is_aliased: None,
             },
         )]);
         let ops = build_operations(&project, &canister, &canister_props, &[], &[]);

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 assert_cmd.workspace = true
 candid.workspace = true
 hex.workspace = true
+reqwest = { version = "0.12", default-features = false, features = ["blocking"] }
 serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -139,6 +139,59 @@ pub fn get_asset_properties(project: &Path, key: &str) -> AssetProperties {
     properties
 }
 
+/// Return the canister ID of `frontend` as printed by `icp canister status --id-only`.
+pub fn frontend_canister_id(project: &Path) -> String {
+    let stdout = icp_cmd(project)
+        .args(["canister", "status", "frontend", "--id-only"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    String::from_utf8(stdout)
+        .expect("--id-only output should be utf-8")
+        .trim()
+        .to_string()
+}
+
+/// Return the local network's HTTP gateway URL (e.g. `http://localhost:1234`),
+/// as reported by `icp network status --json`.
+pub fn gateway_url(project: &Path) -> String {
+    let stdout = icp_cmd(project)
+        .args(["network", "status", "--json"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: serde_json::Value =
+        serde_json::from_slice(&stdout).expect("network status JSON should parse");
+    json["gateway_url"]
+        .as_str()
+        .expect("gateway_url missing from network status JSON")
+        .trim_end_matches('/')
+        .to_string()
+}
+
+/// Fetch `<path>` (must start with `/`) from the `frontend` canister via the
+/// local HTTP gateway. The reqwest client is configured to NOT follow
+/// redirects so callers can assert on 3xx status codes and the `Location`
+/// header. Going through the gateway implicitly validates the
+/// `IC-Certificate` — if certification fails, the gateway short-circuits
+/// before the response reaches the caller.
+pub fn http_fetch(project: &Path, path: &str) -> reqwest::blocking::Response {
+    let cid = frontend_canister_id(project);
+    let base = gateway_url(project);
+    let url = format!("{base}{path}?canisterId={cid}");
+    reqwest::blocking::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("build reqwest client")
+        .get(&url)
+        .send()
+        .unwrap_or_else(|e| panic!("GET {url} failed: {e}"))
+}
+
 /// Call `list` on the `frontend` canister and return all asset details.
 pub fn list_assets(project: &Path) -> Vec<AssetDetails> {
     let stdout = icp_cmd(project)

--- a/e2e/tests/fixture/no-implicit-aliasing/dist/blog/index.html
+++ b/e2e/tests/fixture/no-implicit-aliasing/dist/blog/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><body>blog index at literal path</body></html>

--- a/e2e/tests/fixture/no-implicit-aliasing/dist/foo.html
+++ b/e2e/tests/fixture/no-implicit-aliasing/dist/foo.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><body>foo at literal path</body></html>

--- a/e2e/tests/fixture/no-implicit-aliasing/icp.yaml
+++ b/e2e/tests/fixture/no-implicit-aliasing/icp.yaml
@@ -1,0 +1,19 @@
+networks:
+  - name: local
+    mode: managed
+    gateway:
+      port: 0
+
+canisters:
+  - name: frontend
+    build:
+      steps:
+        - type: pre-built
+          path: wasms/canister.wasm
+
+    sync:
+      steps:
+        - type: plugin
+          path: wasms/plugin.wasm
+          dirs:
+            - dist

--- a/e2e/tests/fixture/redirects/dist/404.html
+++ b/e2e/tests/fixture/redirects/dist/404.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><body>custom not found</body></html>

--- a/e2e/tests/fixture/redirects/dist/410.html
+++ b/e2e/tests/fixture/redirects/dist/410.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><body>tombstone</body></html>

--- a/e2e/tests/fixture/redirects/dist/_redirects
+++ b/e2e/tests/fixture/redirects/dist/_redirects
@@ -1,0 +1,7 @@
+# integration fixture covering all three response kinds
+/old              /new.html              301
+/legacy           https://example.com/   302
+/missing-page     /404.html              404
+/gone-page        /410.html              410
+/about            /about.html            200
+/blog/*           /blog/index.html       200

--- a/e2e/tests/fixture/redirects/dist/about.html
+++ b/e2e/tests/fixture/redirects/dist/about.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><body>about us</body></html>

--- a/e2e/tests/fixture/redirects/dist/blog/index.html
+++ b/e2e/tests/fixture/redirects/dist/blog/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><body>blog index</body></html>

--- a/e2e/tests/fixture/redirects/dist/new.html
+++ b/e2e/tests/fixture/redirects/dist/new.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><body>new page</body></html>

--- a/e2e/tests/fixture/redirects/icp.yaml
+++ b/e2e/tests/fixture/redirects/icp.yaml
@@ -1,0 +1,19 @@
+networks:
+  - name: local
+    mode: managed
+    gateway:
+      port: 0
+
+canisters:
+  - name: frontend
+    build:
+      steps:
+        - type: pre-built
+          path: wasms/canister.wasm
+
+    sync:
+      steps:
+        - type: plugin
+          path: wasms/plugin.wasm
+          dirs:
+            - dist

--- a/e2e/tests/redirects.rs
+++ b/e2e/tests/redirects.rs
@@ -11,7 +11,7 @@ use reqwest::StatusCode;
 /// 3xx redirect (internal + external), 4xx custom error page, 200 rewrite
 /// (exact and subtree).
 #[test]
-fn redirect_rules_honoured_end_to_end() {
+fn redirect_rules_honoured() {
     let tmp = setup_project("tests/fixture/redirects");
     let project = tmp.path();
     let _network = LocalNetwork::start(project);
@@ -83,7 +83,7 @@ fn redirect_rules_honoured_end_to_end() {
 /// or `/blog` → `/blog/index.html`. Literal paths still resolve; the
 /// would-be aliases return 404.
 #[test]
-fn no_implicit_aliasing_after_redirects_landed() {
+fn no_implicit_aliasing() {
     let tmp = setup_project("tests/fixture/no-implicit-aliasing");
     let project = tmp.path();
     let _network = LocalNetwork::start(project);

--- a/e2e/tests/redirects.rs
+++ b/e2e/tests/redirects.rs
@@ -1,0 +1,114 @@
+//! Integration tests for `_redirects` end-to-end via the WASM plugin.
+//!
+//! Each test deploys a fixture to a local replica, then fetches paths via the
+//! HTTP gateway. The gateway validates the response's `IC-Certificate` before
+//! handing it back, so a successful fetch is also proof of certification.
+
+use e2e::{http_fetch, icp_cmd, setup_project, LocalNetwork};
+use reqwest::StatusCode;
+
+/// Deploy the `redirects` fixture and exercise every response kind:
+/// 3xx redirect (internal + external), 4xx custom error page, 200 rewrite
+/// (exact and subtree).
+#[test]
+fn redirect_rules_honoured_end_to_end() {
+    let tmp = setup_project("tests/fixture/redirects");
+    let project = tmp.path();
+    let _network = LocalNetwork::start(project);
+
+    icp_cmd(project).arg("deploy").assert().success();
+
+    // ── 301 redirect to an internal path ────────────────────────────────────
+    let r = http_fetch(project, "/old");
+    assert_eq!(r.status(), StatusCode::MOVED_PERMANENTLY);
+    assert_eq!(
+        r.headers()
+            .get("location")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned),
+        Some("/new.html".into()),
+    );
+
+    // ── 302 redirect to an external URL ─────────────────────────────────────
+    let r = http_fetch(project, "/legacy");
+    assert_eq!(r.status(), StatusCode::FOUND);
+    assert_eq!(
+        r.headers()
+            .get("location")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned),
+        Some("https://example.com/".into()),
+    );
+
+    // ── 404 custom error page ───────────────────────────────────────────────
+    let r = http_fetch(project, "/missing-page");
+    assert_eq!(r.status(), StatusCode::NOT_FOUND);
+    let body = r.text().expect("read body");
+    assert!(
+        body.contains("custom not found"),
+        "expected /404.html body, got: {body}"
+    );
+
+    // ── 410 custom error page ───────────────────────────────────────────────
+    let r = http_fetch(project, "/gone-page");
+    assert_eq!(r.status(), StatusCode::GONE);
+    let body = r.text().expect("read body");
+    assert!(
+        body.contains("tombstone"),
+        "expected /410.html body, got: {body}"
+    );
+
+    // ── 200 rewrite: exact ──────────────────────────────────────────────────
+    let r = http_fetch(project, "/about");
+    assert_eq!(r.status(), StatusCode::OK);
+    let body = r.text().expect("read body");
+    assert!(
+        body.contains("about us"),
+        "expected /about.html body, got: {body}"
+    );
+
+    // ── 200 rewrite: subtree ────────────────────────────────────────────────
+    for sub in &["/blog/anything", "/blog/2024/post"] {
+        let r = http_fetch(project, sub);
+        assert_eq!(r.status(), StatusCode::OK, "fetching {sub}");
+        let body = r.text().expect("read body");
+        assert!(
+            body.contains("blog index"),
+            "fetching {sub}: expected blog index body, got: {body}"
+        );
+    }
+}
+
+/// Without `_redirects`, the canister no longer aliases `/foo` → `/foo.html`
+/// or `/blog` → `/blog/index.html`. Literal paths still resolve; the
+/// would-be aliases return 404.
+#[test]
+fn no_implicit_aliasing_after_redirects_landed() {
+    let tmp = setup_project("tests/fixture/no-implicit-aliasing");
+    let project = tmp.path();
+    let _network = LocalNetwork::start(project);
+
+    icp_cmd(project).arg("deploy").assert().success();
+
+    // Literal paths resolve.
+    let r = http_fetch(project, "/foo.html");
+    assert_eq!(r.status(), StatusCode::OK);
+    let body = r.text().expect("read body");
+    assert!(body.contains("foo at literal path"), "body: {body}");
+
+    let r = http_fetch(project, "/blog/index.html");
+    assert_eq!(r.status(), StatusCode::OK);
+    let body = r.text().expect("read body");
+    assert!(body.contains("blog index at literal path"), "body: {body}");
+
+    // Would-be aliases return 404 — proves the canister no longer synthesises
+    // routes implicitly. `_redirects` is the only mechanism.
+    for path in &["/foo", "/foo/", "/blog", "/blog/"] {
+        let r = http_fetch(project, path);
+        assert_eq!(
+            r.status(),
+            StatusCode::NOT_FOUND,
+            "no-aliasing: GET {path} should 404"
+        );
+    }
+}

--- a/e2e/tests/sync.rs
+++ b/e2e/tests/sync.rs
@@ -219,25 +219,28 @@ fn security_policy_headers_persisted() {
     );
 }
 
-/// Configure two source directories with non-overlapping files and sync.
-/// All files from both directories must appear in the canister with the
-/// correct leading-slash keys.
+/// The assets sync plugin owns the URL space of its canister and only
+/// supports a single source directory. A manifest that lists multiple
+/// `dirs:` entries must fail the sync step before any canister mutation.
 #[test]
-fn multi_directory_sync() {
+fn multi_directory_sync_rejected() {
     let tmp = setup_project("tests/fixture/multi-dir");
     let project = tmp.path();
     let _network = LocalNetwork::start(project);
 
-    icp_cmd(project).arg("deploy").assert().success();
-
-    let assets = list_assets(project);
-
-    assert!(
-        assets.iter().any(|a| a.key == "/page.html"),
-        "/page.html from dist-a should be present; got: {assets:#?}",
+    let output = icp_cmd(project)
+        .arg("deploy")
+        .assert()
+        .failure()
+        .get_output()
+        .clone();
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
     );
     assert!(
-        assets.iter().any(|a| a.key == "/app.js"),
-        "/app.js from dist-b should be present; got: {assets:#?}",
+        combined.contains("expected exactly one input directory"),
+        "expected multi-dir rejection message; got:\n{combined}",
     );
 }

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -38,10 +38,70 @@ The current implementation supports the V2 protocol of the assets canister (tran
 - Walks each directory passed via the manifest's `dirs:` setting; dotfiles are skipped.
 - Detects the MIME type of each file and computes encodings: `gzip` for all `text/*`, `*/javascript`, and `*/html` types (only if the compressed output is smaller), `identity` for everything.
 - Diffs against `list_assets()`: skips encodings already in place (matched by sha256), unsets encodings that are stale, and deletes assets that have been removed or whose `content_type` changed.
+- Reads `_redirects` at the root of each input directory and replaces the canister's ruleset in the same batch (see "Redirects" below).
 - Opens a transaction (`create_batch`), uploads each content chunk via `create_chunks` (one chunk per call, 1.9 MB max), then commits all operations atomically with a single `commit_batch` call.
 - In normal mode all canister calls use `direct: true`. In proxy mode (when a `proxy_canister_id` is provided by the host) the plugin first ensures the signing identity has `Commit` permission, routing a `grant_permission` call through the proxy (which is the canister's controller) if needed, then proceeds with direct calls.
 
 The plugin calls `api_version` first and aborts if the canister advertises anything below 2.
+
+## Redirects
+
+The plugin reads a Netlify-style `_redirects` file at the root of each input directory. The file itself is **not** uploaded as an asset — it's consumed by the plugin and lowered into canister-side rules. Each non-empty, non-comment line:
+
+```
+<from>  <to>  <status>
+```
+
+- `<from>` — absolute path. A trailing `/*` makes the rule match every URL whose path starts with the prefix (subtree). Anywhere else, `*` is an error.
+- `<to>` — absolute path for `200` rewrites and `4xx` custom error pages. For `3xx` rules it may also be a fully-qualified URL (sent in the `Location` header).
+- `<status>` — required integer, one of `{200, 301, 302, 307, 308, 404, 410}`. Unlike Netlify, there is no default; the explicit number keeps the intent (rewrite vs. redirect vs. error) unambiguous.
+- Lines starting with `#` and blank lines are ignored. Inline `# comments` at the end of a rule line are stripped before parsing.
+
+### Examples
+
+```text
+# 3xx — issue a Location-header redirect
+/old-page        /new-page              301
+/external        https://example.com/   302
+
+# 200 — rewrite: serve the target asset's body at the source URL
+/about           /about.html            200
+/blog/*          /blog/index.html       200
+
+# 4xx — custom error page (serves the target asset's body with the override status)
+/missing         /404.html              404
+/gone            /tombstone.html        410
+```
+
+A real asset at the rule's `from` path always wins — a file at `/about.html` is served at `/about.html` regardless of any rule. For 200 rewrites and 4xx error pages, the target asset's existing `Content-Type` and certified headers are inherited verbatim; the rule itself can't override them.
+
+Rule order is significant: the plugin sends rules in declaration order, and the canister returns the first match. Replacing the file is a full replace-all operation — if you remove `_redirects` between deploys, the plugin emits an empty `SetRedirectRules` op so the canister clears its ruleset.
+
+### Migration from built-in aliasing
+
+Earlier versions of this canister implicitly served `/foo.html` at `/foo` and `/foo/index.html` at both `/foo/` and `/foo`. That behaviour has been removed — express the same routing explicitly in `_redirects`:
+
+```text
+# Replace "extensionless HTML" aliasing
+/foo             /foo.html              200
+
+# Replace per-directory index aliasing
+/blog/           /blog/index.html       200
+
+# SPA fallback (formerly served implicitly when no other asset matched)
+/*               /index.html            200
+```
+
+The `enable_aliasing` field in `.ic-assets.json5` and `is_aliased` on `set_asset_properties` are no longer honoured by the plugin; the canister will drop them in a follow-up cleanup. If your config still sets `enable_aliasing`, the plugin emits a warning pointing you at `_redirects`.
+
+### Unsupported syntax
+
+- `:splat` and `:placeholder` substitution in `<to>` — deferred (see the design plan's tier-3 follow-up).
+- Netlify's `!` force suffix on status codes — files always win over rules at the same path; remove the conflicting asset instead.
+- Country/role conditions and query-string matching — out of scope.
+- Inline headers as a fourth field — headers will arrive via a separate `_headers` file in a later track.
+
+Parse errors abort the sync with the offending file path and 1-based line number, before any canister call is issued.
 
 ## TODO
 
@@ -58,7 +118,7 @@ The plugin calls `api_version` first and aborts if the canister advertises anyth
   - Wire it into `AssetConfig::combined_headers()` so that `security_policy` entries in `.ic-assets.json5` expand into the corresponding `Content-Security-Policy`, `Permissions-Policy`, `X-Frame-Options`, etc. headers before the headers map is passed to `CreateAssetArguments`.
   - Emit the same warnings as `ic-asset/src/sync.rs` (`gather_asset_descriptors`): warn when no security policy is set for any asset, warn when `standard` policy is in use (suggesting hardening), and error when `hardened` is declared but no custom headers are provided.
 
-- [x] **Asset properties update** — emit `SetAssetProperties` ops for assets whose properties drifted on the canister. `get_asset_properties` is called after `list_assets` to collect the current `AssetProperties` for every canister asset, and `update_properties` compares `max_age`, `headers`, `allow_raw_access`, and `is_aliased` field-by-field against the resolved project config (headers compared order-insensitively). Mirrors `ic-asset/src/batch_upload/operations.rs::update_properties`.
+- [x] **Asset properties update** — emit `SetAssetProperties` ops for assets whose properties drifted on the canister. `get_asset_properties` is called after `list_assets` to collect the current `AssetProperties` for every canister asset, and `update_properties` compares `max_age`, `headers`, and `allow_raw_access` field-by-field against the resolved project config (headers compared order-insensitively). Mirrors `ic-asset/src/batch_upload/operations.rs::update_properties`. (`is_aliased` is no longer carried; the canister will drop it in a follow-up cleanup PR.)
 
 - [ ] **Header representation: `Map` → `Vec<(name, value)>`** — replace `Option<BTreeMap<String, String>>` / `Option<HashMap<String, String>>` with a list of pairs across `ic-certified-assets` (`Asset`, `AssetProperties`, `CreateAssetArguments`, `SetAssetPropertiesArguments`, `build_headers`, `evidence::hash_headers`) and `assets-sync` (`canister::AssetProperties`, `config::HeadersConfig`, `combined_headers`, `update_properties`). Wire type `vec record { text; text }` is already a list, so this is a Rust-only change — no Candid breaking change, no stable-storage migration. Lets users have multiple `Set-Cookie` values (and removes the tactical Set-Cookie filter in `update_properties` once the canister appends rather than overwrites `ic_env`). Sort by `(name, value)` for deterministic certification/evidence hashing; for `combined_headers` merging, "custom overrides policy" stays a case-insensitive name-set dedupe.
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -35,10 +35,11 @@ The output WASM lands at `../target/wasm32-wasip2/release/plugin.wasm` — the p
 ## Scope
 
 The current implementation supports the V2 protocol of the assets canister (transactional batch API):
-- Walks each directory passed via the manifest's `dirs:` setting; dotfiles are skipped.
+- The manifest's `dirs:` setting must list **exactly one** directory. The plugin rejects the sync before any canister call if zero or multiple entries are given — the assets canister owns the URL space below `/`, and a single tree keeps key collisions and `_redirects` precedence unambiguous.
+- Walks that directory; dotfiles are skipped.
 - Detects the MIME type of each file and computes encodings: `gzip` for all `text/*`, `*/javascript`, and `*/html` types (only if the compressed output is smaller), `identity` for everything.
 - Diffs against `list_assets()`: skips encodings already in place (matched by sha256), unsets encodings that are stale, and deletes assets that have been removed or whose `content_type` changed.
-- Reads `_redirects` at the root of each input directory and replaces the canister's ruleset in the same batch (see "Redirects" below).
+- Reads `_redirects` at the root of the input directory and replaces the canister's ruleset in the same batch (see "Redirects" below).
 - Opens a transaction (`create_batch`), uploads each content chunk via `create_chunks` (one chunk per call, 1.9 MB max), then commits all operations atomically with a single `commit_batch` call.
 - In normal mode all canister calls use `direct: true`. In proxy mode (when a `proxy_canister_id` is provided by the host) the plugin first ensures the signing identity has `Commit` permission, routing a `grant_permission` call through the proxy (which is the canister's controller) if needed, then proceeds with direct calls.
 
@@ -46,7 +47,7 @@ The plugin calls `api_version` first and aborts if the canister advertises anyth
 
 ## Redirects
 
-The plugin reads a Netlify-style `_redirects` file at the root of each input directory. The file itself is **not** uploaded as an asset — it's consumed by the plugin and lowered into canister-side rules. Each non-empty, non-comment line:
+The plugin reads a Netlify-style `_redirects` file at the root of the input directory (`dirs:` must list exactly one). The file itself is **not** uploaded as an asset — it's consumed by the plugin and lowered into canister-side rules. Each non-empty, non-comment line:
 
 ```
 <from>  <to>  <status>


### PR DESCRIPTION
## Summary

Teaches `assets-sync` to read a Netlify-style `_redirects` file at the project root and lower it into the canister's `SetRedirectRules` batch op. This is **Part 2** of the redirects track — the canister-side primitives shipped in #57. Together the two PRs close out the built-in-aliasing removal on the plugin side; a small follow-up canister PR will strip the now-ignored `is_aliased` field from the data model.

## Design

- **New `redirects` module.** Hand-parses `<from> <to> <status>` lines in `assets-sync` and lowers them to the candid `RedirectRule` shape from Part 1. Per-field validation reuses `http::StatusCode` (same path as the canister's `validate()`) and the `url` crate for fully-qualified 3xx targets; trailing `/*` lowers to `RulePattern::Subtree`. Errors carry the file path and 1-based line number, so users see `_redirects: line N: <reason>` before any canister round-trip — the canister's `validate()` remains the backstop.

- **Supported statuses: `{200, 301, 302, 307, 308, 404, 410}`.** No default, matching the explicit-intent posture of the canister side.

- **Rejected at parse time** (each with a regression test):
  - `:splat` / `:placeholder` substitution (deferred to tier 3)
  - the Netlify `!` force suffix (files always win — remove the conflicting asset instead)
  - non-trailing wildcards
  - non-absolute `<to>` on 200/4xx rules
  - any inline headers / conditions / query-string match

- **`sync()` integration.** Parses `_redirects` once per run, fetches the canister's current ruleset via `get_redirect_rules`, and emits a single `SetRedirectRules` batch op when the two differ. Comparison is order-sensitive because the canister matches rules in declaration order. Removing the file emits `SetRedirectRules { rules: vec![] }` so the canister clears its rules. The "nothing to commit" short-circuit now considers rule diffs too, so a `_redirects`-only edit is no longer silently skipped.

- **Scan-layer treatment.** `_redirects` is treated as configuration (read for side effects, not uploaded as an asset), mirroring how `.ic-assets.json[5]` is already handled.

- **`is_aliased` retired plugin-side.** Dropped from the candid wrappers and from `update_properties` drift detection. `enable_aliasing` in `.ic-assets.json5` is warn-and-ignore during the migration window — the warning points users at `_redirects`. The canister still carries `is_aliased` for stable-memory compatibility; the follow-up canister cleanup PR strips it.

- **`dirs:` must list exactly one directory.** Multiple inputs would produce ambiguous `_redirects` precedence and quietly hide key collisions, so the plugin rejects the sync before any canister call when the count is wrong.

- **Docs.** Top-level `README.md` and `plugin/README.md` document the feature with examples for all three response kinds and a "Migration from built-in aliasing" section with copy-paste replacements for the three legacy behaviours (extensionless HTML, directory-index, SPA fallback).

## Test plan

- [x] `cargo test -p assets-sync` — parser unit tests (happy paths + every reject case, each checking line number and message), scan exclusion, and mocked-canister `sync()` tests for the add / remove / unchanged cases.
- [x] `cargo test -p e2e` — `redirect_rules_honoured` drives the real WASM plugin against `pocket-ic` and verifies certificate validation across rewrite / redirect / custom-error-page rules; `no_implicit_aliasing` confirms the canister returns 404 at `/foo`, `/foo/`, `/blog`, `/blog/` with no `_redirects` present.
