### PR TITLE
perf(assets-sync): batch chunks to collapse per-file create_chunks calls

### DIFF
--- a/assets-sync/src/sync.rs
+++ b/assets-sync/src/sync.rs
@@ -380,7 +380,7 @@ fn pack_and_upload_chunks<C: CanisterCall>(
     // First-fit-decreasing: sort descending, then in each pass take every
     // chunk that still fits under MAX_CHUNK_SIZE. Anything that doesn't fit
     // stays in `pending` for the next pass.
-    pending.sort_by(|a, b| b.data.len().cmp(&a.data.len()));
+    pending.sort_by_key(|b| std::cmp::Reverse(b.data.len()));
 
     let total_chunks = pending.len();
     let mut total_calls = 0usize;
@@ -412,7 +412,7 @@ fn pack_and_upload_chunks<C: CanisterCall>(
         total_calls += 1;
         total_bytes += batch_size as u64;
 
-        for (p, id) in batch.into_iter().zip(ids.into_iter()) {
+        for (p, id) in batch.into_iter().zip(ids) {
             let asset = project_assets
                 .get_mut(&p.asset_key)
                 .expect("asset present (collected above)");
@@ -424,9 +424,7 @@ fn pack_and_upload_chunks<C: CanisterCall>(
         }
     }
 
-    println!(
-        "uploaded {total_chunks} chunk(s) in {total_calls} call(s) ({total_bytes} bytes)"
-    );
+    println!("uploaded {total_chunks} chunk(s) in {total_calls} call(s) ({total_bytes} bytes)");
     Ok(())
 }
 

--- a/assets-sync/src/sync.rs
+++ b/assets-sync/src/sync.rs
@@ -201,15 +201,7 @@ pub fn sync<C: CanisterCall>(
     let batch_id = create_batch(canister)?;
     println!("created batch {batch_id}");
 
-    for asset in project_assets.values_mut() {
-        let key = asset.source.key.clone();
-        for (encoding_name, enc) in &mut asset.encodings {
-            if !enc.already_in_place {
-                let data = std::mem::take(&mut enc.data);
-                enc.chunk_ids = upload_chunks(canister, &batch_id, &key, encoding_name, &data)?;
-            }
-        }
-    }
+    pack_and_upload_chunks(canister, &batch_id, &mut project_assets)?;
 
     let operations = build_operations(
         &project_assets,
@@ -323,43 +315,119 @@ fn is_already_in_place(
         .is_some_and(|s| s == sha256)
 }
 
-fn upload_chunks<C: CanisterCall>(
-    canister: &C,
-    batch_id: &Nat,
-    key: &str,
-    encoding: &str,
-    data: &[u8],
-) -> Result<Vec<Nat>, String> {
-    if data.is_empty() {
-        let ids = create_chunks(canister, batch_id, &[&[]])?;
-        println!("  {key}{} 1/1 (0 bytes)", encoding_suffix(encoding));
-        return Ok(ids);
-    }
-    let total = data.len().div_ceil(MAX_CHUNK_SIZE);
-    let mut ids = Vec::with_capacity(total);
-    for (i, chunk) in data.chunks(MAX_CHUNK_SIZE).enumerate() {
-        let mut got = create_chunks(canister, batch_id, &[chunk])?;
-        let id = got
-            .pop()
-            .ok_or_else(|| "create_chunks returned no chunk id".to_string())?;
-        println!(
-            "  {key}{} {}/{} ({} bytes)",
-            encoding_suffix(encoding),
-            i + 1,
-            total,
-            chunk.len()
-        );
-        ids.push(id);
-    }
-    Ok(ids)
-}
-
 fn encoding_suffix(encoding: &str) -> String {
     if encoding == "identity" {
         String::new()
     } else {
         format!(" ({encoding})")
     }
+}
+
+/// Pack-and-upload pass: collect every chunk from every not-yet-uploaded
+/// encoding across all assets, then ship them in `create_chunks` calls of up
+/// to `MAX_CHUNK_SIZE` total bytes each.
+///
+/// This is where the wall-clock win lives versus the old "one chunk per call"
+/// pattern: a project of 100 small files used to make 100 round-trips; now
+/// they ride in a single call (≈1.9 MB budget).
+///
+/// Routing is by `(asset_key, encoding, chunk_index)`: each `PendingChunk`
+/// remembers where its eventual canister id should land in
+/// `enc.chunk_ids[chunk_index]`.
+fn pack_and_upload_chunks<C: CanisterCall>(
+    canister: &C,
+    batch_id: &Nat,
+    project_assets: &mut HashMap<String, ProjectAsset>,
+) -> Result<(), String> {
+    struct PendingChunk {
+        asset_key: String,
+        encoding: String,
+        chunk_index: usize,
+        data: Vec<u8>,
+    }
+
+    let mut pending: Vec<PendingChunk> = Vec::new();
+    for asset in project_assets.values_mut() {
+        let key = asset.source.key.clone();
+        for (encoding_name, enc) in &mut asset.encodings {
+            if enc.already_in_place {
+                continue;
+            }
+            let data = std::mem::take(&mut enc.data);
+            // Slice into MAX_CHUNK_SIZE-sized pieces. An empty encoding still
+            // needs one zero-byte chunk so SetAssetContent has a chunk_id.
+            let chunks: Vec<Vec<u8>> = if data.is_empty() {
+                vec![Vec::new()]
+            } else {
+                data.chunks(MAX_CHUNK_SIZE).map(|c| c.to_vec()).collect()
+            };
+            enc.chunk_ids = vec![Nat::from(0u32); chunks.len()];
+            for (i, chunk) in chunks.into_iter().enumerate() {
+                pending.push(PendingChunk {
+                    asset_key: key.clone(),
+                    encoding: encoding_name.clone(),
+                    chunk_index: i,
+                    data: chunk,
+                });
+            }
+        }
+    }
+
+    if pending.is_empty() {
+        return Ok(());
+    }
+
+    // First-fit-decreasing: sort descending, then in each pass take every
+    // chunk that still fits under MAX_CHUNK_SIZE. Anything that doesn't fit
+    // stays in `pending` for the next pass.
+    pending.sort_by(|a, b| b.data.len().cmp(&a.data.len()));
+
+    let total_chunks = pending.len();
+    let mut total_calls = 0usize;
+    let mut total_bytes = 0u64;
+
+    while !pending.is_empty() {
+        let mut batch: Vec<PendingChunk> = Vec::new();
+        let mut leftovers: Vec<PendingChunk> = Vec::new();
+        let mut batch_size = 0usize;
+        for chunk in std::mem::take(&mut pending) {
+            if batch_size + chunk.data.len() <= MAX_CHUNK_SIZE {
+                batch_size += chunk.data.len();
+                batch.push(chunk);
+            } else {
+                leftovers.push(chunk);
+            }
+        }
+        pending = leftovers;
+
+        let chunk_refs: Vec<&[u8]> = batch.iter().map(|p| p.data.as_slice()).collect();
+        let ids = create_chunks(canister, batch_id, &chunk_refs)?;
+        if ids.len() != batch.len() {
+            return Err(format!(
+                "create_chunks returned {} ids for {} chunks",
+                ids.len(),
+                batch.len()
+            ));
+        }
+        total_calls += 1;
+        total_bytes += batch_size as u64;
+
+        for (p, id) in batch.into_iter().zip(ids.into_iter()) {
+            let asset = project_assets
+                .get_mut(&p.asset_key)
+                .expect("asset present (collected above)");
+            let enc = asset
+                .encodings
+                .get_mut(&p.encoding)
+                .expect("encoding present (collected above)");
+            enc.chunk_ids[p.chunk_index] = id;
+        }
+    }
+
+    println!(
+        "uploaded {total_chunks} chunk(s) in {total_calls} call(s) ({total_bytes} bytes)"
+    );
+    Ok(())
 }
 
 fn build_operations(
@@ -601,102 +669,189 @@ mod tests {
         chunk_ids: Vec<Nat>,
     }
 
-    struct ChunkCounter(Cell<u32>);
+    // Counts each `create_chunks` call, returns one fresh id per chunk in the
+    // request, and records the batch sizes the packer produced. Used to verify
+    // that `pack_and_upload_chunks` collapses many small chunks into single
+    // calls and assigns canister ids to the right encoding slots.
+    struct ChunkBatchRecorder {
+        next_id: Cell<u64>,
+        batches: RefCell<Vec<usize>>, // chunks-per-batch
+    }
 
-    impl CanisterCall for ChunkCounter {
-        fn call<A, R>(&self, method: &str, _arg: A, _: CallType, _: bool) -> Result<R, String>
+    impl ChunkBatchRecorder {
+        fn new() -> Self {
+            Self {
+                next_id: Cell::new(0),
+                batches: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    // Mirror of CreateChunksRequest so the mock can introspect arg.content.len().
+    #[derive(CandidType, serde::Deserialize)]
+    struct ChunksReqMirror {
+        #[allow(dead_code)]
+        batch_id: Nat,
+        content: Vec<serde_bytes::ByteBuf>,
+    }
+
+    impl CanisterCall for ChunkBatchRecorder {
+        fn call<A, R>(&self, method: &str, arg: A, _: CallType, _: bool) -> Result<R, String>
         where
             A: CandidType,
             R: CandidType + DeserializeOwned,
         {
             assert_eq!(method, "create_chunks");
-            let id = self.0.get();
-            self.0.set(id + 1);
-            let bytes = candid::encode_one(MockChunksResponse {
-                chunk_ids: vec![Nat::from(id)],
-            })
-            .map_err(|e| e.to_string())?;
-            candid::decode_one(&bytes).map_err(|e| e.to_string())
+            let bytes = candid::encode_one(&arg).map_err(|e| e.to_string())?;
+            let req: ChunksReqMirror = candid::decode_one(&bytes).map_err(|e| e.to_string())?;
+            let n = req.content.len();
+            self.batches.borrow_mut().push(n);
+            let start = self.next_id.get();
+            self.next_id.set(start + n as u64);
+            let ids: Vec<Nat> = (0..n as u64).map(|i| Nat::from(start + i)).collect();
+            let reply = candid::encode_one(MockChunksResponse { chunk_ids: ids })
+                .map_err(|e| e.to_string())?;
+            candid::decode_one(&reply).map_err(|e| e.to_string())
         }
     }
 
-    #[test]
-    fn upload_chunks_empty_data_creates_one_chunk() {
-        let mock = ChunkCounter(Cell::new(0));
-        let ids = upload_chunks(&mock, &Nat::from(1u32), "/f", "identity", &[]).unwrap();
-        assert_eq!(ids.len(), 1);
-    }
-
-    #[test]
-    fn upload_chunks_small_data_creates_one_chunk() {
-        let mock = ChunkCounter(Cell::new(0));
-        let ids = upload_chunks(&mock, &Nat::from(1u32), "/f", "identity", &[0u8; 100]).unwrap();
-        assert_eq!(ids.len(), 1);
-    }
-
-    #[test]
-    fn upload_chunks_at_boundary_creates_one_chunk() {
-        let mock = ChunkCounter(Cell::new(0));
-        let ids = upload_chunks(
-            &mock,
-            &Nat::from(1u32),
-            "/f",
-            "identity",
-            &[0u8; MAX_CHUNK_SIZE],
-        )
-        .unwrap();
-        assert_eq!(ids.len(), 1);
-    }
-
-    #[test]
-    fn upload_chunks_one_over_boundary_creates_two_chunks() {
-        let mock = ChunkCounter(Cell::new(0));
-        let ids = upload_chunks(
-            &mock,
-            &Nat::from(1u32),
-            "/f",
-            "identity",
-            &[0u8; MAX_CHUNK_SIZE + 1],
-        )
-        .unwrap();
-        assert_eq!(ids.len(), 2);
-    }
-
-    #[test]
-    fn upload_chunks_double_boundary_creates_two_chunks() {
-        let mock = ChunkCounter(Cell::new(0));
-        let ids = upload_chunks(
-            &mock,
-            &Nat::from(1u32),
-            "/f",
-            "identity",
-            &[0u8; MAX_CHUNK_SIZE * 2],
-        )
-        .unwrap();
-        assert_eq!(ids.len(), 2);
-    }
-
-    #[test]
-    fn upload_chunks_returns_sequential_ids() {
-        let mock = ChunkCounter(Cell::new(7));
-        // MAX_CHUNK_SIZE * 3 + 1 → div_ceil = 4 chunks.
-        let ids = upload_chunks(
-            &mock,
-            &Nat::from(1u32),
-            "/f",
-            "identity",
-            &[0u8; MAX_CHUNK_SIZE * 3 + 1],
-        )
-        .unwrap();
-        assert_eq!(
-            ids,
-            vec![
-                Nat::from(7u32),
-                Nat::from(8u32),
-                Nat::from(9u32),
-                Nat::from(10u32),
-            ]
+    fn mk_pending_asset(key: &str, encoding: &str, data: Vec<u8>) -> (String, ProjectAsset) {
+        let mut enc_map = HashMap::new();
+        enc_map.insert(
+            encoding.to_string(),
+            ProjectAssetEncoding {
+                chunk_ids: Vec::new(),
+                sha256: vec![0; 32],
+                already_in_place: false,
+                data,
+            },
         );
+        (
+            key.to_string(),
+            ProjectAsset {
+                source: AssetSource {
+                    path: PathBuf::from(key.trim_start_matches('/')),
+                    key: key.to_string(),
+                },
+                media_type: "application/octet-stream".parse().unwrap(),
+                encodings: enc_map,
+            },
+        )
+    }
+
+    #[test]
+    fn pack_uploads_one_full_chunk_per_call() {
+        // A single MAX-sized encoding ships in one call carrying one chunk.
+        let mut assets = HashMap::from([mk_pending_asset(
+            "/f",
+            "identity",
+            vec![0u8; MAX_CHUNK_SIZE],
+        )]);
+        let mock = ChunkBatchRecorder::new();
+        pack_and_upload_chunks(&mock, &Nat::from(1u32), &mut assets).unwrap();
+        assert_eq!(*mock.batches.borrow(), vec![1]);
+        assert_eq!(assets["/f"].encodings["identity"].chunk_ids.len(), 1);
+    }
+
+    #[test]
+    fn pack_splits_oversized_encoding_into_max_chunks() {
+        // MAX*3 + 1 bytes → 4 chunks: three at MAX, one at 1 byte. Each MAX
+        // chunk fills its own call; the trailing 1-byte chunk gets its own
+        // call too because nothing else is left to share with it.
+        let mut assets = HashMap::from([mk_pending_asset(
+            "/big",
+            "identity",
+            vec![0u8; MAX_CHUNK_SIZE * 3 + 1],
+        )]);
+        let mock = ChunkBatchRecorder::new();
+        pack_and_upload_chunks(&mock, &Nat::from(1u32), &mut assets).unwrap();
+        assert_eq!(*mock.batches.borrow(), vec![1, 1, 1, 1]);
+        assert_eq!(assets["/big"].encodings["identity"].chunk_ids.len(), 4);
+    }
+
+    #[test]
+    fn pack_collapses_many_small_chunks_into_one_call() {
+        // 100 × 1KB chunks fit comfortably under MAX_CHUNK_SIZE (~1.9 MB) →
+        // one call carrying all 100 chunks. This is the optimisation.
+        let mut assets: HashMap<String, ProjectAsset> = (0..100)
+            .map(|i| mk_pending_asset(&format!("/f{i}"), "identity", vec![0u8; 1024]))
+            .collect();
+        let mock = ChunkBatchRecorder::new();
+        pack_and_upload_chunks(&mock, &Nat::from(1u32), &mut assets).unwrap();
+        assert_eq!(*mock.batches.borrow(), vec![100]);
+    }
+
+    #[test]
+    fn pack_packs_full_chunk_alone_then_packs_remaining_smalls() {
+        // One MAX-sized asset + many tiny assets. FFD puts the MAX chunk in
+        // its own call (nothing else fits), then packs the small chunks
+        // together.
+        let mut assets: HashMap<String, ProjectAsset> = HashMap::new();
+        assets.extend([mk_pending_asset(
+            "/big",
+            "identity",
+            vec![0u8; MAX_CHUNK_SIZE],
+        )]);
+        for i in 0..10 {
+            assets.extend([mk_pending_asset(
+                &format!("/tiny{i}"),
+                "identity",
+                vec![0u8; 1024],
+            )]);
+        }
+        let mock = ChunkBatchRecorder::new();
+        pack_and_upload_chunks(&mock, &Nat::from(1u32), &mut assets).unwrap();
+        // Two calls total: one for the big chunk, one for the ten tinies.
+        let batches = mock.batches.borrow().clone();
+        assert_eq!(batches.len(), 2);
+        assert!(batches.contains(&1)); // big chunk on its own
+        assert!(batches.contains(&10)); // 10 tinies packed together
+    }
+
+    #[test]
+    fn pack_routes_chunk_ids_to_correct_encoding_slot() {
+        // Two assets, multi-chunk each. After upload, every encoding's
+        // chunk_ids vec must be filled (no default zeros remaining) and
+        // ids must be distinct.
+        let mut assets = HashMap::from([
+            mk_pending_asset("/a", "identity", vec![0u8; MAX_CHUNK_SIZE + 100]), // 2 chunks
+            mk_pending_asset("/b", "identity", vec![0u8; 500]),                  // 1 chunk
+        ]);
+        let mock = ChunkBatchRecorder::new();
+        pack_and_upload_chunks(&mock, &Nat::from(1u32), &mut assets).unwrap();
+        let a_ids = &assets["/a"].encodings["identity"].chunk_ids;
+        let b_ids = &assets["/b"].encodings["identity"].chunk_ids;
+        assert_eq!(a_ids.len(), 2);
+        assert_eq!(b_ids.len(), 1);
+        let mut all: Vec<&Nat> = a_ids.iter().chain(b_ids.iter()).collect();
+        all.sort_by(|x, y| {
+            // Nat doesn't impl Ord; compare textually.
+            x.to_string().cmp(&y.to_string())
+        });
+        all.dedup();
+        assert_eq!(all.len(), 3, "ids must be distinct");
+    }
+
+    #[test]
+    fn pack_empty_encoding_still_gets_one_chunk_id() {
+        // A zero-byte encoding still needs a chunk_id so SetAssetContent
+        // has something to reference.
+        let mut assets = HashMap::from([mk_pending_asset("/empty", "identity", vec![])]);
+        let mock = ChunkBatchRecorder::new();
+        pack_and_upload_chunks(&mock, &Nat::from(1u32), &mut assets).unwrap();
+        assert_eq!(assets["/empty"].encodings["identity"].chunk_ids.len(), 1);
+    }
+
+    #[test]
+    fn pack_skips_already_in_place_encodings() {
+        // Nothing to upload → no calls made.
+        let (k, mut pa) = mk_pending_asset("/skip", "identity", vec![0u8; 100]);
+        pa.encodings.get_mut("identity").unwrap().already_in_place = true;
+        pa.encodings.get_mut("identity").unwrap().data = Vec::new();
+        let mut assets = HashMap::from([(k, pa)]);
+        let mock = ChunkBatchRecorder::new();
+        pack_and_upload_chunks(&mock, &Nat::from(1u32), &mut assets).unwrap();
+        assert!(mock.batches.borrow().is_empty());
     }
 
     fn mk_project_asset(

--- a/assets-sync/tests/OPTIMIZATIONS.md
+++ b/assets-sync/tests/OPTIMIZATIONS.md
@@ -1,0 +1,119 @@
+# Deferred sync-performance optimizations
+
+Working notes for performance work identified by [`bench_sync.rs`](bench_sync.rs)
+but not yet shipped. Each entry says what to do, the measured or expected
+impact, and what's blocking us from doing it now.
+
+Run the bench to get current baseline numbers:
+
+```sh
+cargo test --release --test bench_sync -- --ignored --nocapture --test-threads=1
+```
+
+## 1. Inline trailing chunk into `commit_batch`
+
+`SetAssetContentArguments` has a `last_chunk: Option<Vec<u8>>` field
+([canister.rs](../src/canister.rs)) that the canister accepts as content
+shipped *inside* `commit_batch` rather than via a separate `create_chunks`
+call. Today we always set it to `None`
+([sync.rs](../src/sync.rs), `build_operations` — `last_chunk: None`).
+
+**What to do.** For each encoding, if the final chunk is sub-`MAX_CHUNK_SIZE`,
+move it out of the upload-pending list and into the `SetAssetContent` op's
+`last_chunk`. Budget the total bytes carried this way against the ingress
+message limit — `dfx`'s `ic-asset` uses `MAX_CHUNK_SIZE / 2`
+(`~950 KB`) as the ceiling.
+
+**Expected impact** (from the bench, post chunk-batching baseline):
+
+| fixture | `create_chunks` now | with `last_chunk` |
+|---|---:|---:|
+| many_tiny  (1000 × 1 KB) | 1  | **0** |
+| many_small (100 × 5 KB)  | 1  | **0** |
+| few_medium (10 × 2 MB)   | 12 | **10** (drops 2 trailing-chunk calls) |
+| one_huge   (1 × 50 MB)   | 28 | **27** (drops the trailing-chunk call) |
+
+For small/medium projects the entire upload disappears into `commit_batch` and
+there is no `create_chunks` round-trip at all.
+
+**Why deferred.** Orthogonal to chunk batching; deserves its own PR so we can
+measure the delta cleanly. Some care needed around the inline-budget
+accounting: `last_chunk` bytes count toward the `commit_batch` arg size,
+which has the same ~2 MB ingress limit, so the budget interacts with the
+"split `commit_batch`" work below.
+
+## 2. Split `commit_batch` into bounded sub-batches
+
+Today we commit every operation in one `commit_batch` call
+([sync.rs](../src/sync.rs), Phase 3). For projects with thousands of operations
+(or with `last_chunk` inlining adding bytes per op), the request may exceed
+the ~2 MB ingress message limit and the call will fail outright.
+
+**What to do.** Mirror the SDK's approach
+([dfx sync.rs:253-290](../../../sdk/src/canisters/frontend/ic-asset/src/sync.rs#L253-L290)):
+split the operations list into batches of at most ~500 ops or ~1.5 MB of
+header bytes, commit each batch, send a final empty-ops `commit_batch` to
+finalize.
+
+**Expected impact.** Correctness/scaling, not raw speed. At today's typical
+project sizes it's a no-op; at 10k+ assets or with `last_chunk` enabled it
+prevents outright failure.
+
+**Why deferred.** No project we know of currently hits the limit. Should land
+together with `last_chunk` inlining since the two share the ingress-size
+budget.
+
+## 3. Eliminate / batch per-asset `get_asset_properties`
+
+[sync.rs](../src/sync.rs) (`sync`, Phase 1) issues one query call per surviving
+asset to read its current `(max_age, headers, allow_raw_access)`. N round-trips
+for N assets, even though most projects have property drift on zero or one
+asset.
+
+**What to do.** Two options:
+
+- **Bulk endpoint.** Add `get_asset_properties_bulk(keys) -> Vec<AssetProperties>`
+  to the canister and use it. One round-trip total.
+- **Always emit `SetAssetProperties`.** Skip the query entirely and emit a
+  `SetAssetProperties` op for every surviving asset with project-desired
+  values. Idempotent; trades N query calls for at most N ops in a batch we
+  were already going to send.
+
+**Expected impact.** Eliminates one round-trip per asset.
+
+**Why deferred.** Query calls are much cheaper than update calls on the IC
+(no consensus), so for typical projects this is unlikely to dominate
+wall-clock. Worth profiling a real deployment first to confirm before adding
+either of the above.
+
+## 4. Host-side concurrent calls
+
+The plugin compiles to a `wasm32-wasip2` component. WASI Preview 2 is
+single-threaded — `std::thread`, `rayon`, and async runtimes are all
+unavailable inside the component. So even though the SDK's async fan-out
+gives `dfx deploy` 50× concurrency on chunk uploads, that lever isn't
+reachable from inside the current plugin model.
+
+**What to do.** Extend the WIT interface
+([`plugin/wit/sync-plugin.wit`](../../plugin/wit/sync-plugin.wit)) with a
+batch-call import — something like
+`canister-call-batch(requests: list<request>) -> list<response>` — and
+implement it on the host (native Rust, tokio-based) so multiple update calls
+fire concurrently. The plugin would still drive everything synchronously,
+but each batch import would expand into N concurrent calls under the hood.
+
+**Expected impact.** Where this helps:
+
+- `one_huge` (1 × 50 MB): 28 MAX-sized `create_chunks` calls. Chunk packing
+  can't help (chunks already fill the call). Concurrency could fan these out.
+
+Where this doesn't help (because we already collapsed to 1 call):
+
+- `many_tiny`, `many_small`: nothing left to parallelize.
+
+**Why deferred.** This is a plugin-host interface change, not an
+`assets-sync` change. The chunk-batching work in this PR already removed the
+majority of the call-count gap — large-file uploads remain the only regime
+where concurrency would still pay off, and even there only by a constant
+factor. Do this only after measuring against a real replica and confirming
+large-file uploads are the bottleneck.

--- a/assets-sync/tests/bench_sync.rs
+++ b/assets-sync/tests/bench_sync.rs
@@ -148,13 +148,7 @@ fn run_bench(label: &str, count: usize, size_bytes: usize) {
 
     let mock = BenchMock::new();
     let started = std::time::Instant::now();
-    let result = sync(
-        &mock,
-        &dirs,
-        &[],
-        &Principal::anonymous().to_text(),
-        None,
-    );
+    let result = sync(&mock, &dirs, &[], &Principal::anonymous().to_text(), None);
     let elapsed = started.elapsed();
     result.expect("sync failed");
 

--- a/assets-sync/tests/bench_sync.rs
+++ b/assets-sync/tests/bench_sync.rs
@@ -1,0 +1,198 @@
+//! Layer 1 benchmark — measures the canister-call pattern `sync()` emits.
+//!
+//! The mock returns instantly, so wall-clock here reflects scan + encode +
+//! Candid only. The wins we're targeting (chunk batching, `last_chunk`
+//! inlining, eliminating per-asset `get_asset_properties`) all move the
+//! *call pattern*, which is what the printed table surfaces.
+//!
+//! Run on a baseline branch, save the output, then re-run on a changed
+//! branch and diff:
+//!
+//! ```sh
+//! cargo test --release --test bench_sync \
+//!   -- --ignored --nocapture --test-threads=1
+//! ```
+//!
+//! Tests are `#[ignore]`'d so they don't slow down the regular suite.
+
+use assets_sync::canister::{AssetDetails, AssetProperties, CallType, CanisterCall, RedirectRule};
+use assets_sync::sync::sync;
+use candid::{CandidType, Decode, Encode, Nat, Principal};
+use serde::Deserialize;
+use std::cell::{Cell, RefCell};
+use std::collections::BTreeMap;
+use std::path::Path;
+
+// Wire-compatible mirrors of the response types defined privately in
+// assets_sync::canister. Same field name → same Candid encoding.
+#[derive(CandidType)]
+struct CreateBatchOk {
+    batch_id: Nat,
+}
+#[derive(CandidType)]
+struct CreateChunksOk {
+    chunk_ids: Vec<Nat>,
+}
+
+// Wire-compatible mirror of CreateChunksRequest so the mock can count chunks
+// submitted per call and return one id per chunk — works whether the plugin
+// sends a single chunk per call (today) or batches many (after optimisation).
+#[derive(CandidType, Deserialize)]
+struct CreateChunksReqMirror {
+    #[allow(dead_code)]
+    batch_id: Nat,
+    content: Vec<serde_bytes::ByteBuf>,
+}
+
+/// Records every canister call (method, Candid arg bytes) and auto-responds
+/// with empty/default values — i.e. a first-time deploy against a fresh
+/// canister.
+struct BenchMock {
+    /// Per-method `(call_count, total_arg_bytes)`. BTreeMap so the printed
+    /// report is stable across runs.
+    stats: RefCell<BTreeMap<String, (u64, u64)>>,
+    next_chunk_id: Cell<u64>,
+}
+
+impl BenchMock {
+    fn new() -> Self {
+        Self {
+            stats: RefCell::new(BTreeMap::new()),
+            next_chunk_id: Cell::new(0),
+        }
+    }
+
+    fn report(&self, label: &str) {
+        let stats = self.stats.borrow();
+        let total_calls: u64 = stats.values().map(|(c, _)| *c).sum();
+        let total_bytes: u64 = stats.values().map(|(_, b)| *b).sum();
+        println!();
+        println!("── {label} ──");
+        println!("{:<28} {:>8} {:>14}", "method", "calls", "arg bytes");
+        println!("{:-<28} {:->8} {:->14}", "", "", "");
+        for (m, (c, b)) in stats.iter() {
+            println!("{m:<28} {c:>8} {b:>14}");
+        }
+        println!("{:-<28} {:->8} {:->14}", "", "", "");
+        println!("{:<28} {:>8} {:>14}", "TOTAL", total_calls, total_bytes);
+    }
+}
+
+impl CanisterCall for BenchMock {
+    fn call<A, R>(&self, method: &str, arg: A, _: CallType, _: bool) -> Result<R, String>
+    where
+        A: CandidType,
+        R: CandidType + serde::de::DeserializeOwned,
+    {
+        let arg_bytes = Encode!(&arg).map_err(|e| e.to_string())?;
+        {
+            let mut stats = self.stats.borrow_mut();
+            let entry = stats.entry(method.to_string()).or_insert((0, 0));
+            entry.0 += 1;
+            entry.1 += arg_bytes.len() as u64;
+        }
+
+        let resp = match method {
+            "api_version" => Encode!(&2u16),
+            "list" => Encode!(&Vec::<AssetDetails>::new()),
+            "get_redirect_rules" => Encode!(&Vec::<RedirectRule>::new()),
+            "get_asset_properties" => Encode!(&AssetProperties {
+                max_age: None,
+                headers: None,
+                allow_raw_access: Some(true),
+            }),
+            "create_batch" => Encode!(&CreateBatchOk {
+                batch_id: Nat::from(1u32),
+            }),
+            "create_chunks" => {
+                let req = Decode!(&arg_bytes, CreateChunksReqMirror)
+                    .map_err(|e| format!("decode create_chunks req: {e}"))?;
+                let n = req.content.len() as u64;
+                let start = self.next_chunk_id.get();
+                self.next_chunk_id.set(start + n);
+                let ids: Vec<Nat> = (0..n).map(|i| Nat::from(start + i)).collect();
+                Encode!(&CreateChunksOk { chunk_ids: ids })
+            }
+            "commit_batch" => Encode!(&()),
+            "list_permitted" => Encode!(&Vec::<Principal>::new()),
+            "grant_permission" => Encode!(&()),
+            other => panic!("BenchMock: unexpected method '{other}'"),
+        }
+        .map_err(|e| e.to_string())?;
+
+        Decode!(&resp, R).map_err(|e| e.to_string())
+    }
+}
+
+/// Writes `count` files of `size_bytes` each into `dir`. Bytes come from a
+/// deterministic LCG so they're incompressible — gzip is skipped per file,
+/// keeping encoder choice out of the measurement.
+fn write_incompressible_files(dir: &Path, count: usize, size_bytes: usize) {
+    let mut state: u64 = 0xdead_beef_cafe_f00d;
+    let mut buf = vec![0u8; size_bytes];
+    for i in 0..count {
+        for b in buf.iter_mut() {
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            *b = (state >> 33) as u8;
+        }
+        std::fs::write(dir.join(format!("f_{i:05}.bin")), &buf).unwrap();
+    }
+}
+
+fn run_bench(label: &str, count: usize, size_bytes: usize) {
+    let tmp = tempfile::tempdir().unwrap();
+    write_incompressible_files(tmp.path(), count, size_bytes);
+    let dirs = vec![tmp.path().to_str().unwrap().to_string()];
+
+    let mock = BenchMock::new();
+    let started = std::time::Instant::now();
+    let result = sync(
+        &mock,
+        &dirs,
+        &[],
+        &Principal::anonymous().to_text(),
+        None,
+    );
+    let elapsed = started.elapsed();
+    result.expect("sync failed");
+
+    mock.report(&format!(
+        "{label}   ({count} × {size_bytes} bytes)   wall: {elapsed:?}"
+    ));
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+//
+// Sized to exercise the three regimes the optimisations target:
+//  - many small files  → most calls today are `create_chunks` for sub-MAX
+//    chunks; chunk-batching should collapse the count
+//  - few medium files  → mix of multi-chunk uploads + single trailing chunk;
+//    last_chunk inlining should remove the trailing-chunk call
+//  - one huge file     → multi-chunk upload of a single asset; chunk packing
+//    doesn't help (chunks already at MAX), but a useful control case
+
+#[test]
+#[ignore = "bench: run with --release --ignored -- --nocapture --test-threads=1"]
+fn bench_many_tiny_files() {
+    run_bench("many_tiny   1000 × 1 KB", 1000, 1024);
+}
+
+#[test]
+#[ignore = "bench: run with --release --ignored -- --nocapture --test-threads=1"]
+fn bench_many_small_files() {
+    run_bench("many_small  100 × 5 KB", 100, 5 * 1024);
+}
+
+#[test]
+#[ignore = "bench: run with --release --ignored -- --nocapture --test-threads=1"]
+fn bench_few_medium_files() {
+    run_bench("few_medium  10 × 2 MB", 10, 2 * 1024 * 1024);
+}
+
+#[test]
+#[ignore = "bench: run with --release --ignored -- --nocapture --test-threads=1"]
+fn bench_one_huge_file() {
+    run_bench("one_huge    1 × 50 MB", 1, 50 * 1024 * 1024);
+}


### PR DESCRIPTION
## Summary

Plugin-based assets sync was much slower than `dfx deploy`. Profiling against synthetic fixtures showed the cause: every chunk became its own `create_chunks` canister call, so a project of 100 small files made 100 update round-trips even though all 100 chunks fit in a single ~1.9 MB ingress payload. This PR adds in-process call-pattern benchmarking, then collapses the upload phase via greedy chunk packing — the worst-case bench fixture (1000 × 1 KB files) drops from 1000 `create_chunks` calls to **1**.

Three more optimizations surfaced during the work (`last_chunk` inlining, `commit_batch` splitting, host-side concurrent calls); they're written up in [`assets-sync/tests/OPTIMIZATIONS.md`](assets-sync/tests/OPTIMIZATIONS.md) with expected impact and the reason each is deferred. None block this PR.

## Design

- **Layer-1 in-process bench, not e2e timing.** The bottleneck we're optimizing is the call *pattern* — how many round-trips, of what size — not raw CPU. A `BenchMock` recording `(method, arg_bytes)` per call ([`assets-sync/tests/bench_sync.rs`](assets-sync/tests/bench_sync.rs)) gives a stable, deterministic table that's faster to diff across changes than a real-replica wall-clock run. Layer 2 (replica wall-clock against the e2e harness) is the eventual safety net before shipping, not the day-to-day iteration tool. Tests are `#[ignore]`'d so they don't slow the regular suite; run with `cargo test --release --test bench_sync -- --ignored --nocapture --test-threads=1`.

- **First-fit-decreasing packing.** `pack_and_upload_chunks` in [`assets-sync/src/sync.rs`](assets-sync/src/sync.rs) collects every chunk from every not-yet-uploaded encoding across all assets into one pending list, sorts by size descending, then in each pass takes every chunk that still fits under `MAX_CHUNK_SIZE`. A full MAX-sized chunk fills its own call; many small chunks pack tightly together. Same algorithm the SDK's `ic-asset` `ChunkUploader` uses, ported to the sync model.

- **Route ids back via `(asset_key, encoding, chunk_index)`.** Each `PendingChunk` records where its eventual canister id should land — `enc.chunk_ids[chunk_index]` is pre-sized at collection time. This decouples upload order from the chunk order the canister expects in `SetAssetContent`, so the packer can sort freely without breaking serving order.

- **WASM-component constraint shaped the lever choice.** The plugin compiles to `wasm32-wasip2`, which is single-threaded — no `rayon`, no async runtime. So the SDK's "fan out 50 concurrent uploads" lever isn't reachable from inside the component. Reducing the *number* of calls (this PR) and packing more into each is what's available without changing the plugin/host WIT interface. Adding a `canister_call_batch` host import for real concurrency is a separate, larger change documented under #4 in `OPTIMIZATIONS.md`.

- **Existing `upload_chunks` helper deleted, not extended.** The previous code had a per-encoding `upload_chunks` that issued one call per chunk; the new pass operates across all encodings at once, so there's nothing for `upload_chunks` to do. Its six unit tests are replaced with seven focused tests of the new packer.

- **`encoding_suffix` kept.** Still used by `prepare_asset`'s "already in place" log line — unchanged.

## Test plan

- [x] `cargo test -p assets-sync` — 172 lib tests green. The seven new `pack_*` unit tests cover: a full MAX-sized chunk gets its own call, an oversized encoding splits at MAX boundaries, many small chunks collapse into one call, FFD packs the largest chunk alone then fills the rest, ids route correctly to the right encoding slot across multi-chunk + single-chunk assets, zero-byte encodings still get one `chunk_id`, and `already_in_place` encodings are skipped (no calls made).

- [x] Bench delta on every fixture:

  | fixture | `create_chunks` BEFORE | AFTER |
  |---|---:|---:|
  | many_tiny  (1000 × 1 KB) | 1000 | **1** |
  | many_small (100 × 5 KB)  | 100  | **1** |
  | few_medium (10 × 2 MB)   | 20   | **12** |
  | one_huge   (1 × 50 MB)   | 28   | 28 (chunks already at MAX — only `last_chunk` inlining helps here) |

- [x] `cargo fmt` + `cargo clippy` — clean (commit `1a208a3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)