### PR TITLE
refactor: remove max_age asset property

### DIFF
--- a/crates/canister-core/src/asset.rs
+++ b/crates/canister-core/src/asset.rs
@@ -76,14 +76,12 @@ impl AssetEncoding {
     fn compute_response_hashes(
         &self,
         headers: &Option<Vec<(String, String)>>,
-        max_age: &Option<u64>,
         content_type: &str,
         encoding_name: &str,
     ) -> HashMap<u16, [u8; 32]> {
         // Collect all user-defined headers
         let base_headers: Vec<(String, Value)> = build_headers(
             headers.as_ref().map(|h| h.iter().map(|(k, v)| (k, v))),
-            max_age,
             content_type,
             encoding_name,
             self.certificate_expression.as_ref(),
@@ -115,7 +113,6 @@ impl AssetEncoding {
 pub struct Asset {
     pub content_type: String,
     pub encodings: HashMap<String, AssetEncoding>,
-    pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
 }
 
@@ -133,7 +130,6 @@ pub struct AssetDetails {
     pub key: String,
     pub content_type: String,
     pub encodings: Vec<AssetEncodingDetails>,
-    pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
 }
 
@@ -150,9 +146,6 @@ impl Asset {
         // gather all headers
         let mut headers: Vec<(String, Value)> = vec![];
 
-        if self.max_age.is_some() {
-            headers.push(("cache-control".to_string(), Value::String("".to_string())));
-        }
         if let Some(custom_headers) = &self.headers {
             for (k, v) in custom_headers.iter() {
                 headers.push((k.clone(), Value::String(v.clone())));
@@ -174,7 +167,6 @@ impl Asset {
             .and_then(|e| e.certificate_expression.as_ref());
         build_headers(
             self.headers.as_ref().map(|h| h.iter().map(|(k, v)| (k, v))),
-            &self.max_age,
             &self.content_type,
             encoding_name.to_owned(),
             ce,
@@ -294,16 +286,12 @@ impl Asset {
 
 fn build_headers(
     custom_headers: Option<impl Iterator<Item = (impl Into<String>, impl Into<String>)>>,
-    max_age: &Option<u64>,
     content_type: impl Into<String>,
     encoding_name: impl Into<String>,
     cert_expr: Option<&CertificateExpression>,
 ) -> Vec<(String, String)> {
     let mut headers: Vec<(String, String)> =
         vec![("content-type".to_string(), content_type.into())];
-    if let Some(max_age) = max_age {
-        headers.push(("cache-control".to_string(), format!("max-age={max_age}")));
-    }
     let encoding_name = encoding_name.into();
     if encoding_name != "identity" {
         headers.push(("content-encoding".to_string(), encoding_name));
@@ -344,15 +332,13 @@ pub(crate) fn on_asset_change(
     let Asset {
         content_type,
         encodings,
-        max_age,
         headers,
         ..
     } = asset;
 
     // Insert certified response values into hash_tree
     for (enc_name, enc) in encodings.iter_mut() {
-        enc.response_hashes =
-            Some(enc.compute_response_hashes(headers, max_age, content_type, enc_name));
+        enc.response_hashes = Some(enc.compute_response_hashes(headers, content_type, enc_name));
 
         insert_new_response_hashes_for_encoding(asset_hashes, enc, &affected_keys);
         enc.certified = true;

--- a/crates/canister-core/src/stable.rs
+++ b/crates/canister-core/src/stable.rs
@@ -44,7 +44,6 @@ impl From<crate::state::State> for StableState {
 pub struct StableAsset {
     pub content_type: String,
     pub encodings: HashMap<String, StableAssetEncoding>,
-    pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
 }
 
@@ -57,7 +56,6 @@ impl From<crate::asset::Asset> for StableAsset {
                 .into_iter()
                 .map(|(k, v)| (k, v.into()))
                 .collect(),
-            max_age: asset.max_age,
             headers: asset.headers,
         }
     }
@@ -72,7 +70,6 @@ impl From<StableAsset> for crate::asset::Asset {
                 .into_iter()
                 .map(|(k, v)| (k, v.into()))
                 .collect(),
-            max_age: stable_asset.max_age,
             headers: stable_asset.headers,
         }
     }

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -106,7 +106,6 @@ impl State {
             Asset {
                 content_type: arg.content_type,
                 encodings: HashMap::new(),
-                max_age: arg.max_age,
                 headers: arg.headers,
             },
         );
@@ -308,7 +307,6 @@ impl State {
                         key: key.clone(),
                         content_type: asset.content_type.clone(),
                         encodings,
-                        max_age: asset.max_age,
                         headers: asset.headers.clone(),
                     }
                 })
@@ -554,7 +552,6 @@ impl State {
             .ok_or_else(|| "asset not found".to_string())?;
 
         Ok(AssetProperties {
-            max_age: asset.max_age,
             headers: asset.headers.clone(),
         })
     }
@@ -568,9 +565,6 @@ impl State {
 
         if let Some(headers) = arg.headers {
             asset.headers = headers
-        }
-        if let Some(max_age) = arg.max_age {
-            asset.max_age = max_age
         }
 
         on_asset_change(&mut self.asset_hashes, &arg.key, asset, dependent_keys);

--- a/crates/canister-core/src/state_hash.rs
+++ b/crates/canister-core/src/state_hash.rs
@@ -80,7 +80,6 @@ fn next_step(
             let args = CreateAssetArguments {
                 key: key.clone(),
                 content_type: asset.content_type.clone(),
-                max_age: asset.max_age,
                 headers: asset.headers.clone(),
             };
             hash_create_asset(&mut hasher, &args);
@@ -173,12 +172,6 @@ fn hash_create_asset(hasher: &mut Sha256, args: &CreateAssetArguments) {
     hasher.update(TAG_CREATE_ASSET);
     hasher.update(&args.key);
     hasher.update(&args.content_type);
-    if let Some(max_age) = args.max_age {
-        hasher.update(TAG_SOME);
-        hasher.update(max_age.to_be_bytes());
-    } else {
-        hasher.update(TAG_NONE);
-    }
     hash_headers(hasher, args.headers.as_ref());
 }
 

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -132,7 +132,6 @@ struct AssetBuilder {
     name: String,
     content_type: String,
     encodings: Vec<(String, Vec<ByteBuf>)>,
-    max_age: Option<u64>,
     headers: Option<Vec<(String, String)>>,
 }
 
@@ -142,14 +141,8 @@ impl AssetBuilder {
             name: name.as_ref().to_string(),
             content_type: content_type.as_ref().to_string(),
             encodings: vec![],
-            max_age: None,
             headers: None,
         }
-    }
-
-    fn with_max_age(mut self, max_age: u64) -> Self {
-        self.max_age = Some(max_age);
-        self
     }
 
     fn with_encoding(mut self, name: impl AsRef<str>, chunks: Vec<impl AsRef<[u8]>>) -> Self {
@@ -257,7 +250,6 @@ fn assemble_create_assets_and_set_contents_operations(
         operations.push(BatchOperation::CreateAsset(CreateAssetArguments {
             key: asset.name.clone(),
             content_type: asset.content_type,
-            max_age: asset.max_age,
             headers: asset.headers,
         }));
 
@@ -813,7 +805,7 @@ fn get_and_get_chunk_for_multichunk_assets() {
 }
 
 #[test]
-fn supports_max_age_headers() {
+fn supports_cache_control_via_headers() {
     let mut state = State::default();
     let system_context = mock_system_context();
 
@@ -824,8 +816,8 @@ fn supports_max_age_headers() {
         &system_context,
         vec![
             AssetBuilder::new("/contents.html", "text/html").with_encoding("identity", vec![BODY]),
-            AssetBuilder::new("/max-age.html", "text/html")
-                .with_max_age(604800)
+            AssetBuilder::new("/cached.html", "text/html")
+                .with_header("Cache-Control", "max-age=604800")
                 .with_encoding("identity", vec![BODY]),
         ],
     );
@@ -846,7 +838,7 @@ fn supports_max_age_headers() {
 
     let response = certified_http_request(
         &state,
-        RequestBuilder::get("/max-age.html")
+        RequestBuilder::get("/cached.html")
             .with_header("Accept-Encoding", "gzip,identity")
             .build(),
     );
@@ -904,8 +896,7 @@ fn supports_custom_http_headers() {
             AssetBuilder::new("/contents.html", "text/html")
                 .with_encoding("identity", vec![BODY])
                 .with_header("Access-Control-Allow-Origin", "*"),
-            AssetBuilder::new("/max-age.html", "text/html")
-                .with_max_age(604800)
+            AssetBuilder::new("/other.html", "text/html")
                 .with_encoding("identity", vec![BODY])
                 .with_header("X-Content-Type-Options", "nosniff"),
         ],
@@ -931,18 +922,13 @@ fn supports_custom_http_headers() {
 
     let response = certified_http_request(
         &state,
-        RequestBuilder::get("/max-age.html")
+        RequestBuilder::get("/other.html")
             .with_header("Accept-Encoding", "gzip,identity")
             .build(),
     );
 
     assert_eq!(response.status_code, 200);
     assert_eq!(response.body.as_ref(), BODY);
-    assert_eq!(
-        lookup_header(&response, "Cache-Control"),
-        Some("max-age=604800"),
-        "No matching Cache-Control header in response: {response:#?}",
-    );
     assert!(
         lookup_header(&response, "X-Content-Type-Options").is_some(),
         "Missing X-Content-Type-Options header in response: {response:#?}",
@@ -967,8 +953,7 @@ fn supports_getting_and_setting_asset_properties() {
             AssetBuilder::new("/contents.html", "text/html")
                 .with_encoding("identity", vec![BODY])
                 .with_header("Access-Control-Allow-Origin", "*"),
-            AssetBuilder::new("/max-age.html", "text/html")
-                .with_max_age(604800)
+            AssetBuilder::new("/props.html", "text/html")
                 .with_encoding("identity", vec![BODY])
                 .with_header("X-Content-Type-Options", "nosniff"),
         ],
@@ -977,97 +962,54 @@ fn supports_getting_and_setting_asset_properties() {
     assert_eq!(
         state.get_asset_properties("/contents.html".into()),
         Ok(AssetProperties {
-            max_age: None,
             headers: Some(vec![("Access-Control-Allow-Origin".into(), "*".into())]),
         })
     );
     assert_eq!(
-        state.get_asset_properties("/max-age.html".into()),
+        state.get_asset_properties("/props.html".into()),
         Ok(AssetProperties {
-            max_age: Some(604800),
             headers: Some(vec![("X-Content-Type-Options".into(), "nosniff".into())]),
         })
     );
 
+    // `Some(Some(..))` replaces the headers map.
     assert!(state
         .set_asset_properties(SetAssetPropertiesArguments {
-            key: "/max-age.html".into(),
-            max_age: Some(Some(1)),
-            headers: Some(Some(vec![(
-                "X-Content-Type-Options".into(),
-                "nosniff".into()
-            )])),
-        })
-        .is_ok());
-    assert_eq!(
-        state.get_asset_properties("/max-age.html".into()),
-        Ok(AssetProperties {
-            max_age: Some(1),
-            headers: Some(vec![("X-Content-Type-Options".into(), "nosniff".into())]),
-        })
-    );
-
-    assert!(state
-        .set_asset_properties(SetAssetPropertiesArguments {
-            key: "/max-age.html".into(),
-            max_age: Some(None),
-            headers: Some(None),
-        })
-        .is_ok());
-    assert_eq!(
-        state.get_asset_properties("/max-age.html".into()),
-        Ok(AssetProperties {
-            max_age: None,
-            headers: None,
-        })
-    );
-
-    assert!(state
-        .set_asset_properties(SetAssetPropertiesArguments {
-            key: "/max-age.html".into(),
-            max_age: Some(Some(1)),
-            headers: Some(Some(vec![(
-                "X-Content-Type-Options".into(),
-                "nosniff".into()
-            )])),
-        })
-        .is_ok());
-    assert_eq!(
-        state.get_asset_properties("/max-age.html".into()),
-        Ok(AssetProperties {
-            max_age: Some(1),
-            headers: Some(vec![("X-Content-Type-Options".into(), "nosniff".into())]),
-        })
-    );
-
-    assert!(state
-        .set_asset_properties(SetAssetPropertiesArguments {
-            key: "/max-age.html".into(),
-            max_age: None,
+            key: "/props.html".into(),
             headers: Some(Some(vec![("new-header".into(), "value".into())])),
         })
         .is_ok());
     assert_eq!(
-        state.get_asset_properties("/max-age.html".into()),
+        state.get_asset_properties("/props.html".into()),
         Ok(AssetProperties {
-            max_age: Some(1),
             headers: Some(vec![("new-header".into(), "value".into())]),
         })
     );
 
+    // `None` leaves the existing headers untouched.
     assert!(state
         .set_asset_properties(SetAssetPropertiesArguments {
-            key: "/max-age.html".into(),
-            max_age: Some(Some(2)),
+            key: "/props.html".into(),
             headers: None,
         })
         .is_ok());
     assert_eq!(
-        state.get_asset_properties("/max-age.html".into()),
+        state.get_asset_properties("/props.html".into()),
         Ok(AssetProperties {
-            max_age: Some(2),
             headers: Some(vec![("new-header".into(), "value".into())]),
         })
+    );
+
+    // `Some(None)` clears the headers map.
+    assert!(state
+        .set_asset_properties(SetAssetPropertiesArguments {
+            key: "/props.html".into(),
+            headers: Some(None),
+        })
+        .is_ok());
+    assert_eq!(
+        state.get_asset_properties("/props.html".into()),
+        Ok(AssetProperties { headers: None })
     );
 }
 
@@ -1089,7 +1031,6 @@ fn create_asset_fails_if_asset_exists() {
             .create_asset(CreateAssetArguments {
                 key: "/contents.html".to_string(),
                 content_type: "text/html".to_string(),
-                max_age: None,
                 headers: None,
             })
             .unwrap_err()
@@ -1346,7 +1287,6 @@ mod certificate_expression {
             &system_context,
             vec![AssetBuilder::new("/contents.html", "text/html")
                 .with_encoding("identity", vec![BODY])
-                .with_max_age(604800)
                 .with_header("Access-Control-Allow-Origin", "*")],
         );
 
@@ -1363,7 +1303,7 @@ mod certificate_expression {
         );
         assert_eq!(
             lookup_header(&response, "ic-certificateexpression").unwrap(),
-            r#"default_certification(ValidationArgs{certification: Certification{no_request_certification: Empty{}, response_certification: ResponseCertification{certified_response_headers: ResponseHeaderList{headers: ["content-type", "cache-control", "Access-Control-Allow-Origin"]}}}})"#,
+            r#"default_certification(ValidationArgs{certification: Certification{no_request_certification: Empty{}, response_certification: ResponseCertification{certified_response_headers: ResponseHeaderList{headers: ["content-type", "Access-Control-Allow-Origin"]}}}})"#,
             "Missing ic-certifiedexpression header in response: {response:#?}",
         );
     }
@@ -1380,7 +1320,6 @@ mod certificate_expression {
             &system_context,
             vec![AssetBuilder::new("/contents.html", "text/html")
                 .with_encoding("gzip", vec![BODY])
-                .with_max_age(604800)
                 .with_header("Access-Control-Allow-Origin", "*")],
         );
 
@@ -1398,14 +1337,13 @@ mod certificate_expression {
         );
         assert_eq!(
             lookup_header(&response, "ic-certificateexpression").unwrap(),
-            r#"default_certification(ValidationArgs{certification: Certification{no_request_certification: Empty{}, response_certification: ResponseCertification{certified_response_headers: ResponseHeaderList{headers: ["content-type", "content-encoding", "cache-control", "Access-Control-Allow-Origin"]}}}})"#,
+            r#"default_certification(ValidationArgs{certification: Certification{no_request_certification: Empty{}, response_certification: ResponseCertification{certified_response_headers: ResponseHeaderList{headers: ["content-type", "content-encoding", "Access-Control-Allow-Origin"]}}}})"#,
             "Missing ic-certificateexpression header in response: {response:#?}",
         );
 
         state
             .set_asset_properties(SetAssetPropertiesArguments {
                 key: "/contents.html".into(),
-                max_age: Some(None),
                 headers: Some(Some(vec![("custom-header".into(), "value".into())])),
             })
             .unwrap();
@@ -1445,7 +1383,6 @@ mod certification {
             &system_context,
             vec![AssetBuilder::new("/contents.html", "text/html")
                 .with_encoding("identity", vec![BODY])
-                .with_max_age(604800)
                 .with_header("Access-Control-Allow-Origin", "*")],
         );
 
@@ -1475,7 +1412,6 @@ mod certification {
             &system_context,
             vec![AssetBuilder::new("/contents.html", "text/html")
                 .with_encoding("identity", vec![UPDATED_BODY])
-                .with_max_age(604800)
                 .with_header("Access-Control-Allow-Origin", "*")],
         );
 
@@ -1543,7 +1479,6 @@ mod last_state_update_timestamp {
                     operations: vec![BatchOperation::CreateAsset(CreateAssetArguments {
                         key: "/test.txt".to_string(),
                         content_type: "text/plain".to_string(),
-                        max_age: None,
                         headers: None,
                     })],
                 },
@@ -1578,7 +1513,6 @@ mod last_state_update_timestamp {
                     operations: vec![BatchOperation::CreateAsset(CreateAssetArguments {
                         key: "/test.txt".to_string(),
                         content_type: "text/plain".to_string(),
-                        max_age: None,
                         headers: None,
                     })],
                 },
@@ -1605,7 +1539,6 @@ mod last_state_update_timestamp {
                                 "x-custom".to_string(),
                                 "value".to_string(),
                             )])),
-                            max_age: None,
                         },
                     )],
                 },
@@ -1634,7 +1567,6 @@ mod last_state_update_timestamp {
                     operations: vec![BatchOperation::CreateAsset(CreateAssetArguments {
                         key: "/test.txt".to_string(),
                         content_type: "text/plain".to_string(),
-                        max_age: None,
                         headers: None,
                     })],
                 },
@@ -1880,7 +1812,6 @@ mod set_asset_content_sha256_verification {
             .create_asset(CreateAssetArguments {
                 key: "/test.txt".to_string(),
                 content_type: "text/plain".to_string(),
-                max_age: None,
                 headers: None,
             })
             .unwrap();
@@ -1925,7 +1856,6 @@ mod set_asset_content_sha256_verification {
             .create_asset(CreateAssetArguments {
                 key: "/test.txt".to_string(),
                 content_type: "text/plain".to_string(),
-                max_age: None,
                 headers: None,
             })
             .unwrap();
@@ -1970,7 +1900,6 @@ mod set_asset_content_sha256_verification {
             .create_asset(CreateAssetArguments {
                 key: "/test.txt".to_string(),
                 content_type: "text/plain".to_string(),
-                max_age: None,
                 headers: None,
             })
             .unwrap();
@@ -2028,7 +1957,6 @@ mod set_asset_content_sha256_verification {
             .create_asset(CreateAssetArguments {
                 key: "/test.txt".to_string(),
                 content_type: "text/plain".to_string(),
-                max_age: None,
                 headers: None,
             })
             .unwrap();
@@ -2077,7 +2005,6 @@ mod set_asset_content_sha256_verification {
             .create_asset(CreateAssetArguments {
                 key: "/test.txt".to_string(),
                 content_type: "text/plain".to_string(),
-                max_age: None,
                 headers: None,
             })
             .unwrap();
@@ -2137,7 +2064,6 @@ mod compute_state_hash {
                 BatchOperation::CreateAsset(CreateAssetArguments {
                     key: "asset1".to_string(),
                     content_type: "text/plain".to_string(),
-                    max_age: None,
                     headers: None,
                 }),
                 BatchOperation::SetAssetContent(SetAssetContentArguments {
@@ -2167,7 +2093,6 @@ mod compute_state_hash {
             operations: vec![BatchOperation::CreateAsset(CreateAssetArguments {
                 key: "asset2".to_string(),
                 content_type: "text/plain".to_string(),
-                max_age: None,
                 headers: None,
             })],
         };

--- a/crates/canister-core/src/types.rs
+++ b/crates/canister-core/src/types.rs
@@ -21,7 +21,6 @@ pub struct StateInfo {
 pub struct CreateAssetArguments {
     pub key: AssetKey,
     pub content_type: String,
-    pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
 }
 
@@ -113,14 +112,12 @@ pub struct CreateChunksResponse {
 
 #[derive(Clone, Debug, CandidType, Deserialize, PartialEq, Eq)]
 pub struct AssetProperties {
-    pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct SetAssetPropertiesArguments {
     pub key: AssetKey,
-    pub max_age: Option<Option<u64>>,
     pub headers: Option<Option<Vec<(String, String)>>>,
 }
 

--- a/crates/canister/assets.did
+++ b/crates/canister/assets.did
@@ -6,7 +6,6 @@ type Time = int;
 type CreateAssetArguments = record {
   key: Key;
   content_type: text;
-  max_age: opt nat64;
   headers: opt vec HeaderField;
 };
 
@@ -111,7 +110,6 @@ type StreamingStrategy = variant {
 
 type SetAssetPropertiesArguments = record {
   key: Key;
-  max_age: opt opt nat64;
   headers: opt opt vec HeaderField;
 };
 
@@ -166,12 +164,10 @@ service: () -> {
       length: nat; // Size of this encoding's blob. Calculated when uploading assets.
       modified: Time;
     };
-    max_age: opt nat64;
     headers: opt vec HeaderField;
   }) query;
 
   get_asset_properties : (key: Key) -> (record {
-    max_age: opt nat64;
     headers: opt vec HeaderField; } ) query;
 
   certified_tree : () -> (record {

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -107,7 +107,6 @@ pub fn setup_project(fixture_path: &str) -> tempfile::TempDir {
 
 #[derive(CandidType, Clone, Debug, Deserialize, PartialEq)]
 pub struct AssetProperties {
-    pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
 }
 

--- a/crates/sync-core/src/canister.rs
+++ b/crates/sync-core/src/canister.rs
@@ -25,7 +25,6 @@ pub struct AssetDetails {
 pub struct CreateAssetArguments {
     pub key: String,
     pub content_type: String,
-    pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
 }
 
@@ -55,7 +54,6 @@ pub struct ClearArguments {}
 #[derive(CandidType, Clone, Debug)]
 pub struct SetAssetPropertiesArguments {
     pub key: String,
-    pub max_age: Option<Option<u64>>,
     pub headers: Option<Option<Vec<(String, String)>>>,
 }
 
@@ -97,7 +95,6 @@ pub struct CommitBatchArguments {
 
 #[derive(CandidType, Clone, Debug, Deserialize, Default)]
 pub struct AssetProperties {
-    pub max_age: Option<u64>,
     pub headers: Option<Vec<(String, String)>>,
 }
 

--- a/crates/sync-core/src/sync.rs
+++ b/crates/sync-core/src/sync.rs
@@ -603,14 +603,13 @@ fn build_operations(
 
     // 2. Create new assets (those not present after deletions). Per-asset
     //    headers come from resolving the project's `_headers` rules against
-    //    each new key; max_age falls back to defaults.
+    //    each new key.
     for (key, pa) in project_assets {
         if !canister_assets.contains_key(key) {
             let resolved = headers::resolve(key, project_header_rules);
             ops.push(BatchOperationKind::CreateAsset(CreateAssetArguments {
                 key: key.clone(),
                 content_type: pa.media_type.to_string(),
-                max_age: None,
                 headers: (!resolved.is_empty()).then_some(resolved),
             }));
         }
@@ -724,13 +723,12 @@ fn load_redirect_rules(dir: &str) -> Result<Vec<RedirectRule>, String> {
     redirects::parse(&content).map_err(|e| format!("{}: {e}", path.display()))
 }
 
-// For each asset that already exists on the canister, reset any per-asset
-// properties (`max_age`, `headers`) that drifted from the project config.
-// Newly-created assets get the same values via `CreateAssetArguments`, so we
-// don't emit `SetAssetProperties` for them.
+// For each asset that already exists on the canister, reset its `headers` when
+// they drifted from the project config. Newly-created assets get the same
+// values via `CreateAssetArguments`, so we don't emit `SetAssetProperties` for
+// them.
 //
-// Headers are resolved from `_headers` per-key; everything else falls back to
-// plugin defaults (None).
+// Headers are resolved from `_headers` per-key.
 //
 // `canister_assets` is the post-deletion view: keys removed in step 1 (missing
 // from the project, or content_type drift forcing delete-then-create) are
@@ -752,22 +750,14 @@ fn update_properties(
             continue;
         };
 
-        let max_age = canister_props.max_age.is_some().then_some(None);
-
         let resolved = headers::resolve(key, project_header_rules);
         let expected_headers = (!resolved.is_empty()).then_some(resolved);
-        let headers = if canister_props.headers != expected_headers {
-            Some(expected_headers)
-        } else {
-            None
-        };
 
-        if max_age.is_some() || headers.is_some() {
+        if canister_props.headers != expected_headers {
             ops.push(BatchOperationKind::SetAssetProperties(
                 SetAssetPropertiesArguments {
                     key: key.clone(),
-                    max_age,
-                    headers,
+                    headers: Some(expected_headers),
                 },
             ));
         }
@@ -999,7 +989,6 @@ mod tests {
         BatchOperationKind::CreateAsset(CreateAssetArguments {
             key: key.to_string(),
             content_type: "text/plain".to_string(),
-            max_age: None,
             headers: Some(vec![(name, value)]),
         })
     }
@@ -1705,7 +1694,6 @@ mod tests {
             })
             .expect("CreateAsset op");
 
-        assert_eq!(create_op.max_age, None);
         assert!(create_op.headers.is_none());
     }
 
@@ -1732,45 +1720,13 @@ mod tests {
             "text/html",
             &[("identity", Some(vec![1, 2, 3]))],
         )]);
-        let canister_props = HashMap::from([(
-            "/index.html".to_string(),
-            AssetProperties {
-                max_age: None,
-                headers: None,
-            },
-        )]);
+        let canister_props =
+            HashMap::from([("/index.html".to_string(), AssetProperties { headers: None })]);
         let ops = build_operations(&project, &canister, &canister_props, &[], &[], &[]);
         assert!(
             set_props_ops(&ops).is_empty(),
             "no SetAssetProperties op when canister already matches defaults"
         );
-    }
-
-    #[test]
-    fn update_properties_clears_max_age_when_canister_has_it() {
-        let project = HashMap::from([mk_project_asset(
-            "/index.html",
-            "text/html",
-            &[("identity", vec![1, 2, 3], true)],
-        )]);
-        let canister = HashMap::from([mk_canister_asset(
-            "/index.html",
-            "text/html",
-            &[("identity", Some(vec![1, 2, 3]))],
-        )]);
-        let canister_props = HashMap::from([(
-            "/index.html".to_string(),
-            AssetProperties {
-                max_age: Some(60),
-                headers: None,
-            },
-        )]);
-        let ops = build_operations(&project, &canister, &canister_props, &[], &[], &[]);
-        let by_key = set_props_ops(&ops);
-        assert_eq!(by_key.len(), 1);
-        // canister has Some(60), defaults are None — the op must explicitly
-        // request clearing (the inner None means "set to null on the canister").
-        assert_eq!(by_key["/index.html"].max_age, Some(None));
     }
 
     #[test]
@@ -1789,7 +1745,6 @@ mod tests {
         let canister_props = HashMap::from([(
             "/index.html".to_string(),
             AssetProperties {
-                max_age: None,
                 headers: Some(canister_headers),
             },
         )]);
@@ -1819,8 +1774,7 @@ mod tests {
         let canister_props = HashMap::from([(
             "/file".to_string(),
             AssetProperties {
-                max_age: Some(60),
-                headers: None,
+                headers: Some(vec![("X-Frame-Options".to_string(), "DENY".to_string())]),
             },
         )]);
         let ops = build_operations(&project, &canister, &canister_props, &[], &[], &[]);
@@ -1925,13 +1879,8 @@ mod tests {
             "text/html",
             &[("identity", Some(vec![1, 2, 3]))],
         )]);
-        let canister_props = HashMap::from([(
-            "/index.html".to_string(),
-            AssetProperties {
-                max_age: None,
-                headers: None,
-            },
-        )]);
+        let canister_props =
+            HashMap::from([("/index.html".to_string(), AssetProperties { headers: None })]);
         let header_rules = vec![mk_header_rule("/*", &[("X-Frame-Options", "DENY")])];
         let ops = build_operations(
             &project,
@@ -1964,7 +1913,6 @@ mod tests {
         let canister_props = HashMap::from([(
             "/index.html".to_string(),
             AssetProperties {
-                max_age: None,
                 headers: Some(vec![("X-Frame-Options".into(), "DENY".into())]),
             },
         )]);
@@ -2095,7 +2043,6 @@ mod tests {
         let canister_props = HashMap::from([(
             "/index.html".to_string(),
             AssetProperties {
-                max_age: None,
                 headers: Some(vec![("X-Frame-Options".into(), "DENY".into())]),
             },
         )]);
@@ -2303,7 +2250,6 @@ mod tests {
         mock.push_ok(
             "get_asset_properties",
             AssetProperties {
-                max_age: None,
                 headers: Some(vec![("X-Frame-Options".into(), "DENY".into())]),
             },
         );
@@ -2447,13 +2393,7 @@ mod tests {
         );
         mock.push_ok("list", Vec::<AssetDetails>::new());
         mock.push_ok("get_redirect_rules", canister_rules);
-        mock.push_ok(
-            "get_asset_properties",
-            AssetProperties {
-                max_age: None,
-                headers: None,
-            },
-        );
+        mock.push_ok("get_asset_properties", AssetProperties { headers: None });
 
         let result = sync(
             &mock,

--- a/crates/sync-core/tests/bench_sync.rs
+++ b/crates/sync-core/tests/bench_sync.rs
@@ -96,10 +96,7 @@ impl CanisterCall for BenchMock {
             "api_version" => Encode!(&2u16),
             "list" => Encode!(&Vec::<AssetDetails>::new()),
             "get_redirect_rules" => Encode!(&Vec::<RedirectRule>::new()),
-            "get_asset_properties" => Encode!(&AssetProperties {
-                max_age: None,
-                headers: None,
-            }),
+            "get_asset_properties" => Encode!(&AssetProperties { headers: None }),
             "create_batch" => Encode!(&CreateBatchOk {
                 batch_id: Nat::from(1u32),
             }),


### PR DESCRIPTION
`max_age` was carried over from the old SDK assets canister. On the canister it only ever synthesized a `cache-control: max-age={N}` response header, and the sync-plugin never wrote a real value — it hardcoded `None` on create and only ever *cleared* a pre-existing value. Its purpose is now fully covered by the `_headers` file, which lets users set `Cache-Control` (and any other response header) directly.

This drops the field everywhere: the canister wire interface (`.did`), `CreateAssetArguments` / `SetAssetPropertiesArguments` / `AssetProperties` / `Asset` / `StableAsset`, the header-building and certification paths, the state hash, the sync-plugin mirrors and diff logic, and the e2e helper. Tests that exercised `max_age` are reworked to drive `Cache-Control` through `headers` instead.