### PR TITLE
refactor(permissions): collapse to one authorized set, drop install args

### DIFF
--- a/crates/canister-core/src/lib.rs
+++ b/crates/canister-core/src/lib.rs
@@ -281,43 +281,23 @@ pub fn guard_is_controller() -> Result<(), String> {
     }
 }
 
-pub fn init(args: Option<AssetCanisterArgs>) {
+pub fn init() {
+    // The authorized set starts empty. Controllers can always sync; this set
+    // only grants sync access to *non*-controllers, managed afterwards through
+    // the `authorize`/`deauthorize` endpoints.
     with_state_mut(|s| s.clear());
-    match args {
-        // No args: the authorized set starts empty. Controllers can still sync;
-        // this set is only for granting sync access to *non*-controllers.
-        None => {}
-        // Explicit args set the authorized set exactly (empty = no principals).
-        Some(AssetCanisterArgs::Init(InitArgs { authorized })) => {
-            with_state_mut(|s| s.set_authorized(authorized))
-        }
-        Some(AssetCanisterArgs::Upgrade(_)) => ic_cdk::trap(
-            "Cannot initialize the canister with an Upgrade argument. Please provide an Init argument.",
-        ),
-    }
 }
 
 pub fn pre_upgrade() -> StableState {
     STATE.with(|s| s.take().into())
 }
 
-pub fn post_upgrade(stable_state: StableState, args: Option<AssetCanisterArgs>) {
-    // No upgrade args leaves the restored authorized set untouched; explicit
-    // args replace it (an empty vector clears it).
-    let authorized = match args {
-        None => None,
-        Some(AssetCanisterArgs::Upgrade(UpgradeArgs { authorized })) => Some(authorized),
-        Some(AssetCanisterArgs::Init(_)) => ic_cdk::trap(
-            "Cannot upgrade the canister with an Init argument. Please provide an Upgrade argument.",
-        ),
-    };
-
+pub fn post_upgrade(stable_state: StableState) {
+    // The restored authorized set is left untouched; change it after upgrade
+    // through the `authorize`/`deauthorize` endpoints.
     with_state_mut(|s| {
         *s = State::from(stable_state);
         certified_data_set(s.root_hash());
-        if let Some(authorized) = authorized {
-            s.set_authorized(authorized);
-        }
     });
 }
 

--- a/crates/canister-core/src/lib.rs
+++ b/crates/canister-core/src/lib.rs
@@ -44,56 +44,18 @@ pub fn api_version() -> u16 {
     2
 }
 
-pub fn authorize(other: Principal) {
-    with_state_mut(|s| s.grant_permission(other, &Permission::Commit))
+/// Adds `principal` to the authorized set. Controller-guarded at the endpoint.
+pub fn authorize(principal: Principal) {
+    with_state_mut(|s| s.authorize(principal))
 }
 
-pub fn grant_permission(arg: GrantPermissionArguments) {
-    with_state_mut(|s| s.grant_permission(arg.to_principal, &arg.permission))
-}
-
-pub async fn deauthorize(other: Principal) {
-    let check_access_result = if other == msg_caller() {
-        // this isn't "ManagePermissions" because these legacy methods only
-        // deal with the Commit permission
-        has_permission_or_is_controller(&Permission::Commit)
-    } else {
-        is_controller()
-    };
-    match check_access_result {
-        Err(e) => trap(&e),
-        Ok(_) => with_state_mut(|s| s.revoke_permission(other, &Permission::Commit)),
-    }
-}
-
-pub async fn revoke_permission(arg: RevokePermissionArguments) {
-    let check_access_result = if arg.of_principal == msg_caller() {
-        has_permission_or_is_controller(&arg.permission)
-    } else {
-        has_permission_or_is_controller(&Permission::ManagePermissions)
-    };
-    match check_access_result {
-        Err(e) => trap(&e),
-        Ok(_) => with_state_mut(|s| s.revoke_permission(arg.of_principal, &arg.permission)),
-    }
+/// Removes `principal` from the authorized set. Controller-guarded at the endpoint.
+pub fn deauthorize(principal: Principal) {
+    with_state_mut(|s| s.deauthorize(&principal))
 }
 
 pub fn list_authorized() -> Vec<Principal> {
-    with_state(|s| {
-        s.list_permitted(&Permission::Commit)
-            .iter()
-            .cloned()
-            .collect()
-    })
-}
-
-pub fn list_permitted(arg: ListPermittedArguments) -> Vec<Principal> {
-    with_state(|s| s.list_permitted(&arg.permission).iter().cloned().collect())
-}
-
-pub async fn take_ownership() {
-    let caller = msg_caller();
-    with_state_mut(|s| s.take_ownership(caller))
+    with_state(|s| s.list_authorized().iter().cloned().collect())
 }
 
 pub fn retrieve(key: AssetKey) -> RcBytes {
@@ -292,40 +254,25 @@ pub fn configure(arg: ConfigureArguments) {
     with_state_mut(|s| s.configure(arg))
 }
 
-pub fn can(permission: Permission) -> Result<(), String> {
-    with_state(|s| {
-        s.can(&msg_caller(), &permission)
-            .then_some(())
-            .ok_or_else(|| format!("Caller does not have {permission} permission"))
-    })
-}
-
-pub fn can_commit() -> Result<(), String> {
-    can(Permission::Commit)
-}
-
-pub fn can_prepare() -> Result<(), String> {
-    can(Permission::Prepare)
-}
-
-pub fn has_permission_or_is_controller(permission: &Permission) -> Result<(), String> {
+/// Whether the current caller may sync assets: either in the authorized set, or
+/// a canister controller. The authorized set holds only the extra (non-controller)
+/// principals — controllers are always allowed without being stored.
+pub fn can_sync() -> bool {
     let caller = msg_caller();
-    let has_permission = with_state(|s| s.has_permission(&caller, permission));
-    let is_controller = ic_cdk::api::is_controller(&caller);
-    if has_permission || is_controller {
+    with_state(|s| s.is_authorized(&caller)) || ic_cdk::api::is_controller(&caller)
+}
+
+/// `#[update(guard = ...)]` guard over every asset-sync operation.
+pub fn guard_can_sync() -> Result<(), String> {
+    if can_sync() {
         Ok(())
     } else {
-        Err(format!(
-            "Caller does not have {permission} permission and is not a controller."
-        ))
+        Err("Caller is not authorized to sync assets and is not a controller.".to_string())
     }
 }
 
-pub fn is_manager_or_controller() -> Result<(), String> {
-    has_permission_or_is_controller(&Permission::ManagePermissions)
-}
-
-pub fn is_controller() -> Result<(), String> {
+/// `#[update(guard = ...)]` guard restricting a call to canister controllers.
+pub fn guard_is_controller() -> Result<(), String> {
     let caller = msg_caller();
     if ic_cdk::api::is_controller(&caller) {
         Ok(())
@@ -335,22 +282,18 @@ pub fn is_controller() -> Result<(), String> {
 }
 
 pub fn init(args: Option<AssetCanisterArgs>) {
-    with_state_mut(|s| {
-        s.clear();
-        s.grant_permission(msg_caller(), &Permission::Commit);
-    });
-
-    if let Some(upgrade_arg) = args {
-        let AssetCanisterArgs::Init(init_args) = upgrade_arg else {
-            ic_cdk::trap(
-                "Cannot initialize the canister with an Upgrade argument. Please provide an Init argument.",
-            )
-        };
-        with_state_mut(|s| {
-            if let Some(set_permissions) = init_args.set_permissions {
-                s.set_permissions(set_permissions);
-            }
-        });
+    with_state_mut(|s| s.clear());
+    match args {
+        // No args: the authorized set starts empty. Controllers can still sync;
+        // this set is only for granting sync access to *non*-controllers.
+        None => {}
+        // Explicit args set the authorized set exactly (empty = no principals).
+        Some(AssetCanisterArgs::Init(InitArgs { authorized })) => {
+            with_state_mut(|s| s.set_authorized(authorized))
+        }
+        Some(AssetCanisterArgs::Upgrade(_)) => ic_cdk::trap(
+            "Cannot initialize the canister with an Upgrade argument. Please provide an Init argument.",
+        ),
     }
 }
 
@@ -359,16 +302,21 @@ pub fn pre_upgrade() -> StableState {
 }
 
 pub fn post_upgrade(stable_state: StableState, args: Option<AssetCanisterArgs>) {
-    let set_permissions = args.and_then(|args| {
-        let AssetCanisterArgs::Upgrade(UpgradeArgs { set_permissions }) = args else {ic_cdk::trap("Cannot upgrade the canister with an Init argument. Please provide an Upgrade argument.")};
-        set_permissions
-    });
+    // No upgrade args leaves the restored authorized set untouched; explicit
+    // args replace it (an empty vector clears it).
+    let authorized = match args {
+        None => None,
+        Some(AssetCanisterArgs::Upgrade(UpgradeArgs { authorized })) => Some(authorized),
+        Some(AssetCanisterArgs::Init(_)) => ic_cdk::trap(
+            "Cannot upgrade the canister with an Init argument. Please provide an Upgrade argument.",
+        ),
+    };
 
     with_state_mut(|s| {
         *s = State::from(stable_state);
         certified_data_set(s.root_hash());
-        if let Some(set_permissions) = set_permissions {
-            s.set_permissions(set_permissions);
+        if let Some(authorized) = authorized {
+            s.set_authorized(authorized);
         }
     });
 }

--- a/crates/canister-core/src/stable.rs
+++ b/crates/canister-core/src/stable.rs
@@ -11,8 +11,7 @@ use crate::{
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StableState {
-    pub(crate) authorized: Vec<Principal>, // ignored if permissions is Some(_)
-    pub(crate) permissions: Option<StableStatePermissions>,
+    pub(crate) authorized: BTreeSet<Principal>,
     pub(crate) stable_assets: HashMap<String, StableAsset>,
 
     pub(crate) next_batch_id: Option<u64>,
@@ -27,14 +26,8 @@ pub struct StableState {
 
 impl From<crate::state::State> for StableState {
     fn from(state: crate::state::State) -> Self {
-        let permissions = StableStatePermissions {
-            commit: state.commit_principals,
-            prepare: state.prepare_principals,
-            manage_permissions: state.manage_permissions_principals,
-        };
         Self {
-            authorized: vec![],
-            permissions: Some(permissions),
+            authorized: state.authorized,
             stable_assets: state
                 .assets
                 .into_iter()
@@ -46,13 +39,6 @@ impl From<crate::state::State> for StableState {
             redirect_rules: Some(state.redirect_rules),
         }
     }
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct StableStatePermissions {
-    pub(crate) commit: BTreeSet<Principal>,
-    pub(crate) prepare: BTreeSet<Principal>,
-    pub(crate) manage_permissions: BTreeSet<Principal>,
 }
 
 /// Same as [crate::state::Configuration] but serde-serializable

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -88,11 +88,6 @@ impl State {
         self.authorized.remove(principal);
     }
 
-    /// Replaces the entire authorized set. Used by init/upgrade args.
-    pub fn set_authorized(&mut self, principals: Vec<Principal>) {
-        self.authorized = principals.into_iter().collect();
-    }
-
     pub fn list_authorized(&self) -> &BTreeSet<Principal> {
         &self.authorized
     }

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -54,10 +54,10 @@ pub struct State {
     pub(crate) batches: HashMap<BatchId, Batch>,
     pub(crate) next_batch_id: BatchId,
 
-    // permissions
-    pub(crate) commit_principals: BTreeSet<Principal>,
-    pub(crate) prepare_principals: BTreeSet<Principal>,
-    pub(crate) manage_permissions_principals: BTreeSet<Principal>,
+    // Principals authorized to sync assets. Canister controllers are always
+    // allowed regardless of membership; this set grants the same access to
+    // non-controllers. Only controllers can change it.
+    pub(crate) authorized: BTreeSet<Principal>,
 
     pub(crate) asset_hashes: CertifiedResponses,
 
@@ -80,39 +80,25 @@ impl State {
             .ok_or_else(|| "asset not found".to_string())
     }
 
-    pub fn set_permissions(
-        &mut self,
-        SetPermissions {
-            prepare,
-            commit,
-            manage_permissions,
-        }: SetPermissions,
-    ) {
-        *self.get_mut_permission_list(&Permission::Prepare) = prepare.into_iter().collect();
-        *self.get_mut_permission_list(&Permission::Commit) = commit.into_iter().collect();
-        *self.get_mut_permission_list(&Permission::ManagePermissions) =
-            manage_permissions.into_iter().collect();
+    pub fn authorize(&mut self, principal: Principal) {
+        self.authorized.insert(principal);
     }
 
-    pub fn grant_permission(&mut self, principal: Principal, permission: &Permission) {
-        let permitted = self.get_mut_permission_list(permission);
-        permitted.insert(principal);
+    pub fn deauthorize(&mut self, principal: &Principal) {
+        self.authorized.remove(principal);
     }
 
-    pub fn revoke_permission(&mut self, principal: Principal, permission: &Permission) {
-        let permitted = self.get_mut_permission_list(permission);
-        permitted.remove(&principal);
+    /// Replaces the entire authorized set. Used by init/upgrade args.
+    pub fn set_authorized(&mut self, principals: Vec<Principal>) {
+        self.authorized = principals.into_iter().collect();
     }
 
-    pub fn list_permitted(&self, permission: &Permission) -> &BTreeSet<Principal> {
-        self.get_permission_list(permission)
+    pub fn list_authorized(&self) -> &BTreeSet<Principal> {
+        &self.authorized
     }
 
-    pub fn take_ownership(&mut self, controller: Principal) {
-        self.commit_principals.clear();
-        self.prepare_principals.clear();
-        self.manage_permissions_principals.clear();
-        self.commit_principals.insert(controller);
+    pub fn is_authorized(&self, principal: &Principal) -> bool {
+        self.authorized.contains(principal)
     }
 
     pub fn root_hash(&self) -> Hash {
@@ -246,33 +232,6 @@ impl State {
         self.chunks.clear();
         self.next_batch_id = Nat::from(1_u8);
         self.next_chunk_id = Nat::from(1_u8);
-    }
-
-    pub fn has_permission(&self, principal: &Principal, permission: &Permission) -> bool {
-        let list = self.get_permission_list(permission);
-        list.contains(principal)
-    }
-
-    pub fn can(&self, principal: &Principal, permission: &Permission) -> bool {
-        self.has_permission(principal, permission)
-            || (*permission == Permission::Prepare
-                && self.has_permission(principal, &Permission::Commit))
-    }
-
-    fn get_permission_list(&self, permission: &Permission) -> &BTreeSet<Principal> {
-        match permission {
-            Permission::Commit => &self.commit_principals,
-            Permission::Prepare => &self.prepare_principals,
-            Permission::ManagePermissions => &self.manage_permissions_principals,
-        }
-    }
-
-    fn get_mut_permission_list(&mut self, permission: &Permission) -> &mut BTreeSet<Principal> {
-        match permission {
-            Permission::Commit => &mut self.commit_principals,
-            Permission::Prepare => &mut self.prepare_principals,
-            Permission::ManagePermissions => &mut self.manage_permissions_principals,
-        }
     }
 
     pub fn retrieve(&self, key: &AssetKey) -> Result<RcBytes, String> {
@@ -826,24 +785,8 @@ impl State {
 
 impl From<StableState> for State {
     fn from(stable_state: StableState) -> Self {
-        let (commit_principals, prepare_principals, manage_permissions_principals) =
-            if let Some(permissions) = stable_state.permissions {
-                (
-                    permissions.commit,
-                    permissions.prepare,
-                    permissions.manage_permissions,
-                )
-            } else {
-                (
-                    stable_state.authorized.into_iter().collect(),
-                    BTreeSet::new(),
-                    BTreeSet::new(),
-                )
-            };
         let mut state = Self {
-            commit_principals,
-            prepare_principals,
-            manage_permissions_principals,
+            authorized: stable_state.authorized,
             assets: stable_state
                 .stable_assets
                 .into_iter()

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -775,22 +775,6 @@ fn authorize_and_deauthorize_toggle_membership() {
 }
 
 #[test]
-fn set_authorized_replaces_the_whole_set() {
-    let mut state = State::default();
-    let a = some_principal();
-    let b = Principal::from_text("aaaaa-aa").unwrap();
-
-    state.authorize(a);
-    state.set_authorized(vec![b]);
-
-    assert!(
-        !state.is_authorized(&a),
-        "set_authorized should replace, not merge"
-    );
-    assert!(state.is_authorized(&b));
-}
-
-#[test]
 fn authorized_set_survives_stable_roundtrip() {
     let mut state = State::default();
     let p = some_principal();

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -678,8 +678,7 @@ fn old_stable_assets_with_is_aliased_load_cleanly() {
         },
     );
     let stable_state = StableState {
-        authorized: vec![],
-        permissions: None,
+        authorized: Default::default(),
         stable_assets,
         next_batch_id: None,
         configuration: None,
@@ -750,6 +749,57 @@ fn preserves_state_on_stable_roundtrip() {
     );
     assert_eq!(response.status_code, 200);
     assert_eq!(response.body.as_ref(), INDEX_BODY);
+}
+
+#[test]
+fn authorize_and_deauthorize_toggle_membership() {
+    let mut state = State::default();
+    let p = some_principal();
+
+    assert!(!state.is_authorized(&p));
+
+    state.authorize(p);
+    assert!(state.is_authorized(&p));
+    assert_eq!(
+        state.list_authorized().iter().copied().collect::<Vec<_>>(),
+        vec![p]
+    );
+
+    // Re-authorizing is idempotent (set semantics).
+    state.authorize(p);
+    assert_eq!(state.list_authorized().len(), 1);
+
+    state.deauthorize(&p);
+    assert!(!state.is_authorized(&p));
+    assert!(state.list_authorized().is_empty());
+}
+
+#[test]
+fn set_authorized_replaces_the_whole_set() {
+    let mut state = State::default();
+    let a = some_principal();
+    let b = Principal::from_text("aaaaa-aa").unwrap();
+
+    state.authorize(a);
+    state.set_authorized(vec![b]);
+
+    assert!(
+        !state.is_authorized(&a),
+        "set_authorized should replace, not merge"
+    );
+    assert!(state.is_authorized(&b));
+}
+
+#[test]
+fn authorized_set_survives_stable_roundtrip() {
+    let mut state = State::default();
+    let p = some_principal();
+    state.authorize(p);
+
+    let stable_state: StableState = state.into();
+    let restored: State = stable_state.into();
+
+    assert!(restored.is_authorized(&p));
 }
 
 #[test]

--- a/crates/canister-core/src/types.rs
+++ b/crates/canister-core/src/types.rs
@@ -154,40 +154,6 @@ pub struct SetAssetPropertiesArguments {
     pub is_aliased: Option<Option<bool>>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, CandidType, Deserialize)]
-pub enum Permission {
-    Commit,
-    ManagePermissions,
-    Prepare,
-}
-
-impl std::fmt::Display for Permission {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match *self {
-            Permission::Commit => f.write_str("Commit"),
-            Permission::Prepare => f.write_str("Prepare"),
-            Permission::ManagePermissions => f.write_str("ManagePermissions"),
-        }
-    }
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct GrantPermissionArguments {
-    pub to_principal: Principal,
-    pub permission: Permission,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct RevokePermissionArguments {
-    pub of_principal: Principal,
-    pub permission: Permission,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct ListPermittedArguments {
-    pub permission: Permission,
-}
-
 #[derive(Clone, Debug, Default, CandidType, Deserialize)]
 pub struct ListRequest {
     pub start: Option<Nat>,
@@ -204,18 +170,15 @@ pub enum AssetCanisterArgs {
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct InitArgs {
-    pub set_permissions: Option<SetPermissions>,
+    /// The authorized set: extra (non-controller) principals allowed to sync.
+    /// Defaults to empty when no init args are given; controllers can always
+    /// sync regardless.
+    pub authorized: Vec<Principal>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct UpgradeArgs {
-    pub set_permissions: Option<SetPermissions>,
-}
-
-/// Sets the list of principals with a certain permission for every permission that is `Some`.
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct SetPermissions {
-    pub prepare: Vec<Principal>,
-    pub commit: Vec<Principal>,
-    pub manage_permissions: Vec<Principal>,
+    /// Replaces the authorized set; an empty vector clears it. Pass no upgrade
+    /// args at all to leave the existing set untouched.
+    pub authorized: Vec<Principal>,
 }

--- a/crates/canister-core/src/types.rs
+++ b/crates/canister-core/src/types.rs
@@ -3,7 +3,7 @@
 use crate::certification::AssetKey;
 use crate::rc_bytes::RcBytes;
 use crate::redirect::RedirectRule;
-use candid::{CandidType, Deserialize, Nat, Principal};
+use candid::{CandidType, Deserialize, Nat};
 use serde_bytes::ByteBuf;
 
 pub type BatchId = Nat;
@@ -158,27 +158,4 @@ pub struct SetAssetPropertiesArguments {
 pub struct ListRequest {
     pub start: Option<Nat>,
     pub length: Option<Nat>,
-}
-
-/// The argument to `init` and `post_upgrade` needs to have the same argument type by definition.
-/// `AssetCanisterArgs` is there so that the two functions can take different argument types.
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub enum AssetCanisterArgs {
-    Init(InitArgs),
-    Upgrade(UpgradeArgs),
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct InitArgs {
-    /// The authorized set: extra (non-controller) principals allowed to sync.
-    /// Defaults to empty when no init args are given; controllers can always
-    /// sync regardless.
-    pub authorized: Vec<Principal>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct UpgradeArgs {
-    /// Replaces the authorized set; an empty vector clears it. Pass no upgrade
-    /// args at all to leave the existing set untouched.
-    pub authorized: Vec<Principal>,
 }

--- a/crates/canister/assets.did
+++ b/crates/canister/assets.did
@@ -136,25 +136,7 @@ type StateInfo = record {
   state_hash: opt text;
 };
 
-type AssetCanisterArgs = variant {
-  Init: InitArgs;
-  Upgrade: UpgradeArgs;
-};
-
-/// `authorized` is the set of extra (non-controller) principals allowed to
-/// sync; an empty vector (or no init args at all) means none. Controllers can
-/// always sync regardless.
-type InitArgs = record {
-  authorized: vec principal;
-};
-
-/// `authorized` replaces the authorized set; an empty vector clears it. Pass no
-/// upgrade args at all to leave the existing set untouched.
-type UpgradeArgs = record {
-  authorized: vec principal;
-};
-
-service: (asset_canister_args: opt AssetCanisterArgs) -> {
+service: () -> {
   // ───────── Canister metadata ─────────
 
   api_version: () -> (nat16) query;

--- a/crates/canister/assets.did
+++ b/crates/canister/assets.did
@@ -136,40 +136,22 @@ type StateInfo = record {
   state_hash: opt text;
 };
 
-type Permission = variant {
-  Commit;
-  ManagePermissions;
-  Prepare;
-};
-
-type GrantPermission = record {
-  to_principal: principal;
-  permission: Permission;
-};
-type RevokePermission = record {
-  of_principal: principal;
-  permission: Permission;
-};
-type ListPermitted = record { permission: Permission };
-
 type AssetCanisterArgs = variant {
   Init: InitArgs;
   Upgrade: UpgradeArgs;
 };
 
+/// `authorized` is the set of extra (non-controller) principals allowed to
+/// sync; an empty vector (or no init args at all) means none. Controllers can
+/// always sync regardless.
 type InitArgs = record {
-  set_permissions: opt SetPermissions;
+  authorized: vec principal;
 };
 
+/// `authorized` replaces the authorized set; an empty vector clears it. Pass no
+/// upgrade args at all to leave the existing set untouched.
 type UpgradeArgs = record {
-  set_permissions: opt SetPermissions;
-};
-
-/// Sets the list of principals granted each permission.
-type SetPermissions = record {
-  prepare: vec principal;
-  commit: vec principal;
-  manage_permissions: vec principal;
+  authorized: vec principal;
 };
 
 service: (asset_canister_args: opt AssetCanisterArgs) -> {
@@ -266,15 +248,16 @@ service: (asset_canister_args: opt AssetCanisterArgs) -> {
   // Delete a batch that has been created but not yet committed
   delete_batch: (DeleteBatchArguments) -> ();
 
-  // ───────── Permissions ─────────
+  // ───────── Authorization ─────────
+  // A set of extra principals authorized to sync assets. Canister controllers
+  // are always authorized (without being listed) and are the only callers that
+  // can change this set.
 
   authorize: (principal) -> ();
   deauthorize: (principal) -> ();
-  grant_permission: (GrantPermission) -> ();
-  revoke_permission: (RevokePermission) -> ();
-  take_ownership: () -> ();
   list_authorized: () -> (vec principal);
-  list_permitted: (ListPermitted) -> (vec principal);
+  // Whether the calling identity may sync assets (authorized or a controller).
+  can_sync: () -> (bool) query;
 
   // ───────── Redirect rules ─────────
 

--- a/crates/canister/src/lib.rs
+++ b/crates/canister/src/lib.rs
@@ -3,10 +3,9 @@ mod state;
 use candid::Principal;
 use canister_core::{
     asset::{AssetDetails, EncodedAsset},
-    can_commit, can_prepare,
     certification::AssetKey,
+    guard_can_sync, guard_is_controller,
     http::{HttpRequest, HttpResponse, StreamingCallbackHttpResponse, StreamingCallbackToken},
-    is_controller, is_manager_or_controller,
     rc_bytes::RcBytes,
     redirect::RedirectRule,
     state::CertifiedTree,
@@ -14,8 +13,7 @@ use canister_core::{
         AssetCanisterArgs, AssetProperties, CommitBatchArguments, ConfigurationResponse,
         ConfigureArguments, CreateAssetArguments, CreateBatchResponse, CreateChunksArg,
         CreateChunksResponse, DeleteAssetArguments, DeleteBatchArguments, GetArg, GetChunkArg,
-        GetChunkResponse, GrantPermissionArguments, ListPermittedArguments, ListRequest,
-        RevokePermissionArguments, SetAssetContentArguments, SetAssetPropertiesArguments,
+        GetChunkResponse, ListRequest, SetAssetContentArguments, SetAssetPropertiesArguments,
         StateInfo, StoreArg, UnsetAssetContentArguments,
     },
 };
@@ -106,24 +104,14 @@ fn get_redirect_rules() -> Vec<RedirectRule> {
 
 // Update methods
 
-#[update(guard = "is_manager_or_controller")]
-fn authorize(other: Principal) {
-    canister_core::authorize(other)
+#[update(guard = "guard_is_controller")]
+fn authorize(principal: Principal) {
+    canister_core::authorize(principal)
 }
 
-#[update(guard = "is_manager_or_controller")]
-fn grant_permission(arg: GrantPermissionArguments) {
-    canister_core::grant_permission(arg)
-}
-
-#[update]
-async fn deauthorize(other: Principal) {
-    canister_core::deauthorize(other).await
-}
-
-#[update]
-async fn revoke_permission(arg: RevokePermissionArguments) {
-    canister_core::revoke_permission(arg).await
+#[update(guard = "guard_is_controller")]
+fn deauthorize(principal: Principal) {
+    canister_core::deauthorize(principal)
 }
 
 #[update]
@@ -131,57 +119,54 @@ fn list_authorized() -> Vec<Principal> {
     canister_core::list_authorized()
 }
 
-#[update]
-fn list_permitted(arg: ListPermittedArguments) -> Vec<Principal> {
-    canister_core::list_permitted(arg)
+// Whether the calling identity may sync assets (authorized or a controller).
+// Lets a client check access up front instead of discovering it mid-sync.
+#[query]
+fn can_sync() -> bool {
+    canister_core::can_sync()
 }
 
-#[update(guard = "is_controller")]
-async fn take_ownership() {
-    canister_core::take_ownership().await
-}
-
-#[update(guard = "can_commit")]
+#[update(guard = "guard_can_sync")]
 fn store(arg: StoreArg) {
     canister_core::store(arg)
 }
 
-#[update(guard = "can_prepare")]
+#[update(guard = "guard_can_sync")]
 fn create_batch() -> CreateBatchResponse {
     canister_core::create_batch()
 }
 
-#[update(guard = "can_prepare")]
+#[update(guard = "guard_can_sync")]
 fn create_chunks(arg: CreateChunksArg) -> CreateChunksResponse {
     canister_core::create_chunks(arg)
 }
 
-#[update(guard = "can_commit")]
+#[update(guard = "guard_can_sync")]
 fn create_asset(arg: CreateAssetArguments) {
     canister_core::create_asset(arg)
 }
 
-#[update(guard = "can_commit")]
+#[update(guard = "guard_can_sync")]
 fn set_asset_content(arg: SetAssetContentArguments) {
     canister_core::set_asset_content(arg)
 }
 
-#[update(guard = "can_commit")]
+#[update(guard = "guard_can_sync")]
 fn unset_asset_content(arg: UnsetAssetContentArguments) {
     canister_core::unset_asset_content(arg)
 }
 
-#[update(guard = "can_commit")]
+#[update(guard = "guard_can_sync")]
 fn delete_asset(arg: DeleteAssetArguments) {
     canister_core::delete_asset(arg)
 }
 
-#[update(guard = "can_commit")]
+#[update(guard = "guard_can_sync")]
 fn clear() {
     canister_core::clear()
 }
 
-#[update(guard = "can_commit")]
+#[update(guard = "guard_can_sync")]
 async fn commit_batch(arg: CommitBatchArguments) {
     canister_core::commit_batch(arg).await
 }
@@ -191,22 +176,22 @@ async fn compute_state_hash() -> Option<String> {
     canister_core::compute_state_hash().await
 }
 
-#[update(guard = "can_prepare")]
+#[update(guard = "guard_can_sync")]
 fn delete_batch(arg: DeleteBatchArguments) {
     canister_core::delete_batch(arg)
 }
 
-#[update(guard = "can_commit")]
+#[update(guard = "guard_can_sync")]
 fn set_asset_properties(arg: SetAssetPropertiesArguments) {
     canister_core::set_asset_properties(arg)
 }
 
-#[update(guard = "can_prepare")]
+#[update(guard = "guard_can_sync")]
 fn get_configuration() -> ConfigurationResponse {
     canister_core::get_configuration()
 }
 
-#[update(guard = "can_commit")]
+#[update(guard = "guard_can_sync")]
 fn configure(arg: ConfigureArguments) {
     canister_core::configure(arg)
 }

--- a/crates/canister/src/lib.rs
+++ b/crates/canister/src/lib.rs
@@ -10,11 +10,11 @@ use canister_core::{
     redirect::RedirectRule,
     state::CertifiedTree,
     types::{
-        AssetCanisterArgs, AssetProperties, CommitBatchArguments, ConfigurationResponse,
-        ConfigureArguments, CreateAssetArguments, CreateBatchResponse, CreateChunksArg,
-        CreateChunksResponse, DeleteAssetArguments, DeleteBatchArguments, GetArg, GetChunkArg,
-        GetChunkResponse, ListRequest, SetAssetContentArguments, SetAssetPropertiesArguments,
-        StateInfo, StoreArg, UnsetAssetContentArguments,
+        AssetProperties, CommitBatchArguments, ConfigurationResponse, ConfigureArguments,
+        CreateAssetArguments, CreateBatchResponse, CreateChunksArg, CreateChunksResponse,
+        DeleteAssetArguments, DeleteBatchArguments, GetArg, GetChunkArg, GetChunkResponse,
+        ListRequest, SetAssetContentArguments, SetAssetPropertiesArguments, StateInfo, StoreArg,
+        UnsetAssetContentArguments,
     },
 };
 use ic_cdk::{init, post_upgrade, pre_upgrade, query, update};
@@ -22,8 +22,8 @@ use ic_cdk::{init, post_upgrade, pre_upgrade, query, update};
 use crate::state::{load_stable_state, save_stable_state};
 
 #[init]
-fn init(args: Option<AssetCanisterArgs>) {
-    canister_core::init(args);
+fn init() {
+    canister_core::init();
 }
 
 #[pre_upgrade]
@@ -33,9 +33,9 @@ fn pre_upgrade() {
 }
 
 #[post_upgrade]
-fn post_upgrade(args: Option<AssetCanisterArgs>) {
+fn post_upgrade() {
     let stable_state = load_stable_state().expect("failed to deserialize stable state");
-    canister_core::post_upgrade(stable_state, args);
+    canister_core::post_upgrade(stable_state);
 }
 
 #[cfg(target_family = "wasm")]

--- a/crates/sync-core/src/canister.rs
+++ b/crates/sync-core/src/canister.rs
@@ -104,13 +104,6 @@ pub struct AssetProperties {
     pub allow_raw_access: Option<bool>,
 }
 
-#[derive(CandidType, Clone, Debug, Deserialize)]
-pub enum Permission {
-    Commit,
-    ManagePermissions,
-    Prepare,
-}
-
 #[derive(CandidType, Debug)]
 struct ListAssetsRequest {
     start: Option<Nat>,
@@ -134,17 +127,6 @@ struct CreateChunksRequest<'a> {
 #[derive(CandidType, Debug, Deserialize)]
 struct CreateChunksResponse {
     chunk_ids: Vec<Nat>,
-}
-
-#[derive(CandidType, Debug)]
-struct ListPermittedArguments {
-    permission: Permission,
-}
-
-#[derive(CandidType, Debug)]
-struct GrantPermissionArguments {
-    to_principal: Principal,
-    permission: Permission,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -239,34 +221,16 @@ pub fn get_redirect_rules(c: &impl CanisterCall) -> Result<Vec<RedirectRule>, St
     c.call("get_redirect_rules", (), CallType::Query, true)
 }
 
-pub fn list_permitted(
-    c: &impl CanisterCall,
-    permission: Permission,
-) -> Result<Vec<Principal>, String> {
-    c.call(
-        "list_permitted",
-        ListPermittedArguments { permission },
-        CallType::Update,
-        true,
-    )
+// Whether the signing identity may sync assets (authorized or a controller).
+// Called directly (not via proxy) so it reflects the identity's own access.
+pub fn can_sync(c: &impl CanisterCall) -> Result<bool, String> {
+    c.call("can_sync", (), CallType::Query, true)
 }
 
 // Routes through the proxy (direct: false) so the proxy canister — the
 // controller — can authorise the call on the assets canister.
-pub fn grant_permission_via_proxy(
-    c: &impl CanisterCall,
-    to_principal: Principal,
-    permission: Permission,
-) -> Result<(), String> {
-    c.call(
-        "grant_permission",
-        GrantPermissionArguments {
-            to_principal,
-            permission,
-        },
-        CallType::Update,
-        false,
-    )
+pub fn authorize_via_proxy(c: &impl CanisterCall, principal: Principal) -> Result<(), String> {
+    c.call("authorize", principal, CallType::Update, false)
 }
 
 #[cfg(test)]

--- a/crates/sync-core/src/sync.rs
+++ b/crates/sync-core/src/sync.rs
@@ -9,11 +9,11 @@ use mime::Mime;
 use std::collections::HashMap;
 
 use crate::canister::{
-    api_version, commit_batch, create_batch, create_chunks, get_asset_properties,
-    get_redirect_rules, grant_permission_via_proxy, list_assets, list_permitted, AssetDetails,
-    AssetProperties, BatchOperationKind, CanisterCall, CommitBatchArguments, CreateAssetArguments,
-    DeleteAssetArguments, Permission, RedirectRule, SetAssetContentArguments,
-    SetAssetPropertiesArguments, SetRedirectRulesArguments, UnsetAssetContentArguments,
+    api_version, authorize_via_proxy, can_sync, commit_batch, create_batch, create_chunks,
+    get_asset_properties, get_redirect_rules, list_assets, AssetDetails, AssetProperties,
+    BatchOperationKind, CanisterCall, CommitBatchArguments, CreateAssetArguments,
+    DeleteAssetArguments, RedirectRule, SetAssetContentArguments, SetAssetPropertiesArguments,
+    SetRedirectRulesArguments, UnsetAssetContentArguments,
 };
 use crate::content::{encoders_for, Content, Encoder};
 use crate::headers::{self, HeaderRule, HEADERS_FILENAME};
@@ -39,29 +39,40 @@ struct ProjectAsset {
     encodings: HashMap<String, ProjectAssetEncoding>,
 }
 
-/// Ensures the signing identity has `Commit` permission on the assets canister.
+/// Ensures the signing identity can sync assets, before any expensive scanning
+/// or diffing work happens — so an unauthorized run fails fast instead of after
+/// reading and encoding the whole project.
 ///
-/// Called only in proxy mode. Queries the current `Commit` permission list and,
-/// if the identity is absent, routes a `grant_permission` call through the proxy
-/// canister. The proxy is the controller of the assets canister and can therefore
-/// authorise the grant even without holding `ManagePermissions` explicitly.
-fn ensure_commit_permission<C: CanisterCall>(
+/// Asks the canister whether the identity may sync (`can_sync`, which is true
+/// for authorized principals *and* controllers):
+/// - If it can, returns immediately.
+/// - In proxy mode, routes an `authorize` call through the proxy canister (the
+///   proxy is the canister's controller and the only caller allowed to change
+///   the authorized set), then the identity can sync directly.
+/// - In direct mode, there is no controller to grant through, so this fails
+///   fast.
+fn ensure_can_sync<C: CanisterCall>(
     canister: &C,
     identity_principal: &str,
+    proxy_mode: bool,
 ) -> Result<(), String> {
-    let principal = Principal::from_text(identity_principal)
-        .map_err(|e| format!("invalid identity principal '{identity_principal}': {e}"))?;
-
-    let permitted = list_permitted(canister, Permission::Commit)?;
-    if permitted.contains(&principal) {
-        println!("proxy mode: identity already has Commit permission");
+    if can_sync(canister)? {
         return Ok(());
     }
 
-    println!("proxy mode: granting Commit permission to {identity_principal} via proxy");
-    grant_permission_via_proxy(canister, principal, Permission::Commit)?;
-    println!("proxy mode: Commit permission granted");
-    Ok(())
+    if proxy_mode {
+        let principal = Principal::from_text(identity_principal)
+            .map_err(|e| format!("invalid identity principal '{identity_principal}': {e}"))?;
+        println!("proxy mode: authorizing {identity_principal} via proxy");
+        authorize_via_proxy(canister, principal)?;
+        println!("proxy mode: identity authorized");
+        Ok(())
+    } else {
+        Err(format!(
+            "identity {identity_principal} is not authorized to sync assets on this canister; \
+             a controller must authorize it (or deploy with --proxy to authorize it automatically)"
+        ))
+    }
 }
 
 pub fn sync<C: CanisterCall>(
@@ -85,9 +96,9 @@ pub fn sync<C: CanisterCall>(
         }
     };
 
-    if let Some(_proxy) = proxy_canister_id {
-        ensure_commit_permission(canister, identity_principal)?;
-    }
+    // Check authorization before any scanning or diffing so an unauthorized
+    // run fails fast rather than after reading and encoding the whole project.
+    ensure_can_sync(canister, identity_principal, proxy_canister_id.is_some())?;
 
     let version = api_version(canister)?;
     if version < 2 {
@@ -1541,6 +1552,7 @@ mod tests {
 
         let mock = SyncMock::new();
         mock.push_ok("api_version", 2u16);
+        mock.push_ok("can_sync", true);
         mock.push_ok("list", Vec::<AssetDetails>::new());
         mock.push_ok(
             "get_redirect_rules",
@@ -1579,6 +1591,7 @@ mod tests {
 
         let mock = SyncMock::new();
         mock.push_ok("api_version", 2u16);
+        mock.push_ok("can_sync", true);
         mock.push_ok("list", Vec::<AssetDetails>::new());
         mock.push_ok("get_redirect_rules", Vec::<RedirectRule>::new());
         mock.push_ok(
@@ -2117,18 +2130,19 @@ mod tests {
 
     // ---- Authorization tests ----
 
-    // Mock for ensure_commit_permission: handles list_permitted and grant_permission only.
+    // Mock for ensure_can_sync: handles can_sync and authorize only.
     struct PermissionMock {
-        permitted: Vec<Principal>,
-        // Tracks the `direct` flag for each grant_permission call.
-        grant_calls: RefCell<Vec<bool>>,
+        // What the canister's `can_sync` reports for the identity.
+        can_sync: bool,
+        // Tracks the `direct` flag for each authorize call.
+        authorize_calls: RefCell<Vec<bool>>,
     }
 
     impl PermissionMock {
-        fn new(permitted: Vec<Principal>) -> Self {
+        fn new(can_sync: bool) -> Self {
             Self {
-                permitted,
-                grant_calls: RefCell::new(vec![]),
+                can_sync,
+                authorize_calls: RefCell::new(vec![]),
             }
         }
     }
@@ -2140,13 +2154,12 @@ mod tests {
             R: CandidType + DeserializeOwned,
         {
             match method {
-                "list_permitted" => {
-                    let bytes =
-                        candid::encode_one(self.permitted.clone()).map_err(|e| e.to_string())?;
+                "can_sync" => {
+                    let bytes = candid::encode_one(self.can_sync).map_err(|e| e.to_string())?;
                     candid::decode_one(&bytes).map_err(|e| e.to_string())
                 }
-                "grant_permission" => {
-                    self.grant_calls.borrow_mut().push(direct);
+                "authorize" => {
+                    self.authorize_calls.borrow_mut().push(direct);
                     let bytes = candid::encode_one(()).map_err(|e| e.to_string())?;
                     candid::decode_one(&bytes).map_err(|e| e.to_string())
                 }
@@ -2206,23 +2219,43 @@ mod tests {
         }
     }
 
-    // Proxy mode: identity absent from Commit list → grant_permission called via proxy.
+    // Proxy mode: identity cannot sync yet → authorize called via proxy.
     #[test]
-    fn ensure_commit_permission_grants_via_proxy_when_absent() {
+    fn ensure_can_sync_grants_via_proxy_when_absent() {
         let identity = Principal::anonymous();
-        let mock = PermissionMock::new(vec![]);
-        ensure_commit_permission(&mock, &identity.to_text()).unwrap();
-        // grant_permission must be called exactly once with direct=false (routed via proxy).
-        assert_eq!(*mock.grant_calls.borrow(), vec![false]);
+        let mock = PermissionMock::new(false);
+        ensure_can_sync(&mock, &identity.to_text(), true).unwrap();
+        // authorize must be called exactly once with direct=false (routed via proxy).
+        assert_eq!(*mock.authorize_calls.borrow(), vec![false]);
     }
 
-    // Proxy mode: identity already in Commit list → grant_permission not called.
+    // Proxy mode: identity can already sync → authorize not called.
     #[test]
-    fn ensure_commit_permission_skips_grant_when_already_permitted() {
+    fn ensure_can_sync_skips_grant_when_already_authorized() {
         let identity = Principal::anonymous();
-        let mock = PermissionMock::new(vec![identity]);
-        ensure_commit_permission(&mock, &identity.to_text()).unwrap();
-        assert!(mock.grant_calls.borrow().is_empty());
+        let mock = PermissionMock::new(true);
+        ensure_can_sync(&mock, &identity.to_text(), true).unwrap();
+        assert!(mock.authorize_calls.borrow().is_empty());
+    }
+
+    // Direct mode: identity can sync (authorized or a controller) → succeeds,
+    // no authorize call.
+    #[test]
+    fn ensure_can_sync_direct_mode_ok_when_can_sync() {
+        let identity = Principal::anonymous();
+        let mock = PermissionMock::new(true);
+        ensure_can_sync(&mock, &identity.to_text(), false).unwrap();
+        assert!(mock.authorize_calls.borrow().is_empty());
+    }
+
+    // Direct mode: identity cannot sync → fails fast (no proxy to grant through).
+    #[test]
+    fn ensure_can_sync_direct_mode_fails_fast_when_cannot_sync() {
+        let identity = Principal::anonymous();
+        let mock = PermissionMock::new(false);
+        let err = ensure_can_sync(&mock, &identity.to_text(), false).unwrap_err();
+        assert!(err.contains("not authorized"), "got: {err}");
+        assert!(mock.authorize_calls.borrow().is_empty());
     }
 
     #[test]
@@ -2267,6 +2300,7 @@ mod tests {
 
         let mock = SyncMock::new();
         mock.push_ok("api_version", 2u16);
+        mock.push_ok("can_sync", true);
         mock.push_ok(
             "list",
             vec![AssetDetails {
@@ -2313,6 +2347,7 @@ mod tests {
 
         let mock = SyncMock::new();
         mock.push_ok("api_version", 2u16);
+        mock.push_ok("can_sync", true);
         mock.push_ok("list", Vec::<AssetDetails>::new());
         mock.push_ok("get_redirect_rules", Vec::<RedirectRule>::new());
         mock.push_ok(
@@ -2413,6 +2448,7 @@ mod tests {
 
         let mock = SyncMock::new();
         mock.push_ok("api_version", 2u16);
+        mock.push_ok("can_sync", true);
         mock.push_ok(
             "list",
             vec![AssetDetails {
@@ -2445,18 +2481,24 @@ mod tests {
         assert!(result.is_ok(), "expected success, got: {result:?}");
     }
 
-    // Direct mode: canister rejects create_batch with a permission error → sync propagates it.
+    // Direct mode: identity passes the early authorization check, but a later
+    // create_batch failure (e.g. the authorized set changed under us) must
+    // still propagate.
     #[test]
-    fn sync_propagates_permission_error_from_create_batch() {
+    fn sync_propagates_error_from_create_batch() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("index.html"), b"<html></html>").unwrap();
 
         let mock = SyncMock::new();
         mock.push_ok("api_version", 2u16);
+        mock.push_ok("can_sync", true);
         // Empty canister → build_operations will produce work → create_batch is called.
         mock.push_ok("list", Vec::<AssetDetails>::new());
         mock.push_ok("get_redirect_rules", Vec::<RedirectRule>::new());
-        mock.push_err("create_batch", "Caller does not have Commit permission");
+        mock.push_err(
+            "create_batch",
+            "Caller is not authorized to sync assets and is not a controller.",
+        );
 
         let result = sync(
             &mock,
@@ -2467,8 +2509,31 @@ mod tests {
 
         let err = result.unwrap_err();
         assert!(
-            err.contains("Commit permission"),
-            "expected permission error, got: {err}"
+            err.contains("not authorized"),
+            "expected create_batch error to propagate, got: {err}"
         );
+    }
+
+    // Direct mode: identity absent from the authorized set → sync fails fast,
+    // before any local scanning or canister diffing.
+    #[test]
+    fn sync_fails_fast_when_identity_not_authorized_in_direct_mode() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), b"<html></html>").unwrap();
+
+        let mock = SyncMock::new();
+        // Only can_sync is programmed: if sync reached scanning/diffing (list,
+        // get_redirect_rules, …) SyncMock would panic on the unprogrammed
+        // method. can_sync=false means the identity cannot sync.
+        mock.push_ok("can_sync", false);
+
+        let err = sync(
+            &mock,
+            &[dir.path().to_str().unwrap().to_string()],
+            &Principal::anonymous().to_text(),
+            None,
+        )
+        .unwrap_err();
+        assert!(err.contains("not authorized"), "got: {err}");
     }
 }

--- a/crates/sync-core/tests/bench_sync.rs
+++ b/crates/sync-core/tests/bench_sync.rs
@@ -114,8 +114,9 @@ impl CanisterCall for BenchMock {
                 Encode!(&CreateChunksOk { chunk_ids: ids })
             }
             "commit_batch" => Encode!(&()),
-            "list_permitted" => Encode!(&Vec::<Principal>::new()),
-            "grant_permission" => Encode!(&()),
+            // The bench drives sync() in direct mode, which checks can_sync up
+            // front; report the identity as allowed so it proceeds.
+            "can_sync" => Encode!(&true),
             other => panic!("BenchMock: unexpected method '{other}'"),
         }
         .map_err(|e| e.to_string())?;


### PR DESCRIPTION
## Summary

Simplifies the canister's permission model down to two rules and removes the install-time arguments that configured it.

### Permission model (`14d6ac2`)
Replaces the three-level model (Commit/Prepare/ManagePermissions) with:
- **Controllers can do anything.**
- A single **authorized** set of *non-controller* principals may sync assets; only controllers can change it. Controllers are always allowed without being stored.

Canister changes:
- Drop the `Permission` enum and `grant_permission`/`revoke_permission`/`list_permitted`/`take_ownership`; keep `authorize`/`deauthorize`/`list_authorized`.
- Collapse the `can_commit`/`can_prepare` guards into one `guard_can_sync`; set management is guarded by `guard_is_controller`.
- Add a `can_sync` query so a caller can check its own access up front.
- Drop the legacy `StableStatePermissions` blob; stable state stores one authorized set.

Sync plugin:
- `ensure_can_sync` runs before any scan/diff and uses `can_sync`, so an unauthorized run fails fast. Proxy mode grants via the proxy; direct mode errors. Controllers are no longer falsely blocked.

### Drop install args (`3cf7f7c`)
Removes `AssetCanisterArgs`/`InitArgs`/`UpgradeArgs` entirely. The canister now installs with **no args**; the authorized set is managed exclusively through the controller-guarded `authorize`/`deauthorize` endpoints.
- `init()` clears state; `post_upgrade(stable_state)` restores it untouched.
- Drop the Init-vs-Upgrade trap branches and `State::set_authorized` (which only existed to apply the args).
- Service signature becomes `service: () -> {`.

## Testing
- `cargo test -p canister-core` — passes
- `cargo test -p sync-core` — passes
- `candid_interface_compatibility` — exported interface matches `assets.did`
- `cargo test -p e2e` — full suite passes (live deploy with no install args)
- `cargo clippy` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)