### PR TITLE
fix(ic-certified-assets): prune empty subtrees in NestedTree::delete

### DIFF
--- a/e2e/build.rs
+++ b/e2e/build.rs
@@ -2,6 +2,7 @@ use std::{env, path::Path, path::PathBuf, process::Command};
 
 fn main() {
     println!("cargo:rerun-if-changed=../canister/src");
+    println!("cargo:rerun-if-changed=../ic-certified-assets/src");
     println!("cargo:rerun-if-changed=../plugin/src");
     println!("cargo:rerun-if-changed=../assets-sync/src");
 

--- a/e2e/tests/redirects.rs
+++ b/e2e/tests/redirects.rs
@@ -123,6 +123,66 @@ fn html_handling_auto_synthesis() {
     expect_200(project, "/index.html", "root index body");
 }
 
+/// When a rule is removed from `_redirects` between deploys, the canister
+/// must not leave an orphaned cert-tree path behind. The HTTP gateway's
+/// verifier rejects wildcard `<*>` witnesses if a "potential exact
+/// expression path" is visible at the requested URL, so a dangling Exact
+/// entry from a deleted rule will turn the removed path into a 503 for
+/// any subsequent request — including ones the user expected the SPA
+/// catch-all to handle.
+///
+/// This test deploys once with a marker rule, verifies it works, removes
+/// the rule from `_redirects`, redeploys, and verifies the marker path
+/// now falls through cleanly to the catch-all 404 rather than 503-ing.
+#[test]
+fn removed_redirect_rule_clears_cert_tree() {
+    let tmp = setup_project("tests/fixture/html-handling-with-catchall");
+    let project = tmp.path();
+    let _network = LocalNetwork::start(project);
+
+    let redirects_path = project.join("dist/_redirects");
+    let original = std::fs::read_to_string(&redirects_path).expect("read original");
+    // Prepend a marker that can't collide with auto-synth (no matching
+    // .html source for this path).
+    std::fs::write(
+        &redirects_path,
+        format!("/marker-path /index.html 307\n{original}"),
+    )
+    .expect("write augmented _redirects");
+
+    icp_cmd(project).arg("deploy").assert().success();
+
+    let r = http_fetch_subdomain(project, "/marker-path");
+    assert_eq!(
+        r.status(),
+        StatusCode::TEMPORARY_REDIRECT,
+        "before removal: /marker-path expected 307, got {}",
+        r.status()
+    );
+
+    // Remove the marker, leaving only the user's catch-all + synth.
+    std::fs::write(&redirects_path, &original).expect("restore _redirects");
+    icp_cmd(project).arg("deploy").assert().success();
+
+    let r = http_fetch_subdomain(project, "/marker-path");
+    // After the fix, the cert tree no longer has an Exact entry at this
+    // path, so the user's `/* /404.html 404` catch-all takes over cleanly.
+    // Before the fix, the orphaned subtree confused the verifier and the
+    // gateway returned 503 instead.
+    assert_eq!(
+        r.status(),
+        StatusCode::NOT_FOUND,
+        "after removal: /marker-path expected 404 from catch-all, got {} \
+         (a 503 here means the cert-tree entry wasn't pruned)",
+        r.status()
+    );
+    let body = r.text().expect("read body");
+    assert!(
+        body.contains("custom 404"),
+        "expected /404.html body from catch-all, got: {body}"
+    );
+}
+
 fn expect_200(project: &std::path::Path, path: &str, body_marker: &str) {
     let r = http_fetch(project, path);
     assert_eq!(

--- a/ic-certified-assets/src/nested_tree.rs
+++ b/ic-certified-assets/src/nested_tree.rs
@@ -108,6 +108,20 @@ impl<K: NestedTreeKeyRequirements, V: NestedTreeValueRequirements> NestedTree<K,
                 NestedTree::Leaf(_) => {}
                 NestedTree::Nested(tree) => {
                     tree.modify(key.as_ref(), |child| child.delete(&path[1..]));
+                    // Prune the child if it's now an empty `Nested` subtree.
+                    // Otherwise a deleted leaf leaves an orphan path that the
+                    // v2 HTTP gateway's response verifier reads as "a
+                    // more-specific Exact expression path might exist for
+                    // this URL" and rejects wildcard `<*>` responses with
+                    // 503. Cascading up the recursion stack means a deep
+                    // delete fully unlinks every now-empty ancestor.
+                    let prune_child = tree.get(key.as_ref()).is_some_and(|c| match c {
+                        NestedTree::Leaf(_) => false,
+                        NestedTree::Nested(rb) => rb.iter().next().is_none(),
+                    });
+                    if prune_child {
+                        tree.delete(key.as_ref());
+                    }
                 }
             }
         } else {
@@ -162,4 +176,41 @@ fn nested_tree_operation() {
     assert_eq!(tree.get(&["one"]), None);
     assert!(!tree.contains_leaf(&["one", "two"]));
     assert!(!tree.contains_leaf(&["one"]));
+}
+
+#[test]
+fn delete_prunes_empty_parent_chain() {
+    // Deleting a deeply-nested leaf must unlink every now-empty ancestor.
+    // Otherwise `contains_path` for the deleted leaf's parents still returns
+    // true (the empty `Nested` subtrees count as "the path exists"), and
+    // the HTTP gateway's response verifier rejects wildcard responses
+    // because a "potential exact expression path" is visible at the
+    // orphaned path.
+    let mut tree: NestedTree<&str, Vec<u8>> = NestedTree::default();
+    tree.insert(&["a", "b", "c"], vec![1]);
+    assert!(tree.contains_path(&["a", "b", "c"]));
+    assert!(tree.contains_path(&["a", "b"]));
+    assert!(tree.contains_path(&["a"]));
+
+    tree.delete(&["a", "b", "c"]);
+    // Every ancestor that has no remaining content must be unlinked.
+    assert!(!tree.contains_path(&["a", "b", "c"]));
+    assert!(!tree.contains_path(&["a", "b"]));
+    assert!(!tree.contains_path(&["a"]));
+}
+
+#[test]
+fn delete_preserves_siblings_in_ancestor_chain() {
+    // Pruning must stop at the first ancestor that still has other
+    // children — we don't want to collapse the whole tree just because
+    // one leaf went away.
+    let mut tree: NestedTree<&str, Vec<u8>> = NestedTree::default();
+    tree.insert(&["a", "b", "c"], vec![1]);
+    tree.insert(&["a", "x"], vec![2]);
+
+    tree.delete(&["a", "b", "c"]);
+    // "a" still has "x" so the chain stops there.
+    assert!(!tree.contains_path(&["a", "b"]));
+    assert!(tree.contains_path(&["a"]));
+    assert_eq!(tree.get(&["a", "x"]), Some(&vec![2]));
 }


### PR DESCRIPTION
## Summary

Fixes a production-visible 503 that appeared when a user removed a rule from `_redirects` and redeployed: the canister's `redirect_rules` field updated, but the cert tree kept a dead `Exact` entry at the deleted path. The v2 HTTP gateway's response verifier reads that orphan as "a more-specific exact expression path might exist for this URL" and rejects the wildcard `<*>` witness the canister returned for the user's `/* /404.html 404` catch-all. Sits on top of the `_redirects` track (PR #58 / branch `lwshang/automatic_trailing_slashes`) — same scenario as `_headers` edits, but exposed first by `_redirects` because rule removal is the only path that drops cert-tree entries without a replacement.

## Design

The bug is local to [`NestedTree::delete`](ic-certified-assets/src/nested_tree.rs): deleting a leaf recursed into the child `Nested` subtree, removed the leaf, and returned — leaving the now-childless `Nested` linked under its parent's key. `contains_path` walks the chain and reports "yes, this path exists" for every ancestor, which is exactly what the v2 verifier consults when deciding whether a wildcard response is admissible.

- **Fix shape: prune-on-the-way-up.** After the recursive `child.delete(&path[1..])` returns, check whether the child is now an empty `Nested` and, if so, unlink it from its parent. Because the check runs at every level on the way back up the recursion, a deep leaf removal fully unlinks every now-childless intermediate — without ever touching ancestors that still have other children. No change to the tree's public API, witness shape, or candid surface.

- **Why "empty `Nested`" is the only prune condition.** `Leaf` children must stay regardless of value; `Nested` children with at least one entry must stay because they represent a real path. The only safe-to-drop state is "we recursed in, the recursion emptied it, nothing else lives there."

- **e2e/build.rs `rerun-if-changed`.** The e2e canister WASM build only re-ran on changes under `canister/src` / `plugin/src` / `assets-sync/src`, so edits to `ic-certified-assets/src` (this fix, plus the cert-tree code generally) didn't invalidate the cached WASM. Added `../ic-certified-assets/src` so the e2e suite picks up canister-side changes automatically.

## Test plan

- [x] \`cargo test -p ic-certified-assets nested_tree\` — two new unit tests: `delete_prunes_empty_parent_chain` (deep leaf → every empty ancestor unlinked) and `delete_preserves_siblings_in_ancestor_chain` (pruning stops at the first ancestor that still has other children).
- [x] \`cargo test -p e2e removed_redirect_rule_clears_cert_tree\` — deploys a fixture with a marker `_redirects` rule, verifies the 307, removes the rule, redeploys, and asserts the path now returns 404 from the catch-all (not 503 from the verifier). Before the fix this test fails with 503; after the fix it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)