### PR TITLE
refactor: remove vestigial aliasing fields

### DIFF
--- a/crates/canister-core/src/asset.rs
+++ b/crates/canister-core/src/asset.rs
@@ -135,7 +135,6 @@ pub struct AssetDetails {
     pub encodings: Vec<AssetEncodingDetails>,
     pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
-    pub is_aliased: Option<bool>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]

--- a/crates/canister-core/src/stable.rs
+++ b/crates/canister-core/src/stable.rs
@@ -70,18 +70,12 @@ impl From<StableConfiguration> for crate::state::Configuration {
 }
 
 /// Same as [crate::asset::Asset] but serde-serializable.
-///
-/// `is_aliased` is kept as an optional ignored field so stable-memory blobs
-/// written before built-in aliasing was removed still deserialize. Newly
-/// written blobs always set it to `None`.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StableAsset {
     pub content_type: String,
     pub encodings: HashMap<String, StableAssetEncoding>,
     pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
-    #[serde(default)]
-    pub is_aliased: Option<bool>,
 }
 
 impl From<crate::asset::Asset> for StableAsset {
@@ -95,7 +89,6 @@ impl From<crate::asset::Asset> for StableAsset {
                 .collect(),
             max_age: asset.max_age,
             headers: asset.headers,
-            is_aliased: None,
         }
     }
 }

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -109,10 +109,6 @@ impl State {
             return Err("asset already exists".to_string());
         }
 
-        // `arg.enable_aliasing` is accepted for backward compatibility but
-        // ignored — the canister no longer aliases on its own; users express
-        // aliasing as an explicit status-200 rule in `_redirects`.
-        let _ = arg.enable_aliasing;
         self.assets.insert(
             arg.key,
             Asset {
@@ -247,8 +243,6 @@ impl State {
         let dependent_keys = self.dependent_keys(&arg.key);
         let asset = self.assets.entry(arg.key.clone()).or_default();
         asset.content_type = arg.content_type;
-        // `arg.aliased` is accepted for backward compatibility but ignored.
-        let _ = arg.aliased;
 
         let hash = sha2::Sha256::digest(&arg.content).into();
         if let Some(provided_hash) = arg.sha256 {
@@ -348,7 +342,6 @@ impl State {
                         encodings,
                         max_age: asset.max_age,
                         headers: asset.headers.clone(),
-                        is_aliased: None,
                     }
                 })
             })
@@ -595,7 +588,6 @@ impl State {
         Ok(AssetProperties {
             max_age: asset.max_age,
             headers: asset.headers.clone(),
-            is_aliased: None,
         })
     }
 
@@ -612,9 +604,6 @@ impl State {
         if let Some(max_age) = arg.max_age {
             asset.max_age = max_age
         }
-
-        // `arg.is_aliased` is accepted for backward compatibility but ignored.
-        let _ = arg.is_aliased;
 
         on_asset_change(&mut self.asset_hashes, &arg.key, asset, dependent_keys);
 

--- a/crates/canister-core/src/state_hash.rs
+++ b/crates/canister-core/src/state_hash.rs
@@ -5,9 +5,6 @@ use itertools::Itertools;
 use serde_bytes::ByteBuf;
 use sha2::{Digest, Sha256};
 
-const TAG_FALSE: [u8; 1] = [0];
-const TAG_TRUE: [u8; 1] = [1];
-
 const TAG_NONE: [u8; 1] = [2];
 const TAG_SOME: [u8; 1] = [3];
 
@@ -85,7 +82,6 @@ fn next_step(
                 content_type: asset.content_type.clone(),
                 max_age: asset.max_age,
                 headers: asset.headers.clone(),
-                enable_aliasing: None,
             };
             hash_create_asset(&mut hasher, &args);
             let mut sorted_encoding_names: Vec<String> = asset.encodings.keys().cloned().collect();
@@ -184,7 +180,6 @@ fn hash_create_asset(hasher: &mut Sha256, args: &CreateAssetArguments) {
         hasher.update(TAG_NONE);
     }
     hash_headers(hasher, args.headers.as_ref());
-    hash_opt_bool(hasher, args.enable_aliasing);
 }
 
 fn hash_set_asset_content(hasher: &mut Sha256, args: &SetAssetContentArguments) {
@@ -192,15 +187,6 @@ fn hash_set_asset_content(hasher: &mut Sha256, args: &SetAssetContentArguments) 
     hasher.update(&args.key);
     hasher.update(&args.content_encoding);
     hash_opt_bytebuf(hasher, args.sha256.as_ref());
-}
-
-fn hash_opt_bool(hasher: &mut Sha256, b: Option<bool>) {
-    if let Some(b) = b {
-        hasher.update(TAG_SOME);
-        hasher.update(if b { TAG_TRUE } else { TAG_FALSE });
-    } else {
-        hasher.update(TAG_NONE);
-    }
 }
 
 fn hash_opt_bytebuf(hasher: &mut Sha256, buf: Option<&ByteBuf>) {

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -134,7 +134,6 @@ struct AssetBuilder {
     encodings: Vec<(String, Vec<ByteBuf>)>,
     max_age: Option<u64>,
     headers: Option<Vec<(String, String)>>,
-    aliasing: Option<bool>,
 }
 
 impl AssetBuilder {
@@ -145,7 +144,6 @@ impl AssetBuilder {
             encodings: vec![],
             max_age: None,
             headers: None,
-            aliasing: None,
         }
     }
 
@@ -261,7 +259,6 @@ fn assemble_create_assets_and_set_contents_operations(
             content_type: asset.content_type,
             max_age: asset.max_age,
             headers: asset.headers,
-            enable_aliasing: asset.aliasing,
         }));
 
         for (enc, chunks) in asset.encodings {
@@ -620,53 +617,6 @@ fn returns_index_file_for_missing_assets_via_rule() {
 
     assert_eq!(response.status_code, 200);
     assert_eq!(response.body.as_ref(), INDEX_BODY);
-}
-
-#[test]
-fn old_stable_assets_with_is_aliased_load_cleanly() {
-    // Mirrors the plan's "guard against accidental data loss" test: a
-    // StableAsset record serialized when built-in aliasing was a real
-    // canister feature must still deserialize and serve correctly after
-    // the in-memory `Asset` lost the `is_aliased` field.
-    use crate::stable::{StableAsset, StableAssetEncoding};
-
-    let mut stable_assets = std::collections::HashMap::new();
-    stable_assets.insert(
-        "/foo.html".to_string(),
-        StableAsset {
-            content_type: "text/html".into(),
-            encodings: HashMap::from([(
-                "identity".into(),
-                StableAssetEncoding {
-                    modified: 0,
-                    content_chunks: vec![],
-                    total_length: 0,
-                    certified: false,
-                    sha256: [0u8; 32],
-                    certificate_expression: None,
-                    response_hashes: None,
-                },
-            )]),
-            max_age: None,
-            headers: None,
-            // Pretend this came from an older serialized blob.
-            is_aliased: Some(true),
-        },
-    );
-    let stable_state = StableState {
-        authorized: Default::default(),
-        stable_assets,
-        next_batch_id: None,
-        configuration: None,
-        last_state_update_timestamp: None,
-        redirect_rules: None,
-    };
-    // Round-trip through serde_cbor (the format stable memory uses).
-    let bytes = serde_cbor::to_vec(&stable_state).unwrap();
-    let restored: StableState = serde_cbor::from_slice(&bytes).unwrap();
-    let state: State = restored.into();
-    // The asset survives; the in-memory shape no longer carries the flag.
-    assert!(state.assets.contains_key("/foo.html"));
 }
 
 #[test]
@@ -1029,7 +979,6 @@ fn supports_getting_and_setting_asset_properties() {
         Ok(AssetProperties {
             max_age: None,
             headers: Some(vec![("Access-Control-Allow-Origin".into(), "*".into())]),
-            is_aliased: None
         })
     );
     assert_eq!(
@@ -1037,7 +986,6 @@ fn supports_getting_and_setting_asset_properties() {
         Ok(AssetProperties {
             max_age: Some(604800),
             headers: Some(vec![("X-Content-Type-Options".into(), "nosniff".into())]),
-            is_aliased: None
         })
     );
 
@@ -1049,7 +997,6 @@ fn supports_getting_and_setting_asset_properties() {
                 "X-Content-Type-Options".into(),
                 "nosniff".into()
             )])),
-            is_aliased: None
         })
         .is_ok());
     assert_eq!(
@@ -1057,7 +1004,6 @@ fn supports_getting_and_setting_asset_properties() {
         Ok(AssetProperties {
             max_age: Some(1),
             headers: Some(vec![("X-Content-Type-Options".into(), "nosniff".into())]),
-            is_aliased: None
         })
     );
 
@@ -1066,7 +1012,6 @@ fn supports_getting_and_setting_asset_properties() {
             key: "/max-age.html".into(),
             max_age: Some(None),
             headers: Some(None),
-            is_aliased: None
         })
         .is_ok());
     assert_eq!(
@@ -1074,7 +1019,6 @@ fn supports_getting_and_setting_asset_properties() {
         Ok(AssetProperties {
             max_age: None,
             headers: None,
-            is_aliased: None
         })
     );
 
@@ -1086,7 +1030,6 @@ fn supports_getting_and_setting_asset_properties() {
                 "X-Content-Type-Options".into(),
                 "nosniff".into()
             )])),
-            is_aliased: None
         })
         .is_ok());
     assert_eq!(
@@ -1094,7 +1037,6 @@ fn supports_getting_and_setting_asset_properties() {
         Ok(AssetProperties {
             max_age: Some(1),
             headers: Some(vec![("X-Content-Type-Options".into(), "nosniff".into())]),
-            is_aliased: None
         })
     );
 
@@ -1103,7 +1045,6 @@ fn supports_getting_and_setting_asset_properties() {
             key: "/max-age.html".into(),
             max_age: None,
             headers: Some(Some(vec![("new-header".into(), "value".into())])),
-            is_aliased: None
         })
         .is_ok());
     assert_eq!(
@@ -1111,7 +1052,6 @@ fn supports_getting_and_setting_asset_properties() {
         Ok(AssetProperties {
             max_age: Some(1),
             headers: Some(vec![("new-header".into(), "value".into())]),
-            is_aliased: None
         })
     );
 
@@ -1120,7 +1060,6 @@ fn supports_getting_and_setting_asset_properties() {
             key: "/max-age.html".into(),
             max_age: Some(Some(2)),
             headers: None,
-            is_aliased: None
         })
         .is_ok());
     assert_eq!(
@@ -1128,43 +1067,6 @@ fn supports_getting_and_setting_asset_properties() {
         Ok(AssetProperties {
             max_age: Some(2),
             headers: Some(vec![("new-header".into(), "value".into())]),
-            is_aliased: None
-        })
-    );
-
-    assert!(state
-        .set_asset_properties(SetAssetPropertiesArguments {
-            key: "/max-age.html".into(),
-            max_age: None,
-            headers: None,
-            is_aliased: Some(Some(false))
-        })
-        .is_ok());
-    assert_eq!(
-        state.get_asset_properties("/max-age.html".into()),
-        Ok(AssetProperties {
-            max_age: Some(2),
-            headers: Some(vec![("new-header".into(), "value".into())]),
-            // `is_aliased` is accepted on the candid surface but ignored —
-            // the canister no longer aliases on its own.
-            is_aliased: None
-        })
-    );
-
-    assert!(state
-        .set_asset_properties(SetAssetPropertiesArguments {
-            key: "/max-age.html".into(),
-            max_age: None,
-            headers: Some(None),
-            is_aliased: Some(None)
-        })
-        .is_ok());
-    assert_eq!(
-        state.get_asset_properties("/max-age.html".into()),
-        Ok(AssetProperties {
-            max_age: Some(2),
-            headers: None,
-            is_aliased: None
         })
     );
 }
@@ -1189,7 +1091,6 @@ fn create_asset_fails_if_asset_exists() {
                 content_type: "text/html".to_string(),
                 max_age: None,
                 headers: None,
-                enable_aliasing: None,
             })
             .unwrap_err()
             == "asset already exists"
@@ -1506,7 +1407,6 @@ mod certificate_expression {
                 key: "/contents.html".into(),
                 max_age: Some(None),
                 headers: Some(Some(vec![("custom-header".into(), "value".into())])),
-                is_aliased: None,
             })
             .unwrap();
         let response = certified_http_request(
@@ -1976,7 +1876,6 @@ mod last_state_update_timestamp {
                         content_type: "text/plain".to_string(),
                         max_age: None,
                         headers: None,
-                        enable_aliasing: None,
                     })],
                 },
                 progress,
@@ -2009,7 +1908,6 @@ mod last_state_update_timestamp {
                     content_encoding: "identity".to_string(),
                     content: ByteBuf::from(b"test content".to_vec()),
                     sha256: None,
-                    aliased: None,
                 },
                 &system_context,
             )
@@ -2040,7 +1938,6 @@ mod last_state_update_timestamp {
                     content_encoding: "identity".to_string(),
                     content: ByteBuf::from(b"test content".to_vec()),
                     sha256: None,
-                    aliased: None,
                 },
                 &system_context,
             )
@@ -2064,7 +1961,6 @@ mod last_state_update_timestamp {
                                 "value".to_string(),
                             )])),
                             max_age: None,
-                            is_aliased: None,
                         },
                     )],
                 },
@@ -2093,7 +1989,6 @@ mod last_state_update_timestamp {
                     content_encoding: "identity".to_string(),
                     content: ByteBuf::from(b"test content".to_vec()),
                     sha256: None,
-                    aliased: None,
                 },
                 &system_context,
             )
@@ -2337,7 +2232,6 @@ mod set_asset_content_sha256_verification {
                 content_type: "text/plain".to_string(),
                 max_age: None,
                 headers: None,
-                enable_aliasing: None,
             })
             .unwrap();
 
@@ -2383,7 +2277,6 @@ mod set_asset_content_sha256_verification {
                 content_type: "text/plain".to_string(),
                 max_age: None,
                 headers: None,
-                enable_aliasing: None,
             })
             .unwrap();
 
@@ -2429,7 +2322,6 @@ mod set_asset_content_sha256_verification {
                 content_type: "text/plain".to_string(),
                 max_age: None,
                 headers: None,
-                enable_aliasing: None,
             })
             .unwrap();
 
@@ -2488,7 +2380,6 @@ mod set_asset_content_sha256_verification {
                 content_type: "text/plain".to_string(),
                 max_age: None,
                 headers: None,
-                enable_aliasing: None,
             })
             .unwrap();
 
@@ -2538,7 +2429,6 @@ mod set_asset_content_sha256_verification {
                 content_type: "text/plain".to_string(),
                 max_age: None,
                 headers: None,
-                enable_aliasing: None,
             })
             .unwrap();
 
@@ -2599,7 +2489,6 @@ mod compute_state_hash {
                     content_type: "text/plain".to_string(),
                     max_age: None,
                     headers: None,
-                    enable_aliasing: None,
                 }),
                 BatchOperation::SetAssetContent(SetAssetContentArguments {
                     key: "asset1".to_string(),
@@ -2630,7 +2519,6 @@ mod compute_state_hash {
                 content_type: "text/plain".to_string(),
                 max_age: None,
                 headers: None,
-                enable_aliasing: None,
             })],
         };
         run_computation_until_completion(|progress| {

--- a/crates/canister-core/src/types.rs
+++ b/crates/canister-core/src/types.rs
@@ -37,7 +37,6 @@ pub struct CreateAssetArguments {
     pub content_type: String,
     pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
-    pub enable_aliasing: Option<bool>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
@@ -98,7 +97,6 @@ pub struct StoreArg {
     pub content_encoding: String,
     pub content: ByteBuf,
     pub sha256: Option<ByteBuf>,
-    pub aliased: Option<bool>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
@@ -140,7 +138,6 @@ pub struct CreateChunksResponse {
 pub struct AssetProperties {
     pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
-    pub is_aliased: Option<bool>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
@@ -148,7 +145,6 @@ pub struct SetAssetPropertiesArguments {
     pub key: AssetKey,
     pub max_age: Option<Option<u64>>,
     pub headers: Option<Option<Vec<(String, String)>>>,
-    pub is_aliased: Option<Option<bool>>,
 }
 
 #[derive(Clone, Debug, Default, CandidType, Deserialize)]

--- a/crates/canister/assets.did
+++ b/crates/canister/assets.did
@@ -8,7 +8,6 @@ type CreateAssetArguments = record {
   content_type: text;
   max_age: opt nat64;
   headers: opt vec HeaderField;
-  enable_aliasing: opt bool;
 };
 
 // Add or change content for an asset, by content encoding
@@ -114,7 +113,6 @@ type SetAssetPropertiesArguments = record {
   key: Key;
   max_age: opt opt nat64;
   headers: opt opt vec HeaderField;
-  is_aliased: opt opt bool;
 };
 
 type ConfigurationResponse = record {
@@ -182,13 +180,11 @@ service: () -> {
     };
     max_age: opt nat64;
     headers: opt vec HeaderField;
-    is_aliased: opt bool;
   }) query;
 
   get_asset_properties : (key: Key) -> (record {
     max_age: opt nat64;
-    headers: opt vec HeaderField;
-    is_aliased: opt bool; } ) query;
+    headers: opt vec HeaderField; } ) query;
 
   certified_tree : () -> (record {
     certificate: blob;
@@ -205,7 +201,6 @@ service: () -> {
     content_encoding: text;
     content: blob;
     sha256: opt blob;
-    aliased: opt bool;
   }) -> ();
 
   create_asset: (CreateAssetArguments) -> ();

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -109,7 +109,6 @@ pub fn setup_project(fixture_path: &str) -> tempfile::TempDir {
 pub struct AssetProperties {
     pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
-    pub is_aliased: Option<bool>,
 }
 
 /// Call `get_asset_properties` on the `frontend` canister for `key`.


### PR DESCRIPTION
## What

Removes the `enable_aliasing` / `aliased` / `is_aliased` fields from the canister API and internals. These were accepted-but-ignored compatibility shims left over from the old **built-in aliasing** feature (auto-serving `/foo.html` for a request to `/foo`). That behavior is already gone — aliasing is now expressed explicitly as status-200 redirect rules in `_redirects`.

The sync-plugin (`sync-core`) never declared these fields in its own Candid types, so this is a **no-behavior-change deletion** of dead surface.

## Changes

- **API** ([`types.rs`](crates/canister-core/src/types.rs), [`assets.did`](crates/canister/assets.did)): drop `enable_aliasing` (`CreateAssetArguments`), `aliased` (`StoreArg`/`store`), and `is_aliased` (`AssetProperties`, `SetAssetPropertiesArguments`, `AssetDetails`, `list`).
- **Logic** ([`state.rs`](crates/canister-core/src/state.rs)): remove the three `let _ = arg.…` ignore-shims and the two `is_aliased: None` placeholder returns.
- **Persistence** ([`stable.rs`](crates/canister-core/src/stable.rs)): drop the `#[serde(default)] is_aliased` field on `StableAsset`.
- **Hashing** ([`state_hash.rs`](crates/canister-core/src/state_hash.rs)): drop `enable_aliasing` from the create-asset hash; remove the now-dead `hash_opt_bool` helper and `TAG_TRUE`/`TAG_FALSE`.
- **Tests / e2e**: delete the `old_stable_assets_with_is_aliased_load_cleanly` round-trip test and the two `set_asset_properties` blocks asserting `is_aliased` was ignored; strip the field literals; drop `is_aliased` from the e2e `AssetProperties`. Rule-based aliasing tests are untouched.

## Verification

- `cargo test -p canister-core` → 98 passed
- `cargo test -p sync-core` → 190 passed
- `cargo test -p e2e` → 12 passed (live replica)
- `cargo build -p canister`, `cargo fmt --check`, `cargo clippy` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)