### PR TITLE
refactor: remove unused Clear batch operation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,29 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
       - name: Install icp CLI
         run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/dfinity/icp-cli/releases/latest/download/icp-cli-installer.sh | sh
+      # Warm the shared network-launcher cache once, up front, so the parallel
+      # e2e tests reuse it instead of each racing to download the same tarball.
+      # ICP_CLI_GITHUB_TOKEN authenticates this download (5000/h limit vs the
+      # unauthenticated 60/h that the tests were tripping); a short retry
+      # absorbs the occasional transient 5xx from GitHub. Only this step needs
+      # the token — once the launcher is cached, the test step downloads nothing.
+      - name: Pre-download network launcher
+        run: |
+          for attempt in 1 2 3; do
+            if icp network update; then
+              exit 0
+            fi
+            echo "network launcher download attempt $attempt failed; retrying..." >&2
+            sleep $((attempt * 5))
+          done
+          echo "network launcher download failed after 3 attempts" >&2
+          exit 1
+        env:
+          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run tests
         run: | # https://github.com/rust-lang/cargo/issues/6669 we have to run ALL tests with two commands
           cargo test --all-targets --no-fail-fast
           cargo test --doc
-        env:
-          ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   fmt:
     name: cargo fmt

--- a/crates/canister-core/src/batch.rs
+++ b/crates/canister-core/src/batch.rs
@@ -233,10 +233,6 @@ impl State {
                         self.delete_asset(arg.clone());
                         Ok(())
                     }
-                    BatchOperation::Clear(_) => {
-                        self.clear();
-                        Ok(())
-                    }
                     BatchOperation::SetAssetProperties(arg) => {
                         self.set_asset_properties(arg.clone())
                     }

--- a/crates/canister-core/src/lib.rs
+++ b/crates/canister-core/src/lib.rs
@@ -202,13 +202,6 @@ pub fn guard_is_controller() -> Result<(), String> {
     }
 }
 
-pub fn init() {
-    // The authorized set starts empty. Controllers can always sync; this set
-    // only grants sync access to *non*-controllers, managed afterwards through
-    // the `authorize`/`deauthorize` endpoints.
-    with_state_mut(|s| s.clear());
-}
-
 pub fn pre_upgrade() -> StableState {
     STATE.with(|s| s.take().into())
 }

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -207,14 +207,6 @@ impl State {
         }
     }
 
-    pub fn clear(&mut self) {
-        self.assets.clear();
-        self.batches.clear();
-        self.chunks.clear();
-        self.next_batch_id = Nat::from(1_u8);
-        self.next_chunk_id = Nat::from(1_u8);
-    }
-
     pub fn retrieve(&self, key: &AssetKey) -> Result<RcBytes, String> {
         let asset = self.get_asset(key)?;
 
@@ -694,7 +686,7 @@ impl From<StableState> for State {
             next_batch_id: stable_state
                 .next_batch_id
                 .map(BatchId::from)
-                .unwrap_or_else(|| Nat::from(1_u8)),
+                .unwrap_or_default(),
             last_state_update_timestamp_ns: stable_state.last_state_update_timestamp.unwrap_or(0),
             redirect_rules: stable_state.redirect_rules.unwrap_or_default(),
             ..Self::default()

--- a/crates/canister-core/src/types.rs
+++ b/crates/canister-core/src/types.rs
@@ -46,15 +46,11 @@ pub struct DeleteAssetArguments {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct ClearArguments {}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
 pub enum BatchOperation {
     CreateAsset(CreateAssetArguments),
     SetAssetContent(SetAssetContentArguments),
     UnsetAssetContent(UnsetAssetContentArguments),
     DeleteAsset(DeleteAssetArguments),
-    Clear(ClearArguments),
     SetAssetProperties(SetAssetPropertiesArguments),
     SetRedirectRules(SetRedirectRulesArguments),
 }

--- a/crates/canister/assets.did
+++ b/crates/canister/assets.did
@@ -113,7 +113,7 @@ type StateInfo = record {
   state_hash: opt text;
 };
 
-service: () -> {
+service: {
   // ───────── Canister metadata ─────────
 
   api_version: () -> (nat16) query;

--- a/crates/canister/assets.did
+++ b/crates/canister/assets.did
@@ -29,9 +29,6 @@ type DeleteAssetArguments = record {
   key: Key;
 };
 
-// Reset everything
-type ClearArguments = record {};
-
 type BatchOperationKind = variant {
   CreateAsset: CreateAssetArguments;
   SetAssetContent: SetAssetContentArguments;
@@ -40,8 +37,6 @@ type BatchOperationKind = variant {
 
   UnsetAssetContent: UnsetAssetContentArguments;
   DeleteAsset: DeleteAssetArguments;
-
-  Clear: ClearArguments;
 
   SetRedirectRules: SetRedirectRulesArguments;
 };
@@ -179,8 +174,8 @@ service: () -> {
   //
   // Assets are only ever mutated through committed batches — there are no
   // single-asset mutation endpoints. A batch's `operations` carry the
-  // per-asset changes (create, set/unset content, set properties, delete,
-  // clear), applied atomically when the batch is committed.
+  // per-asset changes (create, set/unset content, set properties, delete),
+  // applied atomically when the batch is committed.
 
   create_batch : () -> (record { batch_id: BatchId });
   create_chunks: (record { batch_id: BatchId; content: vec blob }) -> (record { chunk_ids: vec ChunkId });

--- a/crates/canister/src/lib.rs
+++ b/crates/canister/src/lib.rs
@@ -15,14 +15,9 @@ use canister_core::{
         ListRequest, StateInfo,
     },
 };
-use ic_cdk::{init, post_upgrade, pre_upgrade, query, update};
+use ic_cdk::{post_upgrade, pre_upgrade, query, update};
 
 use crate::state::{load_stable_state, save_stable_state};
-
-#[init]
-fn init() {
-    canister_core::init();
-}
 
 #[pre_upgrade]
 fn pre_upgrade() {

--- a/crates/sync-core/src/canister.rs
+++ b/crates/sync-core/src/canister.rs
@@ -49,9 +49,6 @@ pub struct DeleteAssetArguments {
 }
 
 #[derive(CandidType, Clone, Debug)]
-pub struct ClearArguments {}
-
-#[derive(CandidType, Clone, Debug)]
 pub struct SetAssetPropertiesArguments {
     pub key: String,
     pub headers: Option<Option<Vec<(String, String)>>>,
@@ -78,7 +75,6 @@ pub struct SetRedirectRulesArguments {
 
 #[derive(CandidType, Clone, Debug)]
 pub enum BatchOperationKind {
-    Clear(ClearArguments),
     DeleteAsset(DeleteAssetArguments),
     CreateAsset(CreateAssetArguments),
     UnsetAssetContent(UnsetAssetContentArguments),

--- a/crates/sync-core/src/sync.rs
+++ b/crates/sync-core/src/sync.rs
@@ -564,8 +564,7 @@ fn header_bytes_of(op: &BatchOperationKind) -> usize {
             .iter()
             .map(|r| r.headers.as_deref().map_or(0, sum))
             .sum(),
-        BatchOperationKind::Clear(_)
-        | BatchOperationKind::DeleteAsset(_)
+        BatchOperationKind::DeleteAsset(_)
         | BatchOperationKind::UnsetAssetContent(_)
         | BatchOperationKind::SetAssetContent(_) => 0,
     }


### PR DESCRIPTION
## Summary

Removes dead code from the canister/plugin batch path. With no backward-compat constraint (the only contract is that the canister and sync-plugin in this repo work together), unused operations and redundant lifecycle code can be dropped.

### Remove the unused `Clear` batch operation

`Clear` was dead: the sync-plugin never constructs it, and the canister only handled it defensively. Removed everything tied to it:

- **`assets.did`** — the `ClearArguments` type, the `Clear:` variant, and the "clear" mention in the batch comment
- **`canister-core/src/types.rs`** — the `ClearArguments` struct and `BatchOperation::Clear` variant
- **`canister-core/src/batch.rs`** — the `Clear` match arm
- **`sync-core/src/canister.rs`** — the `ClearArguments` struct and `BatchOperationKind::Clear` variant
- **`sync-core/src/sync.rs`** — `Clear` from the header-byte match

The remaining six variants (`CreateAsset`, `SetAssetContent`, `UnsetAssetContent`, `DeleteAsset`, `SetAssetProperties`, `SetRedirectRules`) are all actively emitted by `build_operations`, so the enum now matches exactly the set of operations the plugin produces.

### Drop redundant `init`/`clear`

`STATE` is already constructed as `State::default()` at module load, so the `#[init]` hook only re-cleared already-empty maps and bumped the first batch/chunk id from `0` to `1`. Starting at `0` is already the behavior in tests and after every upgrade (`post_upgrade` resets `next_chunk_id` via `..Self::default()`), and nothing treats id `0` as a sentinel.

- Dropped the `#[init]` hook, `canister_core::init()`, and the now-unused `State::clear()`
- Defaulted the `next_batch_id` post-upgrade fallback to `0`, consistent with fresh install

### Fix flaky CI: pre-download the network launcher

CI failed intermittently because the e2e tests each invoke `icp network start`, which downloads the network-launcher tarball from GitHub. On a fresh runner the parallel tests raced to fetch the same **unauthenticated** tarball, hitting GitHub's 60-req/hour per-IP limit and failing with `500 Internal Server Error`.

- Added a **Pre-download network launcher** CI step that warms the shared (flock-serialized) launcher cache once up front via `icp network update`, authenticated with `ICP_CLI_GITHUB_TOKEN` (5000/h limit) and a short retry to absorb transient 5xx.
- The test step then reuses the cached launcher and downloads nothing, so the token is scoped to just the pre-download step.

> Root-cause note: the released `icp` only attaches the token when *resolving* `latest`, not when downloading the tarball itself. A separate fix in `icp-cli` (`cache.rs`) routes the tarball download through the same authenticated request; until that ships in a release, this CI step is what hardens the suite.
