### PR TITLE
fix(sync): avoid canonicalize on WASI preopened dirs

### DIFF
--- a/crates/e2e/tests/fixture/nested/icp.yaml
+++ b/crates/e2e/tests/fixture/nested/icp.yaml
@@ -1,0 +1,22 @@
+networks:
+  - name: local
+    mode: managed
+    gateway:
+      port: 0
+
+canisters:
+  - name: frontend
+    build:
+      steps:
+        - type: pre-built
+          path: wasms/canister.wasm
+
+    sync:
+      steps:
+        - type: plugin
+          path: wasms/plugin.wasm
+          # A multi-component (nested) directory. The host preopens it under a
+          # multi-segment WASI guest name, which broke `canonicalize`/`realpath`
+          # in the plugin's scan step.
+          dirs:
+            - src/frontend/dist

--- a/crates/e2e/tests/fixture/nested/src/frontend/dist/assets/style.css
+++ b/crates/e2e/tests/fixture/nested/src/frontend/dist/assets/style.css
@@ -1,0 +1,1 @@
+body { color: rebeccapurple; }

--- a/crates/e2e/tests/fixture/nested/src/frontend/dist/index.html
+++ b/crates/e2e/tests/fixture/nested/src/frontend/dist/index.html
@@ -1,0 +1,1 @@
+<html><body><h1>nested dir</h1></body></html>

--- a/crates/e2e/tests/sync.rs
+++ b/crates/e2e/tests/sync.rs
@@ -20,6 +20,30 @@ fn basic_deploy() {
     );
 }
 
+/// Deploy a fixture whose `dirs` entry is a *nested* path (`src/frontend/dist`).
+/// The host preopens it under a multi-segment WASI guest name; the plugin's scan
+/// step must not call `canonicalize`/`realpath` on it (WASI returns ENOENT for
+/// any path under a multi-component preopen, even though plain access works).
+#[test]
+fn nested_dir_deploy() {
+    let tmp = setup_project("tests/fixture/nested");
+    let project = tmp.path();
+    let _network = LocalNetwork::start(project);
+
+    icp_cmd(project).arg("deploy").assert().success();
+
+    let assets = list_assets(project);
+
+    assert!(
+        assets.iter().any(|a| a.key == "/index.html"),
+        "expected /index.html in canister asset list; got: {assets:#?}",
+    );
+    assert!(
+        assets.iter().any(|a| a.key == "/assets/style.css"),
+        "expected /assets/style.css (nested subdir) in canister asset list; got: {assets:#?}",
+    );
+}
+
 #[test]
 fn basic_deploy_with_proxy() {
     let tmp = setup_project("tests/fixture/basic");

--- a/crates/sync-core/src/scan.rs
+++ b/crates/sync-core/src/scan.rs
@@ -25,13 +25,33 @@ pub struct AssetSource {
     pub key: String,
 }
 
+/// Builds an absolute root for `dir` (a manifest-relative directory the host
+/// preopened) by prepending `/` and dropping `.` / redundant components.
+///
+/// We deliberately avoid [`Path::canonicalize`] here. Under WASI it calls
+/// `realpath`, which returns `ENOENT` ("No such file or directory") for *any*
+/// path beneath a preopen whose guest name has more than one component (e.g.
+/// `src/frontend/dist`) — even though ordinary access (`read_dir`, `metadata`,
+/// `read`) through that preopen works fine. Single-component dirs like `dist`
+/// happen to canonicalize to `/dist`; this helper produces the same shape
+/// (`/src/frontend/dist`) for nested dirs without touching `realpath`.
+///
+/// The host guarantees `dir` is relative and free of `..` components, so keeping
+/// only `Normal` components cannot escape the preopen.
+fn absolute_root(dir: &str) -> PathBuf {
+    let mut root = PathBuf::from("/");
+    for component in Path::new(dir).components() {
+        if let std::path::Component::Normal(c) = component {
+            root.push(c);
+        }
+    }
+    root
+}
+
 /// Scans `dir` for asset files.
 pub fn scan(dir: &str) -> Result<Vec<AssetSource>, String> {
     let mut out = Vec::new();
-    let root = Path::new(dir);
-    let root_abs = root
-        .canonicalize()
-        .map_err(|e| format!("canonicalize {}: {e}", root.display()))?;
+    let root_abs = absolute_root(dir);
     walk(&root_abs, &root_abs, &mut out)?;
     Ok(out)
 }


### PR DESCRIPTION
Ports the WASI `canonicalize` fix from the `migration` branch (#71) to `main`.

## Problem
The sync plugin's scan step canonicalized the manifest `dir`. On `wasm32-wasip2`, `Path::canonicalize` calls `realpath`, which returns `ENOENT` for **any** path beneath a preopen whose WASI guest name has more than one component (e.g. `src/frontend/dist`) — even though `read_dir`/`metadata`/`read` through that preopen work fine. So a nested `dir` failed:

```
failed to run plugin
  caused by: plugin returned error: canonicalize src/frontend/dist: No such file or directory (os error 44)
```

Single-component dirs like `dist` happened to canonicalize to `/dist` and worked, which is why the existing fixtures never caught it. (Originally reported on the [forum](https://forum.dfinity.org/t/icp-cli-announcements-and-feedback-discussion/60410/97) against the migration recipe; same root cause lives here.)

## Fix
Build the scan root by prepending `/` to the (host-validated, relative, `..`-free) manifest dir instead of canonicalizing. This yields the same shape canonicalize produced for single-component dirs (`/dist`, `/src/frontend/dist`) and uses only plain `wasi:filesystem` ops the preopen supports. `main`'s `scan()` had a single `canonicalize` call; `walk` already uses `read_dir` paths rooted at that dir, and `_headers`/`_redirects` load via relative paths — none of which need canonicalization.

## Test
Adds an e2e fixture + `nested_dir_deploy` test using `dirs: [src/frontend/dist]` with a nested subdir asset. Verified it fails with the exact error above when the fix is reverted, and passes with it.

- `cargo test -p sync-core` — 188 pass
- `cargo test -p e2e --test sync` — 7 pass (incl. nested regression)
- `cargo clippy -p sync-core` — clean

Note: this is the same fix already shipped on `migration` as `migration-v2.2.1` (consumed by `asset-canister-v2.2.1`).