### PR TITLE
refactor: remove allow_raw_access

### DIFF
--- a/crates/canister-core/src/asset.rs
+++ b/crates/canister-core/src/asset.rs
@@ -117,7 +117,6 @@ pub struct Asset {
     pub encodings: HashMap<String, AssetEncoding>,
     pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
-    pub allow_raw_access: Option<bool>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
@@ -136,7 +135,6 @@ pub struct AssetDetails {
     pub encodings: Vec<AssetEncodingDetails>,
     pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
-    pub allow_raw_access: Option<bool>,
     pub is_aliased: Option<bool>,
 }
 
@@ -149,10 +147,6 @@ pub struct AssetEncodingDetails {
 }
 
 impl Asset {
-    pub fn allow_raw_access(&self) -> bool {
-        self.allow_raw_access.unwrap_or(true)
-    }
-
     fn update_ic_certificate_expressions(&mut self) {
         // gather all headers
         let mut headers: Vec<(String, Value)> = vec![];

--- a/crates/canister-core/src/http.rs
+++ b/crates/canister-core/src/http.rs
@@ -5,8 +5,6 @@ use crate::rc_bytes::RcBytes;
 use candid::{define_function, CandidType, Deserialize, Nat};
 use serde_bytes::ByteBuf;
 
-const HTTP_REDIRECT_PERMANENT: u16 = 308;
-
 pub type HeaderField = (String, String);
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
@@ -79,53 +77,6 @@ impl HttpRequest {
             None => &self.url[..],
         }
     }
-
-    pub fn get_header_value(&self, header_key: &str) -> Option<&String> {
-        self.headers
-            .iter()
-            .find_map(|(k, v)| k.eq_ignore_ascii_case(header_key).then_some(v))
-    }
-
-    pub fn redirect_from_raw_to_certified_domain(&self) -> HttpResponse {
-        #[cfg(not(test))]
-        let canister_id = ic_cdk::api::canister_self().to_text();
-        #[cfg(test)]
-        let canister_id = self.get_canister_id();
-
-        let location = match self.get_header_value("Host") {
-            Some(host_header) if host_header.ends_with("ic0.app") => {
-                format!("https://{canister_id}.ic0.app{path}", path = self.url)
-            }
-            _ => format!("https://{canister_id}.icp0.io{path}", path = self.url),
-        };
-        HttpResponse::build_redirect(HTTP_REDIRECT_PERMANENT, location)
-    }
-
-    #[cfg(test)]
-    pub fn get_canister_id(&self) -> &str {
-        if let Some(host_header) = self.get_header_value("Host") {
-            if host_header.contains(".localhost")
-                || host_header.contains(".io")
-                || host_header.contains(".app")
-            {
-                return host_header.split('.').next().unwrap();
-            } else if let Some(t) = self.url.split("canisterId=").nth(1) {
-                let x = t.split_once('&');
-                if let Some(c) = x {
-                    return c.0;
-                }
-            }
-        }
-        unreachable!()
-    }
-
-    pub fn is_raw_domain(&self) -> bool {
-        if let Some(host_header) = self.get_header_value("Host") {
-            host_header.contains(".raw.ic")
-        } else {
-            false
-        }
-    }
 }
 
 impl HttpResponse {
@@ -158,16 +109,6 @@ impl HttpResponse {
             status_code: 404,
             headers: vec![("content-type".to_string(), "text/plain".to_string())],
             body: RcBytes::from(ByteBuf::from("not found")),
-            upgrade: None,
-            streaming_strategy: None,
-        }
-    }
-
-    pub fn build_redirect(status_code: u16, location: String) -> HttpResponse {
-        HttpResponse {
-            status_code,
-            headers: vec![("Location".to_string(), location)],
-            body: RcBytes::from(ByteBuf::default()),
             upgrade: None,
             streaming_strategy: None,
         }

--- a/crates/canister-core/src/stable.rs
+++ b/crates/canister-core/src/stable.rs
@@ -82,7 +82,6 @@ pub struct StableAsset {
     pub headers: Option<Vec<(String, String)>>,
     #[serde(default)]
     pub is_aliased: Option<bool>,
-    pub allow_raw_access: Option<bool>,
 }
 
 impl From<crate::asset::Asset> for StableAsset {
@@ -97,7 +96,6 @@ impl From<crate::asset::Asset> for StableAsset {
             max_age: asset.max_age,
             headers: asset.headers,
             is_aliased: None,
-            allow_raw_access: asset.allow_raw_access,
         }
     }
 }
@@ -113,7 +111,6 @@ impl From<StableAsset> for crate::asset::Asset {
                 .collect(),
             max_age: stable_asset.max_age,
             headers: stable_asset.headers,
-            allow_raw_access: stable_asset.allow_raw_access,
         }
     }
 }

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -120,7 +120,6 @@ impl State {
                 encodings: HashMap::new(),
                 max_age: arg.max_age,
                 headers: arg.headers,
-                allow_raw_access: arg.allow_raw_access,
             },
         );
         Ok(())
@@ -349,7 +348,6 @@ impl State {
                         encodings,
                         max_age: asset.max_age,
                         headers: asset.headers.clone(),
-                        allow_raw_access: asset.allow_raw_access,
                         is_aliased: None,
                     }
                 })
@@ -418,13 +416,9 @@ impl State {
         chunk_index: usize,
         callback: CallbackFunc,
         etags: Vec<Hash>,
-        req: HttpRequest,
     ) -> HttpResponse {
         // Asset at the requested path wins.
         if let Ok(asset) = self.get_asset(&path.into()) {
-            if !asset.allow_raw_access() && req.is_raw_domain() {
-                return req.redirect_from_raw_to_certified_domain();
-            }
             let (cert_header, _) = self.asset_hashes.witness_to_header(path, certificate);
             if let Some(response) = asset.build_http_response_for_encodings(
                 &requested_encodings,
@@ -443,18 +437,6 @@ impl State {
         for (idx, rule) in self.redirect_rules.iter().enumerate() {
             if !rule.matches(path) {
                 continue;
-            }
-            // Rules that borrow a body from a target asset (200 rewrite or
-            // 4xx custom error page) honor the target's `allow_raw_access`
-            // setting — checked even before the rule has a certified entry
-            // because the target may not yet have an encoding.
-            let borrows_from_target = matches!(rule.status, 200 | 404 | 410);
-            if borrows_from_target {
-                if let Some(target) = self.assets.get(&rule.to) {
-                    if !target.allow_raw_access() && req.is_raw_domain() {
-                        return req.redirect_from_raw_to_certified_domain();
-                    }
-                }
             }
             let Some(entry) = self
                 .rule_certified_entries
@@ -554,9 +536,7 @@ impl State {
         };
 
         match url_decode(path) {
-            Ok(path) => {
-                self.build_http_response(certificate, &path, encodings, 0, callback, etags, req)
-            }
+            Ok(path) => self.build_http_response(certificate, &path, encodings, 0, callback, etags),
             Err(err) => HttpResponse {
                 status_code: 400,
                 headers: vec![],
@@ -615,7 +595,6 @@ impl State {
         Ok(AssetProperties {
             max_age: asset.max_age,
             headers: asset.headers.clone(),
-            allow_raw_access: asset.allow_raw_access,
             is_aliased: None,
         })
     }
@@ -632,9 +611,6 @@ impl State {
         }
         if let Some(max_age) = arg.max_age {
             asset.max_age = max_age
-        }
-        if let Some(allow_raw_access) = arg.allow_raw_access {
-            asset.allow_raw_access = allow_raw_access
         }
 
         // `arg.is_aliased` is accepted for backward compatibility but ignored.

--- a/crates/canister-core/src/state_hash.rs
+++ b/crates/canister-core/src/state_hash.rs
@@ -86,7 +86,6 @@ fn next_step(
                 max_age: asset.max_age,
                 headers: asset.headers.clone(),
                 enable_aliasing: None,
-                allow_raw_access: asset.allow_raw_access,
             };
             hash_create_asset(&mut hasher, &args);
             let mut sorted_encoding_names: Vec<String> = asset.encodings.keys().cloned().collect();
@@ -185,7 +184,6 @@ fn hash_create_asset(hasher: &mut Sha256, args: &CreateAssetArguments) {
         hasher.update(TAG_NONE);
     }
     hash_headers(hasher, args.headers.as_ref());
-    hash_opt_bool(hasher, args.allow_raw_access);
     hash_opt_bool(hasher, args.enable_aliasing);
 }
 

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -135,7 +135,6 @@ struct AssetBuilder {
     max_age: Option<u64>,
     headers: Option<Vec<(String, String)>>,
     aliasing: Option<bool>,
-    allow_raw_access: Option<bool>,
 }
 
 impl AssetBuilder {
@@ -147,7 +146,6 @@ impl AssetBuilder {
             max_age: None,
             headers: None,
             aliasing: None,
-            allow_raw_access: None,
         }
     }
 
@@ -170,11 +168,6 @@ impl AssetBuilder {
     fn with_header(mut self, header_key: &str, header_value: &str) -> Self {
         let hm = self.headers.get_or_insert_with(Vec::new);
         hm.push((header_key.to_string(), header_value.to_string()));
-        self
-    }
-
-    fn with_allow_raw_access(mut self, allow_raw_access: Option<bool>) -> Self {
-        self.allow_raw_access = allow_raw_access;
         self
     }
 }
@@ -269,7 +262,6 @@ fn assemble_create_assets_and_set_contents_operations(
             max_age: asset.max_age,
             headers: asset.headers,
             enable_aliasing: asset.aliasing,
-            allow_raw_access: asset.allow_raw_access,
         }));
 
         for (enc, chunks) in asset.encodings {
@@ -302,21 +294,6 @@ fn lookup_header<'a>(response: &'a HttpResponse, header: &str) -> Option<&'a str
         .headers
         .iter()
         .find_map(|(h, v)| h.eq_ignore_ascii_case(header).then_some(v.as_str()))
-}
-
-impl State {
-    fn fake_http_request(&self, host: &str, path: &str) -> HttpResponse {
-        let fake_cert = [0xca, 0xfe];
-        self.http_request(
-            RequestBuilder::get(path).with_header("Host", host).build(),
-            &fake_cert,
-            unused_callback(),
-        )
-    }
-
-    fn create_test_asset(&mut self, asset: AssetBuilder) {
-        create_assets(self, &mock_system_context(), vec![asset]);
-    }
 }
 
 #[test]
@@ -674,7 +651,6 @@ fn old_stable_assets_with_is_aliased_load_cleanly() {
             headers: None,
             // Pretend this came from an older serialized blob.
             is_aliased: Some(true),
-            allow_raw_access: None,
         },
     );
     let stable_state = StableState {
@@ -1053,7 +1029,6 @@ fn supports_getting_and_setting_asset_properties() {
         Ok(AssetProperties {
             max_age: None,
             headers: Some(vec![("Access-Control-Allow-Origin".into(), "*".into())]),
-            allow_raw_access: None,
             is_aliased: None
         })
     );
@@ -1062,7 +1037,6 @@ fn supports_getting_and_setting_asset_properties() {
         Ok(AssetProperties {
             max_age: Some(604800),
             headers: Some(vec![("X-Content-Type-Options".into(), "nosniff".into())]),
-            allow_raw_access: None,
             is_aliased: None
         })
     );
@@ -1075,7 +1049,6 @@ fn supports_getting_and_setting_asset_properties() {
                 "X-Content-Type-Options".into(),
                 "nosniff".into()
             )])),
-            allow_raw_access: None,
             is_aliased: None
         })
         .is_ok());
@@ -1084,7 +1057,6 @@ fn supports_getting_and_setting_asset_properties() {
         Ok(AssetProperties {
             max_age: Some(1),
             headers: Some(vec![("X-Content-Type-Options".into(), "nosniff".into())]),
-            allow_raw_access: None,
             is_aliased: None
         })
     );
@@ -1094,7 +1066,6 @@ fn supports_getting_and_setting_asset_properties() {
             key: "/max-age.html".into(),
             max_age: Some(None),
             headers: Some(None),
-            allow_raw_access: None,
             is_aliased: None
         })
         .is_ok());
@@ -1103,7 +1074,6 @@ fn supports_getting_and_setting_asset_properties() {
         Ok(AssetProperties {
             max_age: None,
             headers: None,
-            allow_raw_access: None,
             is_aliased: None
         })
     );
@@ -1116,7 +1086,6 @@ fn supports_getting_and_setting_asset_properties() {
                 "X-Content-Type-Options".into(),
                 "nosniff".into()
             )])),
-            allow_raw_access: None,
             is_aliased: None
         })
         .is_ok());
@@ -1125,7 +1094,6 @@ fn supports_getting_and_setting_asset_properties() {
         Ok(AssetProperties {
             max_age: Some(1),
             headers: Some(vec![("X-Content-Type-Options".into(), "nosniff".into())]),
-            allow_raw_access: None,
             is_aliased: None
         })
     );
@@ -1135,7 +1103,6 @@ fn supports_getting_and_setting_asset_properties() {
             key: "/max-age.html".into(),
             max_age: None,
             headers: Some(Some(vec![("new-header".into(), "value".into())])),
-            allow_raw_access: None,
             is_aliased: None
         })
         .is_ok());
@@ -1144,7 +1111,6 @@ fn supports_getting_and_setting_asset_properties() {
         Ok(AssetProperties {
             max_age: Some(1),
             headers: Some(vec![("new-header".into(), "value".into())]),
-            allow_raw_access: None,
             is_aliased: None
         })
     );
@@ -1154,7 +1120,6 @@ fn supports_getting_and_setting_asset_properties() {
             key: "/max-age.html".into(),
             max_age: Some(Some(2)),
             headers: None,
-            allow_raw_access: None,
             is_aliased: None
         })
         .is_ok());
@@ -1163,7 +1128,6 @@ fn supports_getting_and_setting_asset_properties() {
         Ok(AssetProperties {
             max_age: Some(2),
             headers: Some(vec![("new-header".into(), "value".into())]),
-            allow_raw_access: None,
             is_aliased: None
         })
     );
@@ -1173,7 +1137,6 @@ fn supports_getting_and_setting_asset_properties() {
             key: "/max-age.html".into(),
             max_age: None,
             headers: None,
-            allow_raw_access: None,
             is_aliased: Some(Some(false))
         })
         .is_ok());
@@ -1182,7 +1145,6 @@ fn supports_getting_and_setting_asset_properties() {
         Ok(AssetProperties {
             max_age: Some(2),
             headers: Some(vec![("new-header".into(), "value".into())]),
-            allow_raw_access: None,
             // `is_aliased` is accepted on the candid surface but ignored —
             // the canister no longer aliases on its own.
             is_aliased: None
@@ -1194,7 +1156,6 @@ fn supports_getting_and_setting_asset_properties() {
             key: "/max-age.html".into(),
             max_age: None,
             headers: Some(None),
-            allow_raw_access: None,
             is_aliased: Some(None)
         })
         .is_ok());
@@ -1203,7 +1164,6 @@ fn supports_getting_and_setting_asset_properties() {
         Ok(AssetProperties {
             max_age: Some(2),
             headers: None,
-            allow_raw_access: None,
             is_aliased: None
         })
     );
@@ -1229,7 +1189,6 @@ fn create_asset_fails_if_asset_exists() {
                 content_type: "text/html".to_string(),
                 max_age: None,
                 headers: None,
-                allow_raw_access: None,
                 enable_aliasing: None,
             })
             .unwrap_err()
@@ -1449,108 +1408,6 @@ fn headers_candid_hashmap_btreemap_roundtrip() {
 }
 
 #[cfg(test)]
-mod allow_raw_access {
-    use super::*;
-
-    const FILE_BODY: &[u8] = b"<!DOCTYPE html><html>file body</html>";
-
-    #[test]
-    fn redirects_from_raw_to_certified() {
-        // The raw-domain redirect now triggers for both direct asset hits and
-        // 200-rule aliases — explicit rules replace the canister's old
-        // built-in `.html` / `index.html` aliasing.
-        let mut state = State::default();
-
-        state.create_test_asset(
-            AssetBuilder::new("/page.html", "text/html").with_allow_raw_access(Some(false)),
-        );
-        set_exact_rewrite_rule(&mut state, "/page", "/page.html");
-        let response = state.fake_http_request("a-b-c.raw.icp0.io", "/page");
-        assert_eq!(response.status_code, 308);
-        assert_eq!(
-            lookup_header(&response, "Location").unwrap(),
-            "https://a-b-c.icp0.io/page"
-        );
-        let response = state.fake_http_request("a-b-c.raw.ic0.app", "/page");
-        assert_eq!(response.status_code, 308);
-        assert_eq!(
-            lookup_header(&response, "Location").unwrap(),
-            "https://a-b-c.ic0.app/page"
-        );
-
-        state.create_test_asset(
-            AssetBuilder::new("/page2.html", "text/html").with_allow_raw_access(Some(false)),
-        );
-        set_exact_rewrite_rules(
-            &mut state,
-            &[("/page", "/page.html"), ("/page2", "/page2.html")],
-        );
-        let response = state.fake_http_request("a-b-c.raw.icp0.io", "/page2");
-        assert_eq!(response.status_code, 308);
-        assert_eq!(
-            lookup_header(&response, "Location").unwrap(),
-            "https://a-b-c.icp0.io/page2"
-        );
-
-        state.create_test_asset(
-            AssetBuilder::new("/index.html", "text/html").with_allow_raw_access(Some(false)),
-        );
-        set_root_spa_rule(&mut state, "/index.html");
-        let response = state.fake_http_request("a-b-c.raw.icp0.io", "/");
-        assert_eq!(response.status_code, 308);
-        assert_eq!(
-            lookup_header(&response, "Location").unwrap(),
-            "https://a-b-c.icp0.io/"
-        );
-
-        let mut state = State::default();
-        state.create_test_asset(
-            AssetBuilder::new("/index.html", "text/html").with_allow_raw_access(Some(false)),
-        );
-        set_root_spa_rule(&mut state, "/index.html");
-        let response = state.fake_http_request("a-b-c.raw.icp0.io", "/");
-        assert_eq!(response.status_code, 308);
-        assert_eq!(
-            lookup_header(&response, "Location").unwrap(),
-            "https://a-b-c.icp0.io/"
-        );
-    }
-
-    #[test]
-    fn wont_redirect_from_raw_to_certified() {
-        let mut state = State::default();
-        state.create_test_asset(
-            AssetBuilder::new("/blog.html", "text/html")
-                .with_encoding("identity", vec![FILE_BODY])
-                .with_allow_raw_access(Some(true)),
-        );
-        let response = state.fake_http_request("a-b-c.raw.icp0.io", "/blog.html");
-        dbg!(&response);
-        assert_eq!(response.status_code, 200);
-
-        let mut state = State::default();
-        state.create_test_asset(
-            AssetBuilder::new("/index.html", "text/html")
-                .with_encoding("identity", vec![FILE_BODY])
-                .with_allow_raw_access(Some(true)),
-        );
-        let response = state.fake_http_request("a-b-c.raw.icp0.io", "/index.html");
-        dbg!(&response);
-        assert_eq!(response.status_code, 200);
-
-        let mut state = State::default();
-        state.create_test_asset(
-            AssetBuilder::new("/index.html", "text/html")
-                .with_encoding("identity", vec![FILE_BODY])
-                .with_allow_raw_access(Some(true)),
-        );
-        let response = state.fake_http_request("a-b-c.localhost:4444", "/index.html");
-        dbg!(&response);
-        assert_eq!(response.status_code, 200);
-    }
-}
-
-#[cfg(test)]
 mod certificate_expression {
     use super::*;
     use crate::certification::build_ic_certificate_expression_from_headers_and_encoding;
@@ -1649,7 +1506,6 @@ mod certificate_expression {
                 key: "/contents.html".into(),
                 max_age: Some(None),
                 headers: Some(Some(vec![("custom-header".into(), "value".into())])),
-                allow_raw_access: None,
                 is_aliased: None,
             })
             .unwrap();
@@ -2121,7 +1977,6 @@ mod last_state_update_timestamp {
                         max_age: None,
                         headers: None,
                         enable_aliasing: None,
-                        allow_raw_access: None,
                     })],
                 },
                 progress,
@@ -2210,7 +2065,6 @@ mod last_state_update_timestamp {
                             )])),
                             max_age: None,
                             is_aliased: None,
-                            allow_raw_access: None,
                         },
                     )],
                 },
@@ -2483,7 +2337,6 @@ mod set_asset_content_sha256_verification {
                 content_type: "text/plain".to_string(),
                 max_age: None,
                 headers: None,
-                allow_raw_access: None,
                 enable_aliasing: None,
             })
             .unwrap();
@@ -2530,7 +2383,6 @@ mod set_asset_content_sha256_verification {
                 content_type: "text/plain".to_string(),
                 max_age: None,
                 headers: None,
-                allow_raw_access: None,
                 enable_aliasing: None,
             })
             .unwrap();
@@ -2577,7 +2429,6 @@ mod set_asset_content_sha256_verification {
                 content_type: "text/plain".to_string(),
                 max_age: None,
                 headers: None,
-                allow_raw_access: None,
                 enable_aliasing: None,
             })
             .unwrap();
@@ -2637,7 +2488,6 @@ mod set_asset_content_sha256_verification {
                 content_type: "text/plain".to_string(),
                 max_age: None,
                 headers: None,
-                allow_raw_access: None,
                 enable_aliasing: None,
             })
             .unwrap();
@@ -2688,7 +2538,6 @@ mod set_asset_content_sha256_verification {
                 content_type: "text/plain".to_string(),
                 max_age: None,
                 headers: None,
-                allow_raw_access: None,
                 enable_aliasing: None,
             })
             .unwrap();
@@ -2751,7 +2600,6 @@ mod compute_state_hash {
                     max_age: None,
                     headers: None,
                     enable_aliasing: None,
-                    allow_raw_access: None,
                 }),
                 BatchOperation::SetAssetContent(SetAssetContentArguments {
                     key: "asset1".to_string(),
@@ -2783,7 +2631,6 @@ mod compute_state_hash {
                 max_age: None,
                 headers: None,
                 enable_aliasing: None,
-                allow_raw_access: None,
             })],
         };
         run_computation_until_completion(|progress| {

--- a/crates/canister-core/src/types.rs
+++ b/crates/canister-core/src/types.rs
@@ -38,7 +38,6 @@ pub struct CreateAssetArguments {
     pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
     pub enable_aliasing: Option<bool>,
-    pub allow_raw_access: Option<bool>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
@@ -141,7 +140,6 @@ pub struct CreateChunksResponse {
 pub struct AssetProperties {
     pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
-    pub allow_raw_access: Option<bool>,
     pub is_aliased: Option<bool>,
 }
 
@@ -150,7 +148,6 @@ pub struct SetAssetPropertiesArguments {
     pub key: AssetKey,
     pub max_age: Option<Option<u64>>,
     pub headers: Option<Option<Vec<(String, String)>>>,
-    pub allow_raw_access: Option<Option<bool>>,
     pub is_aliased: Option<Option<bool>>,
 }
 

--- a/crates/canister/assets.did
+++ b/crates/canister/assets.did
@@ -9,7 +9,6 @@ type CreateAssetArguments = record {
   max_age: opt nat64;
   headers: opt vec HeaderField;
   enable_aliasing: opt bool;
-  allow_raw_access: opt bool;
 };
 
 // Add or change content for an asset, by content encoding
@@ -115,7 +114,6 @@ type SetAssetPropertiesArguments = record {
   key: Key;
   max_age: opt opt nat64;
   headers: opt opt vec HeaderField;
-  allow_raw_access: opt opt bool;
   is_aliased: opt opt bool;
 };
 
@@ -184,14 +182,12 @@ service: () -> {
     };
     max_age: opt nat64;
     headers: opt vec HeaderField;
-    allow_raw_access: opt bool;
     is_aliased: opt bool;
   }) query;
 
   get_asset_properties : (key: Key) -> (record {
     max_age: opt nat64;
     headers: opt vec HeaderField;
-    allow_raw_access: opt bool;
     is_aliased: opt bool; } ) query;
 
   certified_tree : () -> (record {

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -109,7 +109,6 @@ pub fn setup_project(fixture_path: &str) -> tempfile::TempDir {
 pub struct AssetProperties {
     pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
-    pub allow_raw_access: Option<bool>,
     pub is_aliased: Option<bool>,
 }
 

--- a/crates/sync-core/src/canister.rs
+++ b/crates/sync-core/src/canister.rs
@@ -27,7 +27,6 @@ pub struct CreateAssetArguments {
     pub content_type: String,
     pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
-    pub allow_raw_access: Option<bool>,
 }
 
 #[derive(CandidType, Clone, Debug)]
@@ -58,7 +57,6 @@ pub struct SetAssetPropertiesArguments {
     pub key: String,
     pub max_age: Option<Option<u64>>,
     pub headers: Option<Option<Vec<(String, String)>>>,
-    pub allow_raw_access: Option<Option<bool>>,
 }
 
 #[derive(CandidType, Clone, Debug, Deserialize, PartialEq, Eq)]
@@ -101,7 +99,6 @@ pub struct CommitBatchArguments {
 pub struct AssetProperties {
     pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
-    pub allow_raw_access: Option<bool>,
 }
 
 #[derive(CandidType, Debug)]

--- a/crates/sync-core/src/sync.rs
+++ b/crates/sync-core/src/sync.rs
@@ -603,7 +603,7 @@ fn build_operations(
 
     // 2. Create new assets (those not present after deletions). Per-asset
     //    headers come from resolving the project's `_headers` rules against
-    //    each new key; max_age and allow_raw_access fall back to defaults.
+    //    each new key; max_age falls back to defaults.
     for (key, pa) in project_assets {
         if !canister_assets.contains_key(key) {
             let resolved = headers::resolve(key, project_header_rules);
@@ -612,7 +612,6 @@ fn build_operations(
                 content_type: pa.media_type.to_string(),
                 max_age: None,
                 headers: (!resolved.is_empty()).then_some(resolved),
-                allow_raw_access: Some(true),
             }));
         }
     }
@@ -726,12 +725,12 @@ fn load_redirect_rules(dir: &str) -> Result<Vec<RedirectRule>, String> {
 }
 
 // For each asset that already exists on the canister, reset any per-asset
-// properties (`max_age`, `headers`, `allow_raw_access`) that drifted from the
-// project config. Newly-created assets get the same values via
-// `CreateAssetArguments`, so we don't emit `SetAssetProperties` for them.
+// properties (`max_age`, `headers`) that drifted from the project config.
+// Newly-created assets get the same values via `CreateAssetArguments`, so we
+// don't emit `SetAssetProperties` for them.
 //
 // Headers are resolved from `_headers` per-key; everything else falls back to
-// plugin defaults (None / Some(true)).
+// plugin defaults (None).
 //
 // `canister_assets` is the post-deletion view: keys removed in step 1 (missing
 // from the project, or content_type drift forcing delete-then-create) are
@@ -763,16 +762,12 @@ fn update_properties(
             None
         };
 
-        let allow_raw_access =
-            (canister_props.allow_raw_access != Some(true)).then_some(Some(true));
-
-        if max_age.is_some() || headers.is_some() || allow_raw_access.is_some() {
+        if max_age.is_some() || headers.is_some() {
             ops.push(BatchOperationKind::SetAssetProperties(
                 SetAssetPropertiesArguments {
                     key: key.clone(),
                     max_age,
                     headers,
-                    allow_raw_access,
                 },
             ));
         }
@@ -1006,7 +1001,6 @@ mod tests {
             content_type: "text/plain".to_string(),
             max_age: None,
             headers: Some(vec![(name, value)]),
-            allow_raw_access: Some(true),
         })
     }
 
@@ -1713,7 +1707,6 @@ mod tests {
 
         assert_eq!(create_op.max_age, None);
         assert!(create_op.headers.is_none());
-        assert_eq!(create_op.allow_raw_access, Some(true));
     }
 
     fn set_props_ops(
@@ -1744,7 +1737,6 @@ mod tests {
             AssetProperties {
                 max_age: None,
                 headers: None,
-                allow_raw_access: Some(true),
             },
         )]);
         let ops = build_operations(&project, &canister, &canister_props, &[], &[], &[]);
@@ -1771,7 +1763,6 @@ mod tests {
             AssetProperties {
                 max_age: Some(60),
                 headers: None,
-                allow_raw_access: Some(true),
             },
         )]);
         let ops = build_operations(&project, &canister, &canister_props, &[], &[], &[]);
@@ -1800,7 +1791,6 @@ mod tests {
             AssetProperties {
                 max_age: None,
                 headers: Some(canister_headers),
-                allow_raw_access: Some(true),
             },
         )]);
         let ops = build_operations(&project, &canister, &canister_props, &[], &[], &[]);
@@ -1831,7 +1821,6 @@ mod tests {
             AssetProperties {
                 max_age: Some(60),
                 headers: None,
-                allow_raw_access: Some(true),
             },
         )]);
         let ops = build_operations(&project, &canister, &canister_props, &[], &[], &[]);
@@ -1941,7 +1930,6 @@ mod tests {
             AssetProperties {
                 max_age: None,
                 headers: None,
-                allow_raw_access: Some(true),
             },
         )]);
         let header_rules = vec![mk_header_rule("/*", &[("X-Frame-Options", "DENY")])];
@@ -1978,7 +1966,6 @@ mod tests {
             AssetProperties {
                 max_age: None,
                 headers: Some(vec![("X-Frame-Options".into(), "DENY".into())]),
-                allow_raw_access: Some(true),
             },
         )]);
         // No header rules — canister-stored headers should be cleared.
@@ -2110,7 +2097,6 @@ mod tests {
             AssetProperties {
                 max_age: None,
                 headers: Some(vec![("X-Frame-Options".into(), "DENY".into())]),
-                allow_raw_access: Some(true),
             },
         )]);
         let header_rules = vec![mk_header_rule("/*", &[("X-Frame-Options", "DENY")])];
@@ -2319,7 +2305,6 @@ mod tests {
             AssetProperties {
                 max_age: None,
                 headers: Some(vec![("X-Frame-Options".into(), "DENY".into())]),
-                allow_raw_access: Some(true),
             },
         );
 
@@ -2467,7 +2452,6 @@ mod tests {
             AssetProperties {
                 max_age: None,
                 headers: None,
-                allow_raw_access: Some(true),
             },
         );
 

--- a/crates/sync-core/tests/bench_sync.rs
+++ b/crates/sync-core/tests/bench_sync.rs
@@ -99,7 +99,6 @@ impl CanisterCall for BenchMock {
             "get_asset_properties" => Encode!(&AssetProperties {
                 max_age: None,
                 headers: None,
-                allow_raw_access: Some(true),
             }),
             "create_batch" => Encode!(&CreateBatchOk {
                 batch_id: Nat::from(1u32),


### PR DESCRIPTION
## Summary

`allow_raw_access` was carried over from the old SDK assets canister. It let an asset owner block serving from the `.raw.ic*` domain by redirecting raw-domain requests to the certified domain. We don't plan to support it anymore, so this removes the feature end to end — including the raw-domain redirect machinery it was the sole user of.

## Changes

- **canister-core**
  - Drop the field from `Asset` / `AssetDetails`, the wire types (`CreateAssetArguments`, `AssetProperties`, `SetAssetPropertiesArguments`), stable state, and state-hash input.
  - Remove both raw→certified redirect checks from `build_http_response` (direct asset hit + redirect-rule target) and the now-unused `req: HttpRequest` parameter.
  - Delete the orphaned raw-domain helpers in `http.rs` that only existed to support it: `is_raw_domain`, `redirect_from_raw_to_certified_domain`, `get_canister_id`, `build_redirect`, `get_header_value`, and the `HTTP_REDIRECT_PERMANENT` const.
  - Remove the `allow_raw_access` test module and its now-unused helpers.
- **sync-core** — drop the field from the canister wire types; stop emitting it in create/property-drift operations.
- **assets.did + e2e** — drop the field from the candid interface and the e2e helper struct.

## Behavior change

Assets are now **always served on the raw domain without redirect**, since per-asset raw blocking no longer exists. Consistent with the repo's no-backward-compatibility stance (no production instances), no shim is left behind. The adjacent `enable_aliasing` / `is_aliased` ignored-compat fields are intentionally left untouched.

## Testing

- `cargo build --workspace` — clean
- `cargo clippy --workspace --all-targets` — no warnings
- `cargo test -p canister-core` — 99 passed
- `cargo test -p sync-core` — 190 passed
- `cargo test -p canister` — `candid_interface_compatibility` passes (trimmed `assets.did` matches the exported interface)
- `cargo test -p e2e` — 12 passed against a live local replica

🤖 Generated with [Claude Code](https://claude.com/claude-code)