### PR TITLE
refactor: drop single-asset mutation endpoints; sync via batch only

### DIFF
--- a/crates/canister-core/src/lib.rs
+++ b/crates/canister-core/src/lib.rs
@@ -65,18 +65,6 @@ pub fn retrieve(key: AssetKey) -> RcBytes {
     })
 }
 
-pub fn store(arg: StoreArg) {
-    let system_context = SystemContext::new();
-
-    with_state_mut(|s| {
-        if let Err(msg) = s.store(arg, &system_context) {
-            trap(&msg);
-        }
-        s.on_redirect_rules_change();
-        certified_data_set(s.root_hash());
-    });
-}
-
 pub fn create_batch() -> CreateBatchResponse {
     let system_context = SystemContext::new();
 
@@ -93,54 +81,6 @@ pub fn create_chunks(arg: CreateChunksArg) -> CreateChunksResponse {
         Ok(chunk_ids) => CreateChunksResponse { chunk_ids },
         Err(msg) => trap(&msg),
     })
-}
-
-pub fn create_asset(arg: CreateAssetArguments) {
-    with_state_mut(|s| {
-        if let Err(msg) = s.create_asset(arg) {
-            trap(&msg);
-        }
-        s.on_redirect_rules_change();
-        certified_data_set(s.root_hash());
-    })
-}
-
-pub fn set_asset_content(arg: SetAssetContentArguments) {
-    let system_context = SystemContext::new();
-
-    with_state_mut(|s| {
-        if let Err(msg) = s.set_asset_content(arg, &system_context) {
-            trap(&msg);
-        }
-        s.on_redirect_rules_change();
-        certified_data_set(s.root_hash());
-    })
-}
-
-pub fn unset_asset_content(arg: UnsetAssetContentArguments) {
-    with_state_mut(|s| {
-        if let Err(msg) = s.unset_asset_content(arg) {
-            trap(&msg);
-        }
-        s.on_redirect_rules_change();
-        certified_data_set(s.root_hash());
-    })
-}
-
-pub fn delete_asset(arg: DeleteAssetArguments) {
-    with_state_mut(|s| {
-        s.delete_asset(arg);
-        s.on_redirect_rules_change();
-        certified_data_set(s.root_hash());
-    });
-}
-
-pub fn clear() {
-    with_state_mut(|s| {
-        s.clear();
-        s.on_redirect_rules_change();
-        certified_data_set(s.root_hash());
-    });
 }
 
 pub async fn commit_batch(arg: CommitBatchArguments) {
@@ -234,16 +174,6 @@ pub fn http_request_streaming_callback(
 
 pub fn get_asset_properties(key: AssetKey) -> AssetProperties {
     with_state(|s| s.get_asset_properties(key).unwrap_or_else(|msg| trap(&msg)))
-}
-
-pub fn set_asset_properties(arg: SetAssetPropertiesArguments) {
-    with_state_mut(|s| {
-        if let Err(msg) = s.set_asset_properties(arg) {
-            trap(&msg);
-        }
-        s.on_redirect_rules_change();
-        certified_data_set(s.root_hash());
-    })
 }
 
 pub fn get_configuration() -> ConfigurationResponse {

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -239,30 +239,6 @@ impl State {
         Ok(id_enc.content_chunks[0].clone())
     }
 
-    pub fn store(&mut self, arg: StoreArg, system_context: &SystemContext) -> Result<(), String> {
-        let dependent_keys = self.dependent_keys(&arg.key);
-        let asset = self.assets.entry(arg.key.clone()).or_default();
-        asset.content_type = arg.content_type;
-
-        let hash = sha2::Sha256::digest(&arg.content).into();
-        if let Some(provided_hash) = arg.sha256 {
-            if hash != provided_hash.as_ref() {
-                return Err("sha256 mismatch".to_string());
-            }
-        }
-
-        let encoding = asset.encodings.entry(arg.content_encoding).or_default();
-        encoding.total_length = arg.content.len();
-        encoding.content_chunks = vec![RcBytes::from(arg.content)];
-        encoding.modified = Int::from(system_context.current_timestamp_ns);
-        encoding.sha256 = hash;
-
-        on_asset_change(&mut self.asset_hashes, &arg.key, asset, dependent_keys);
-        self.last_state_update_timestamp_ns = system_context.current_timestamp_ns;
-
-        Ok(())
-    }
-
     pub fn compute_state_hash(&mut self) -> ComputationStatus<String, (), ()> {
         if self.last_state_hash_timestamp != self.last_state_update_timestamp_ns {
             self.state_hash_computation = None;

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -1854,7 +1854,6 @@ mod enforce_limits {
 #[cfg(test)]
 mod last_state_update_timestamp {
     use super::*;
-    use crate::types::StoreArg;
 
     #[test]
     fn timestamp_updates_on_commit_batch() {
@@ -1892,35 +1891,6 @@ mod last_state_update_timestamp {
     }
 
     #[test]
-    fn timestamp_updates_on_store() {
-        let mut state = State::default();
-        let system_context = mock_system_context();
-
-        // Initial timestamp should be 0
-        assert_eq!(state.last_state_update_timestamp_ns(), 0);
-
-        // Store an asset
-        state
-            .store(
-                StoreArg {
-                    key: "/test.txt".to_string(),
-                    content_type: "text/plain".to_string(),
-                    content_encoding: "identity".to_string(),
-                    content: ByteBuf::from(b"test content".to_vec()),
-                    sha256: None,
-                },
-                &system_context,
-            )
-            .unwrap();
-
-        // Timestamp should be updated
-        assert_eq!(
-            state.last_state_update_timestamp_ns(),
-            system_context.current_timestamp_ns
-        );
-    }
-
-    #[test]
     fn timestamp_updates_on_multiple_operations() {
         let mut state = State::default();
         let mut system_context = mock_system_context();
@@ -1928,20 +1898,25 @@ mod last_state_update_timestamp {
         // Initial timestamp should be 0
         assert_eq!(state.last_state_update_timestamp_ns(), 0);
 
-        // First operation at time T1
+        // First operation at time T1: create an asset.
         let initial_time = system_context.current_timestamp_ns;
-        state
-            .store(
-                StoreArg {
-                    key: "/test.txt".to_string(),
-                    content_type: "text/plain".to_string(),
-                    content_encoding: "identity".to_string(),
-                    content: ByteBuf::from(b"test content".to_vec()),
-                    sha256: None,
+        let batch_id = state.create_batch(&system_context).unwrap();
+        run_computation_until_completion(|progress| {
+            state.commit_batch(
+                &CommitBatchArguments {
+                    batch_id: batch_id.clone(),
+                    operations: vec![BatchOperation::CreateAsset(CreateAssetArguments {
+                        key: "/test.txt".to_string(),
+                        content_type: "text/plain".to_string(),
+                        max_age: None,
+                        headers: None,
+                    })],
                 },
+                progress,
                 &system_context,
             )
-            .unwrap();
+        })
+        .unwrap();
         assert_eq!(state.last_state_update_timestamp_ns(), initial_time);
 
         // Second operation at time T2 (advanced)
@@ -1980,19 +1955,24 @@ mod last_state_update_timestamp {
         let mut state = State::default();
         let system_context = mock_system_context();
 
-        // Store an asset to update timestamp
-        state
-            .store(
-                StoreArg {
-                    key: "/test.txt".to_string(),
-                    content_type: "text/plain".to_string(),
-                    content_encoding: "identity".to_string(),
-                    content: ByteBuf::from(b"test content".to_vec()),
-                    sha256: None,
+        // Commit a batch to update the timestamp.
+        let batch_id = state.create_batch(&system_context).unwrap();
+        run_computation_until_completion(|progress| {
+            state.commit_batch(
+                &CommitBatchArguments {
+                    batch_id: batch_id.clone(),
+                    operations: vec![BatchOperation::CreateAsset(CreateAssetArguments {
+                        key: "/test.txt".to_string(),
+                        content_type: "text/plain".to_string(),
+                        max_age: None,
+                        headers: None,
+                    })],
                 },
+                progress,
                 &system_context,
             )
-            .unwrap();
+        })
+        .unwrap();
 
         let expected_timestamp = state.last_state_update_timestamp_ns();
         assert_eq!(expected_timestamp, system_context.current_timestamp_ns);

--- a/crates/canister-core/src/types.rs
+++ b/crates/canister-core/src/types.rs
@@ -91,15 +91,6 @@ pub struct DeleteBatchArguments {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct StoreArg {
-    pub key: AssetKey,
-    pub content_type: String,
-    pub content_encoding: String,
-    pub content: ByteBuf,
-    pub sha256: Option<ByteBuf>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct GetArg {
     pub key: AssetKey,
     pub accept_encodings: Vec<String>,

--- a/crates/canister/assets.did
+++ b/crates/canister/assets.did
@@ -191,27 +191,12 @@ service: () -> {
     tree: blob;
   }) query;
 
-  // ───────── Asset mutations ─────────
-
-  // Single call to create an asset with content for a single content encoding that
-  // fits within the message ingress limit.
-  store: (record {
-    key: Key;
-    content_type: text;
-    content_encoding: text;
-    content: blob;
-    sha256: opt blob;
-  }) -> ();
-
-  create_asset: (CreateAssetArguments) -> ();
-  set_asset_content: (SetAssetContentArguments) -> ();
-  unset_asset_content: (UnsetAssetContentArguments) -> ();
-  set_asset_properties: (SetAssetPropertiesArguments) -> ();
-
-  delete_asset: (DeleteAssetArguments) -> ();
-  clear: () -> ();
-
   // ───────── Batch upload ─────────
+  //
+  // Assets are only ever mutated through committed batches — there are no
+  // single-asset mutation endpoints. A batch's `operations` carry the
+  // per-asset changes (create, set/unset content, set properties, delete,
+  // clear), applied atomically when the batch is committed.
 
   create_batch : () -> (record { batch_id: BatchId });
   create_chunks: (record { batch_id: BatchId; content: vec blob }) -> (record { chunk_ids: vec ChunkId });

--- a/crates/canister/src/lib.rs
+++ b/crates/canister/src/lib.rs
@@ -11,10 +11,8 @@ use canister_core::{
     state::CertifiedTree,
     types::{
         AssetProperties, CommitBatchArguments, ConfigurationResponse, ConfigureArguments,
-        CreateAssetArguments, CreateBatchResponse, CreateChunksArg, CreateChunksResponse,
-        DeleteAssetArguments, DeleteBatchArguments, GetArg, GetChunkArg, GetChunkResponse,
-        ListRequest, SetAssetContentArguments, SetAssetPropertiesArguments, StateInfo, StoreArg,
-        UnsetAssetContentArguments,
+        CreateBatchResponse, CreateChunksArg, CreateChunksResponse, DeleteBatchArguments, GetArg,
+        GetChunkArg, GetChunkResponse, ListRequest, StateInfo,
     },
 };
 use ic_cdk::{init, post_upgrade, pre_upgrade, query, update};
@@ -127,11 +125,6 @@ fn can_sync() -> bool {
 }
 
 #[update(guard = "guard_can_sync")]
-fn store(arg: StoreArg) {
-    canister_core::store(arg)
-}
-
-#[update(guard = "guard_can_sync")]
 fn create_batch() -> CreateBatchResponse {
     canister_core::create_batch()
 }
@@ -139,31 +132,6 @@ fn create_batch() -> CreateBatchResponse {
 #[update(guard = "guard_can_sync")]
 fn create_chunks(arg: CreateChunksArg) -> CreateChunksResponse {
     canister_core::create_chunks(arg)
-}
-
-#[update(guard = "guard_can_sync")]
-fn create_asset(arg: CreateAssetArguments) {
-    canister_core::create_asset(arg)
-}
-
-#[update(guard = "guard_can_sync")]
-fn set_asset_content(arg: SetAssetContentArguments) {
-    canister_core::set_asset_content(arg)
-}
-
-#[update(guard = "guard_can_sync")]
-fn unset_asset_content(arg: UnsetAssetContentArguments) {
-    canister_core::unset_asset_content(arg)
-}
-
-#[update(guard = "guard_can_sync")]
-fn delete_asset(arg: DeleteAssetArguments) {
-    canister_core::delete_asset(arg)
-}
-
-#[update(guard = "guard_can_sync")]
-fn clear() {
-    canister_core::clear()
 }
 
 #[update(guard = "guard_can_sync")]
@@ -179,11 +147,6 @@ async fn compute_state_hash() -> Option<String> {
 #[update(guard = "guard_can_sync")]
 fn delete_batch(arg: DeleteBatchArguments) {
     canister_core::delete_batch(arg)
-}
-
-#[update(guard = "guard_can_sync")]
-fn set_asset_properties(arg: SetAssetPropertiesArguments) {
-    canister_core::set_asset_properties(arg)
 }
 
 #[update(guard = "guard_can_sync")]


### PR DESCRIPTION
## What

Makes a committed batch the only way to mutate assets. Removes the direct single-asset update endpoints so `sync()` (the batch / `commit_batch` path the plugin uses) is the only write surface:

`store`, `create_asset`, `set_asset_content`, `unset_asset_content`, `set_asset_properties`, `delete_asset`, `clear`

The removal spans all three layers that defined them:

- **`crates/canister/src/lib.rs`** — the 7 `#[update]` endpoints (and now-unused type imports).
- **`crates/canister-core/src/lib.rs`** — the matching `canister_core::*` wrapper functions.
- **`crates/canister/assets.did`** — the "Asset mutations" service block.

## Kept

- Batch upload flow: `create_batch`, `create_chunks`, `commit_batch`, `delete_batch`.
- All `BatchOperationKind` variants and their argument types — these are the sync wire protocol and are still applied atomically inside `commit_batch`.
- The `State::*` state-machine primitives that `commit_batch` and the tests build on.

## Cleanup

`store` was a single-call create-with-content composite that only backed the removed endpoint (not reused by the batch path), so this also drops the orphaned `State::store` method and the `StoreArg` type, and migrates the store-based timestamp tests onto `commit_batch` (one was redundant with `timestamp_updates_on_commit_batch` and was removed).

## Verification

- `cargo test -p canister-core` — 97 passed
- `cargo test -p canister` — candid `service_equal` check passes, confirming `assets.did` matches the generated interface
- `cargo test -p sync-core` — 190 passed
- `cargo test -p e2e` — 12 passed (deploy / no-op re-sync / content update / deletion / multi-dir, through the `icp` CLI against a live replica)

The sync plugin never called these endpoints, so no client-side changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)