### PR TITLE
refactor: replace batch upload with single-sync sessions

### DIFF
--- a/crates/canister-core/src/asset.rs
+++ b/crates/canister-core/src/asset.rs
@@ -20,7 +20,7 @@ use crate::http::{
     CallbackFunc, HeaderField, HttpResponse, StreamingCallbackToken, StreamingStrategy,
 };
 use crate::rc_bytes::RcBytes;
-use candid::{CandidType, Deserialize, Int, Nat};
+use candid::{CandidType, Deserialize, Nat};
 use ic_certification::Hash;
 use ic_representation_independent_hash::Value;
 use serde_bytes::ByteBuf;
@@ -49,7 +49,8 @@ pub fn encoding_certification_order<'a>(
 
 const STATUS_CODES_TO_CERTIFY: [u16; 2] = [200, 304];
 
-pub(crate) type Timestamp = Int;
+/// Nanoseconds since the Unix epoch (`ic0.time()`); always non-negative.
+pub(crate) type Timestamp = u64;
 
 #[derive(Default, Clone, Debug)]
 pub struct AssetEncoding {

--- a/crates/canister-core/src/batch.rs
+++ b/crates/canister-core/src/batch.rs
@@ -1,16 +1,15 @@
-//! Batch / chunk machinery for the assets canister.
+//! Sync / chunk machinery for the assets canister.
 //!
-//! Holds the data types for chunked uploads ([`Chunk`], [`Batch`]) and the
-//! incremental-computation harness used by `commit_batch` to spread expensive
-//! work across multiple canister calls ([`ComputationStatus`],
-//! [`CommitBatchProgress`]).
+//! Holds the data types for a sync and its chunked uploads ([`Chunk`],
+//! [`SyncSession`]) and the incremental-computation harness used by
+//! `execute_operations` to spread expensive work across multiple canister
+//! calls ([`ComputationStatus`], [`ExecuteOperationsProgress`]).
 //!
-//! The State methods that drive batches — `create_batch`, `create_chunks`,
-//! `commit_batch`, `delete_batch` — live here too, alongside the small
-//! helpers they rely on. State methods unrelated to batches stay in the
+//! The State methods that drive a sync — `start_sync`, `create_chunks`,
+//! `execute_operations`, `cancel_sync` — live here too, alongside the small
+//! helpers they rely on. State methods unrelated to syncing stay in the
 //! state machine module.
 
-use crate::asset::Timestamp;
 use crate::certification::{AssetKey, HashTreePath};
 use crate::http::HttpResponse;
 use crate::rc_bytes::RcBytes;
@@ -18,25 +17,29 @@ use crate::redirect;
 use crate::state::State;
 use crate::system_context::SystemContext;
 use crate::types::{
-    BatchId, BatchOperation, ChunkId, CommitBatchArguments, CreateChunksArg, DeleteBatchArguments,
-    SetAssetContentArguments,
+    BatchOperation, CancelSyncArguments, ChunkId, CreateChunksArg, ExecuteOperationsArguments,
+    SessionId, SetAssetContentArguments, StartSyncResult,
 };
-use candid::{Int, Nat};
+use candid::Principal;
 use ic_representation_independent_hash::Value;
-use serde_bytes::ByteBuf;
 use sha2::Digest;
 
-/// The amount of time a batch is kept alive. Modifying the batch
-/// delays the expiry further.
-pub const BATCH_EXPIRY_NANOS: u64 = 300_000_000_000;
+/// How long a sync may sit idle (no calls carrying its session id) before a
+/// *different* caller is allowed to reclaim it. Comfortably shorter than any
+/// real deploy's inter-call gap; the owner can always reclaim their own sync
+/// immediately regardless of this.
+pub const SYNC_IDLE_TIMEOUT_NANOS: u64 = 30_000_000_000;
 
 pub struct Chunk {
-    pub batch_id: BatchId,
     pub content: RcBytes,
 }
 
-pub struct Batch {
-    pub expires_at: Timestamp,
+/// The single in-progress sync. The canister holds at most one at a time;
+/// `start_sync` rejects a second caller while this is present and non-stale.
+pub struct SyncSession {
+    pub id: SessionId,
+    pub owner: Principal,
+    pub last_activity_ns: u64,
 }
 
 /// Status of an incremental computation
@@ -52,22 +55,19 @@ pub enum ComputationStatus<D, P, E> {
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Default)]
-pub enum CommitBatchProgress {
-    /// Initial state when `commit_batch` is first called.
+pub enum ExecuteOperationsProgress {
+    /// Initial state when `execute_operations` is first called.
     ///
-    /// This phase:
-    /// - Computes and validates batch limits
-    /// - Transitions to `ProcessingOperations` with the first operation
+    /// This phase validates that the call belongs to the active sync (and
+    /// records activity), then transitions to `ProcessingOperations` with the
+    /// first operation.
     #[default]
     Starting,
-    /// Processing batch operations one at a time.
+    /// Processing operations one at a time.
     ///
     /// When a `SetAssetContent` operation is encountered, this transitions to
     /// `HashingChunks` to hash the asset content incrementally.
-    ProcessingOperations {
-        batch_id: BatchId,
-        operation_index: usize,
-    },
+    ProcessingOperations { operation_index: usize },
     /// Incrementally hashing asset content chunks, one chunk per call.
     ///
     /// This phase is entered when processing a `SetAssetContent` operation to avoid
@@ -77,7 +77,6 @@ pub enum CommitBatchProgress {
     /// After all chunks are hashed, the hash is finalized, the asset encoding is created,
     /// and processing continues with the next operation in `ProcessingOperations`.
     HashingChunks {
-        batch_id: BatchId,
         operation_index: usize,
         set_asset_content_arg: SetAssetContentArguments,
         content_chunks: Vec<RcBytes>,
@@ -88,60 +87,82 @@ pub enum CommitBatchProgress {
 }
 
 impl State {
-    pub fn create_batch(&mut self, system_context: &SystemContext) -> BatchId {
+    /// Begins a sync, returning a fresh session id.
+    ///
+    /// At most one sync runs at a time. If a sync is already in progress:
+    /// - the **same owner** can always reclaim it immediately (retrying their
+    ///   own deploy shouldn't have to wait), and
+    /// - a **different** caller may reclaim it only once it has gone stale
+    ///   (`SYNC_IDLE_TIMEOUT_NANOS` since its last call); otherwise the call
+    ///   returns `Busy` so a teammate can't barge into an active deploy.
+    ///
+    /// Reclaiming clears the previous session's staged chunks. The session id
+    /// counter is monotonic and never reused.
+    pub fn start_sync(
+        &mut self,
+        owner: Principal,
+        system_context: &SystemContext,
+    ) -> StartSyncResult {
         let now = system_context.current_timestamp_ns;
-        self.batches.retain(|_, b| b.expires_at > now);
-        self.chunks
-            .retain(|_, c| self.batches.contains_key(&c.batch_id));
 
-        let batch_id = self.next_batch_id.clone();
-        self.next_batch_id += 1_u8;
+        if let Some(active) = &self.sync_session {
+            let idle = now.saturating_sub(active.last_activity_ns);
+            let reclaimable = active.owner == owner || idle >= SYNC_IDLE_TIMEOUT_NANOS;
+            if !reclaimable {
+                return StartSyncResult::Busy {
+                    owner: active.owner,
+                    idle_for_secs: idle / 1_000_000_000,
+                };
+            }
+        }
 
-        self.batches.insert(
-            batch_id.clone(),
-            Batch {
-                expires_at: Int::from(now + BATCH_EXPIRY_NANOS),
-            },
-        );
+        // No active sync, or we're taking over: drop any staged chunks left by
+        // the previous session before starting fresh.
+        self.chunks.clear();
 
-        batch_id
+        let session_id = self.next_session_id;
+        self.next_session_id += 1;
+        self.sync_session = Some(SyncSession {
+            id: session_id,
+            owner,
+            last_activity_ns: now,
+        });
+
+        StartSyncResult::Started { session_id }
+    }
+
+    /// Marks the active session as touched (resets its idle clock). Returns an
+    /// error if `session_id` does not match the active session — the sync was
+    /// superseded or never started.
+    fn touch_session(&mut self, session_id: SessionId, now: u64) -> Result<(), String> {
+        match &mut self.sync_session {
+            Some(s) if s.id == session_id => {
+                s.last_activity_ns = now;
+                Ok(())
+            }
+            _ => Err("no active sync for this session id".to_string()),
+        }
     }
 
     pub fn create_chunks(
         &mut self,
         CreateChunksArg {
-            batch_id,
+            session_id,
             content: chunks,
         }: CreateChunksArg,
         system_context: &SystemContext,
     ) -> Result<Vec<ChunkId>, String> {
-        self.create_chunks_helper(batch_id, chunks, system_context)
-    }
-
-    /// Post-condition: `chunks.len() == output_chunk_ids.len()`
-    fn create_chunks_helper(
-        &mut self,
-        batch_id: Nat,
-        chunks: Vec<ByteBuf>,
-        system_context: &SystemContext,
-    ) -> Result<Vec<ChunkId>, String> {
-        let batch = self
-            .batches
-            .get_mut(&batch_id)
-            .ok_or_else(|| "batch not found".to_string())?;
-
-        batch.expires_at = Int::from(system_context.current_timestamp_ns + BATCH_EXPIRY_NANOS);
+        self.touch_session(session_id, system_context.current_timestamp_ns)?;
 
         let chunks_len = chunks.len();
 
         let mut chunk_ids = Vec::with_capacity(chunks.len());
         for chunk in chunks {
-            let chunk_id = self.next_chunk_id.clone();
-            self.next_chunk_id += 1_u8;
+            let chunk_id = self.next_chunk_id;
+            self.next_chunk_id += 1;
             self.chunks.insert(
-                chunk_id.clone(),
+                chunk_id,
                 Chunk {
-                    batch_id: batch_id.clone(),
                     content: RcBytes::from(chunk),
                 },
             );
@@ -152,28 +173,36 @@ impl State {
         Ok(chunk_ids)
     }
 
-    pub fn commit_batch(
+    pub fn execute_operations(
         &mut self,
-        arg: &CommitBatchArguments,
-        progress: CommitBatchProgress,
+        arg: &ExecuteOperationsArguments,
+        progress: ExecuteOperationsProgress,
         system_context: &SystemContext,
-    ) -> ComputationStatus<(), CommitBatchProgress, String> {
+    ) -> ComputationStatus<(), ExecuteOperationsProgress, String> {
         match progress {
-            CommitBatchProgress::Starting => {
-                let initial_progress = CommitBatchProgress::ProcessingOperations {
-                    batch_id: arg.batch_id.clone(),
-                    operation_index: 0,
-                };
+            ExecuteOperationsProgress::Starting => {
+                // Reject calls that don't belong to the active sync, and reset
+                // its idle clock so a concurrent reclaim can't steal it
+                // mid-flight.
+                if let Err(e) =
+                    self.touch_session(arg.session_id, system_context.current_timestamp_ns)
+                {
+                    return ComputationStatus::Error(e);
+                }
+                let initial_progress =
+                    ExecuteOperationsProgress::ProcessingOperations { operation_index: 0 };
                 ComputationStatus::InProgress(initial_progress)
             }
-            CommitBatchProgress::ProcessingOperations {
-                batch_id,
-                operation_index,
-            } => {
+            ExecuteOperationsProgress::ProcessingOperations { operation_index } => {
                 // Process one operation per call
                 if operation_index >= arg.operations.len() {
-                    // All operations processed
-                    self.batches.remove(&batch_id);
+                    // All operations in this call processed. Finalize the sync
+                    // only when the caller signals this is the last call;
+                    // otherwise keep the session open for further operations.
+                    if arg.is_final {
+                        self.sync_session = None;
+                        self.chunks.clear();
+                    }
                     self.certify_404_if_required();
                     // Asset ops in this batch may have clobbered tree entries
                     // that redirect rules own (any rule whose source path
@@ -217,8 +246,7 @@ impl State {
                         }
 
                         // Start hashing phase with an empty hasher
-                        let progress = CommitBatchProgress::HashingChunks {
-                            batch_id,
+                        let progress = ExecuteOperationsProgress::HashingChunks {
                             operation_index,
                             set_asset_content_arg: arg.clone(),
                             content_chunks,
@@ -256,14 +284,12 @@ impl State {
                     return ComputationStatus::Error(e);
                 }
 
-                let progress = CommitBatchProgress::ProcessingOperations {
-                    batch_id,
+                let progress = ExecuteOperationsProgress::ProcessingOperations {
                     operation_index: operation_index + 1,
                 };
                 ComputationStatus::InProgress(progress)
             }
-            CommitBatchProgress::HashingChunks {
-                batch_id,
+            ExecuteOperationsProgress::HashingChunks {
                 operation_index,
                 set_asset_content_arg,
                 content_chunks,
@@ -274,7 +300,7 @@ impl State {
                 if chunk_index >= content_chunks.len() {
                     // All chunks hashed, finalize and complete set_asset_content
                     let sha256: [u8; 32] = hasher.finalize().into();
-                    let now = Int::from(system_context.current_timestamp_ns);
+                    let now = system_context.current_timestamp_ns;
 
                     if let Err(e) = self.complete_set_asset_content(
                         set_asset_content_arg.clone(),
@@ -287,16 +313,14 @@ impl State {
                     }
 
                     // Continue with next operation
-                    let progress = CommitBatchProgress::ProcessingOperations {
-                        batch_id,
+                    let progress = ExecuteOperationsProgress::ProcessingOperations {
                         operation_index: operation_index + 1,
                     };
                     ComputationStatus::InProgress(progress)
                 } else {
                     // Hash one chunk per iteration
                     hasher.update(&content_chunks[chunk_index]);
-                    let progress = CommitBatchProgress::HashingChunks {
-                        batch_id,
+                    let progress = ExecuteOperationsProgress::HashingChunks {
                         operation_index,
                         set_asset_content_arg,
                         content_chunks,
@@ -310,12 +334,23 @@ impl State {
         }
     }
 
-    pub fn delete_batch(&mut self, arg: DeleteBatchArguments) -> Result<(), String> {
-        if self.batches.remove(&arg.batch_id).is_none() {
-            return Err("batch not found".to_string());
+    /// Cancels the active sync, if it matches `session_id` and is owned by
+    /// `caller`. Lets a client cleanly release the sync lock on abort instead
+    /// of waiting for it to go stale. A caller cannot cancel someone else's
+    /// sync (a stale one is reclaimed via `start_sync` instead).
+    pub fn cancel_sync(
+        &mut self,
+        arg: CancelSyncArguments,
+        caller: Principal,
+    ) -> Result<(), String> {
+        match &self.sync_session {
+            Some(s) if s.id == arg.session_id && s.owner == caller => {
+                self.sync_session = None;
+                self.chunks.clear();
+                Ok(())
+            }
+            _ => Err("no active sync for this session id".to_string()),
         }
-        self.chunks.retain(|_, c| c.batch_id != arg.batch_id);
-        Ok(())
     }
 
     fn certify_404_if_required(&mut self) {

--- a/crates/canister-core/src/lib.rs
+++ b/crates/canister-core/src/lib.rs
@@ -65,12 +65,11 @@ pub fn retrieve(key: AssetKey) -> RcBytes {
     })
 }
 
-pub fn create_batch() -> CreateBatchResponse {
+pub fn start_sync() -> StartSyncResult {
     let system_context = SystemContext::new();
+    let caller = msg_caller();
 
-    with_state_mut(|s| CreateBatchResponse {
-        batch_id: s.create_batch(&system_context),
-    })
+    with_state_mut(|s| s.start_sync(caller, &system_context))
 }
 
 pub fn create_chunks(arg: CreateChunksArg) -> CreateChunksResponse {
@@ -82,12 +81,12 @@ pub fn create_chunks(arg: CreateChunksArg) -> CreateChunksResponse {
     })
 }
 
-pub async fn commit_batch(arg: CommitBatchArguments) {
+pub async fn execute_operations(arg: ExecuteOperationsArguments) {
     let system_context = SystemContext::new();
     let arg_ref = &arg;
 
     loop_with_message_extension_until_completion(|progress| {
-        with_state_mut(|s| s.commit_batch(arg_ref, progress, &system_context))
+        with_state_mut(|s| s.execute_operations(arg_ref, progress, &system_context))
     })
     .await
     .map_err(|msg| trap(&msg))
@@ -108,8 +107,9 @@ pub fn get_state_info() -> StateInfo {
     with_state(|s| s.get_state_info())
 }
 
-pub fn delete_batch(arg: DeleteBatchArguments) {
-    if let Err(msg) = with_state_mut(|s| s.delete_batch(arg)) {
+pub fn cancel_sync(arg: CancelSyncArguments) {
+    let caller = msg_caller();
+    if let Err(msg) = with_state_mut(|s| s.cancel_sync(arg, caller)) {
         trap(&msg);
     }
 }

--- a/crates/canister-core/src/stable.rs
+++ b/crates/canister-core/src/stable.rs
@@ -1,20 +1,16 @@
 use std::collections::{BTreeSet, HashMap};
 
 use candid::Principal;
-use num_traits::ToPrimitive;
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    asset::Timestamp, certification::CertificateExpression, rc_bytes::RcBytes,
-    redirect::RedirectRule, types::BatchId,
-};
+use crate::{certification::CertificateExpression, rc_bytes::RcBytes, redirect::RedirectRule};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct StableState {
     pub(crate) authorized: BTreeSet<Principal>,
     pub(crate) stable_assets: HashMap<String, StableAsset>,
 
-    pub(crate) next_batch_id: Option<u64>,
+    pub(crate) next_session_id: u64,
     pub(crate) last_state_update_timestamp: Option<u64>,
 
     /// Optional so a `StableState` serialized before this field existed still
@@ -32,7 +28,7 @@ impl From<crate::state::State> for StableState {
                 .into_iter()
                 .map(|(k, v)| (k, v.into()))
                 .collect(),
-            next_batch_id: Some(batch_id_to_u64(state.next_batch_id)),
+            next_session_id: state.next_session_id,
             last_state_update_timestamp: Some(state.last_state_update_timestamp_ns),
             redirect_rules: Some(state.redirect_rules),
         }
@@ -90,7 +86,7 @@ pub struct StableAssetEncoding {
 impl From<crate::asset::AssetEncoding> for StableAssetEncoding {
     fn from(asset_encoding: crate::asset::AssetEncoding) -> Self {
         Self {
-            modified: timestamp_to_u64(asset_encoding.modified),
+            modified: asset_encoding.modified,
             content_chunks: asset_encoding.content_chunks,
             total_length: asset_encoding.total_length,
             certified: asset_encoding.certified,
@@ -104,7 +100,7 @@ impl From<crate::asset::AssetEncoding> for StableAssetEncoding {
 impl From<StableAssetEncoding> for crate::asset::AssetEncoding {
     fn from(stable_asset_encoding: StableAssetEncoding) -> Self {
         Self {
-            modified: Timestamp::from(stable_asset_encoding.modified),
+            modified: stable_asset_encoding.modified,
             content_chunks: stable_asset_encoding.content_chunks,
             total_length: stable_asset_encoding.total_length,
             certified: stable_asset_encoding.certified,
@@ -113,12 +109,4 @@ impl From<StableAssetEncoding> for crate::asset::AssetEncoding {
             response_hashes: stable_asset_encoding.response_hashes,
         }
     }
-}
-
-fn timestamp_to_u64(timestamp: Timestamp) -> u64 {
-    timestamp.0.to_u64().expect("timestamp overflow")
-}
-
-fn batch_id_to_u64(batch_id: BatchId) -> u64 {
-    batch_id.0.to_u64().expect("batch id overflow")
 }

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -8,7 +8,7 @@ use crate::{
     asset::{
         on_asset_change, Asset, AssetDetails, AssetEncoding, AssetEncodingDetails, EncodedAsset,
     },
-    batch::{Batch, Chunk, ComputationStatus},
+    batch::{Chunk, ComputationStatus, SyncSession},
     certification::{AssetKey, CertifiedResponses},
     http::{
         CallbackFunc, HttpRequest, HttpResponse, StreamingCallbackHttpResponse,
@@ -21,7 +21,7 @@ use crate::{
     types::*,
     url::url_decode,
 };
-use candid::{CandidType, Deserialize, Int, Nat, Principal};
+use candid::{CandidType, Deserialize, Nat, Principal};
 use ic_certification::{AsHashTree, Hash};
 use num_traits::ToPrimitive;
 use serde::Serialize;
@@ -43,8 +43,9 @@ pub struct State {
     pub(crate) chunks: HashMap<ChunkId, Chunk>,
     pub(crate) next_chunk_id: ChunkId,
 
-    pub(crate) batches: HashMap<BatchId, Batch>,
-    pub(crate) next_batch_id: BatchId,
+    /// The single in-progress sync, if any. At most one runs at a time.
+    pub(crate) sync_session: Option<SyncSession>,
+    pub(crate) next_session_id: SessionId,
 
     // Principals authorized to sync assets. Canister controllers are always
     // allowed regardless of membership; this set grants the same access to
@@ -126,7 +127,7 @@ impl State {
             return Err("asset not found".to_string());
         }
 
-        let now = Int::from(system_context.current_timestamp_ns);
+        let now = system_context.current_timestamp_ns;
 
         let mut content_chunks = vec![];
         for chunk_id in arg.chunk_ids.iter() {
@@ -151,7 +152,7 @@ impl State {
         arg: SetAssetContentArguments,
         content_chunks: Vec<RcBytes>,
         sha256: [u8; 32],
-        now: Int,
+        now: u64,
         dependent_keys: Vec<AssetKey>,
     ) -> Result<(), String> {
         if let Some(provided_hash) = arg.sha256 {
@@ -290,7 +291,7 @@ impl State {
                             content_encoding: enc_name.clone(),
                             sha256: Some(ByteBuf::from(enc.sha256)),
                             length: Nat::from(enc.total_length),
-                            modified: enc.modified.clone(),
+                            modified: enc.modified,
                         })
                         .collect();
                     encodings.sort_by(|l, r| l.content_encoding.cmp(&r.content_encoding));
@@ -579,10 +580,10 @@ impl State {
     }
 
     /// Rebuild the certified-tree entries for `redirect_rules`. Called whenever
-    /// the rule list changes (in `commit_batch`) or assets are restored from
-    /// stable memory (in `From<StableState>`). Caller must refresh
-    /// `certified_data` after this — `commit_batch` already does so via the
-    /// `certified_data_set(s.root_hash())` it runs after each batch.
+    /// the rule list changes (in `execute_operations`) or assets are restored
+    /// from stable memory (in `From<StableState>`). Caller must refresh
+    /// `certified_data` after this — `execute_operations` already does so via
+    /// the `certified_data_set(s.root_hash())` it runs after each sync call.
     ///
     /// Status-200 rules borrow each encoding's certificate expression and
     /// response hash from the target asset, so this also has to run after any
@@ -683,10 +684,7 @@ impl From<StableState> for State {
                 .into_iter()
                 .map(|(k, v)| (k, v.into()))
                 .collect(),
-            next_batch_id: stable_state
-                .next_batch_id
-                .map(BatchId::from)
-                .unwrap_or_default(),
+            next_session_id: stable_state.next_session_id,
             last_state_update_timestamp_ns: stable_state.last_state_update_timestamp.unwrap_or(0),
             redirect_rules: stable_state.redirect_rules.unwrap_or_default(),
             ..Self::default()

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::batch::{ComputationStatus, BATCH_EXPIRY_NANOS};
+use crate::batch::{ComputationStatus, SYNC_IDLE_TIMEOUT_NANOS};
 use crate::http::{
     CallbackFunc, HttpRequest, HttpResponse, StreamingCallbackToken, StreamingStrategy,
 };
@@ -6,9 +6,9 @@ use crate::stable::StableState;
 use crate::state::State;
 use crate::system_context::SystemContext;
 use crate::types::{
-    AssetProperties, BatchId, BatchOperation, CommitBatchArguments, CreateAssetArguments,
-    DeleteAssetArguments, DeleteBatchArguments, GetArg, GetChunkArg, ListRequest,
-    SetAssetContentArguments, SetAssetPropertiesArguments,
+    AssetProperties, BatchOperation, CancelSyncArguments, CreateAssetArguments,
+    DeleteAssetArguments, ExecuteOperationsArguments, GetArg, GetChunkArg, ListRequest, SessionId,
+    SetAssetContentArguments, SetAssetPropertiesArguments, StartSyncResult,
 };
 use crate::url::{url_decode, UrlDecodeError};
 use crate::CreateChunksArg;
@@ -204,40 +204,61 @@ impl RequestBuilder {
     }
 }
 
+/// Starts a sync and returns its session id, panicking if the canister reports
+/// `Busy` (no concurrent sync is expected in these single-threaded tests).
+fn start_session(state: &mut State, ctx: &SystemContext) -> SessionId {
+    match state.start_sync(some_principal(), ctx) {
+        StartSyncResult::Started { session_id } => session_id,
+        other => panic!("expected Started, got {other:?}"),
+    }
+}
+
+/// Runs `operations` to completion in a single finalizing `execute_operations`
+/// (`is_final: true`), the way a small sync would.
+fn execute_all(
+    state: &mut State,
+    session_id: SessionId,
+    operations: Vec<BatchOperation>,
+    ctx: &SystemContext,
+) {
+    run_computation_until_completion(|progress| {
+        state.execute_operations(
+            &ExecuteOperationsArguments {
+                session_id,
+                operations: operations.clone(),
+                is_final: true,
+            },
+            progress,
+            ctx,
+        )
+    })
+    .unwrap();
+}
+
 fn create_assets(
     state: &mut State,
     system_context: &SystemContext,
     assets: Vec<AssetBuilder>,
-) -> BatchId {
-    let batch_id = state.create_batch(system_context);
+) -> SessionId {
+    let session_id = start_session(state, system_context);
 
     let operations = assemble_create_assets_and_set_contents_operations(
         state,
         system_context,
         assets,
-        &batch_id,
+        session_id,
     );
 
-    run_computation_until_completion(|progress| {
-        state.commit_batch(
-            &CommitBatchArguments {
-                batch_id: batch_id.clone(),
-                operations: operations.clone(),
-            },
-            progress,
-            system_context,
-        )
-    })
-    .unwrap();
+    execute_all(state, session_id, operations, system_context);
 
-    batch_id
+    session_id
 }
 
 fn assemble_create_assets_and_set_contents_operations(
     state: &mut State,
     system_context: &SystemContext,
     assets: Vec<AssetBuilder>,
-    batch_id: &BatchId,
+    session_id: SessionId,
 ) -> Vec<BatchOperation> {
     let mut operations = vec![];
 
@@ -257,7 +278,7 @@ fn assemble_create_assets_and_set_contents_operations(
             let chunk_ids = state
                 .create_chunks(
                     CreateChunksArg {
-                        batch_id: batch_id.clone(),
+                        session_id,
                         content: chunks,
                     },
                     system_context,
@@ -292,7 +313,7 @@ fn can_create_assets_using_batch_api() {
 
     const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
 
-    let batch_id = create_assets(
+    let session_id = create_assets(
         &mut state,
         &system_context,
         vec![AssetBuilder::new("/contents.html", "text/html").with_encoding("identity", vec![BODY])],
@@ -308,18 +329,19 @@ fn can_create_assets_using_batch_api() {
     assert_eq!(response.status_code, 200);
     assert_eq!(response.body.as_ref(), BODY);
 
-    // Try to update a completed batch.
+    // The finalizing execute_operations ended the sync, so the session id is no
+    // longer valid for further chunk uploads.
     let error_msg = state
         .create_chunks(
             CreateChunksArg {
-                batch_id,
+                session_id,
                 content: vec![ByteBuf::new()],
             },
             &system_context,
         )
         .unwrap_err();
 
-    let expected = "batch not found";
+    let expected = "no active sync";
     assert!(
         error_msg.contains(expected),
         "expected '{expected}' error, got: {error_msg}"
@@ -460,7 +482,7 @@ fn set_root_spa_rule(state: &mut State, target: &str) {
     use crate::redirect::{RedirectRule, RulePattern};
     use crate::types::SetRedirectRulesArguments;
     let system_context = mock_system_context();
-    let batch_id = state.create_batch(&system_context);
+    let session_id = start_session(state, &system_context);
     let ops = vec![BatchOperation::SetRedirectRules(
         SetRedirectRulesArguments {
             rules: vec![RedirectRule {
@@ -471,17 +493,7 @@ fn set_root_spa_rule(state: &mut State, target: &str) {
             }],
         },
     )];
-    run_computation_until_completion(|progress| {
-        state.commit_batch(
-            &CommitBatchArguments {
-                batch_id: batch_id.clone(),
-                operations: ops.clone(),
-            },
-            progress,
-            &system_context,
-        )
-    })
-    .unwrap();
+    execute_all(state, session_id, ops, &system_context);
 }
 
 fn set_exact_rewrite_rule(state: &mut State, from: &str, to: &str) {
@@ -492,7 +504,7 @@ fn set_exact_rewrite_rules(state: &mut State, pairs: &[(&str, &str)]) {
     use crate::redirect::{RedirectRule, RulePattern};
     use crate::types::SetRedirectRulesArguments;
     let system_context = mock_system_context();
-    let batch_id = state.create_batch(&system_context);
+    let session_id = start_session(state, &system_context);
     let rules = pairs
         .iter()
         .map(|(from, to)| RedirectRule {
@@ -505,78 +517,126 @@ fn set_exact_rewrite_rules(state: &mut State, pairs: &[(&str, &str)]) {
     let ops = vec![BatchOperation::SetRedirectRules(
         SetRedirectRulesArguments { rules },
     )];
-    run_computation_until_completion(|progress| {
-        state.commit_batch(
-            &CommitBatchArguments {
-                batch_id: batch_id.clone(),
-                operations: ops.clone(),
-            },
-            progress,
-            &system_context,
-        )
-    })
-    .unwrap();
+    execute_all(state, session_id, ops, &system_context);
 }
 
 #[test]
-fn batches_are_dropped_after_timeout() {
+fn second_sync_rejected_while_first_is_active() {
+    // A different principal cannot start a sync while another's is in progress
+    // and not yet stale.
     let mut state = State::default();
-    let mut system_context = mock_system_context();
+    let system_context = mock_system_context();
 
-    let batch_1 = state.create_batch(&system_context);
+    let owner_a = some_principal();
+    let owner_b = Principal::from_text("aaaaa-aa").unwrap();
+    assert_ne!(owner_a, owner_b);
 
-    const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
+    let StartSyncResult::Started { .. } = state.start_sync(owner_a, &system_context) else {
+        panic!("first start_sync should succeed");
+    };
 
-    let _chunk_1 = state
-        .create_chunks(
-            CreateChunksArg {
-                batch_id: batch_1.clone(),
-                content: vec![ByteBuf::from(BODY.to_vec())],
-            },
-            &system_context,
-        )
-        .unwrap();
-
-    system_context.current_timestamp_ns =
-        system_context.current_timestamp_ns + BATCH_EXPIRY_NANOS + 1;
-    let _batch_2 = state.create_batch(&system_context);
-
-    match state.create_chunks(
-        CreateChunksArg {
-            batch_id: batch_1,
-            content: vec![ByteBuf::from(BODY.to_vec())],
-        },
-        &system_context,
-    ) {
-        Err(err) if err.contains("batch not found") => (),
-        other => panic!("expected 'batch not found' error, got: {other:?}"),
+    match state.start_sync(owner_b, &system_context) {
+        StartSyncResult::Busy { owner, .. } => assert_eq!(owner, owner_a),
+        other => panic!("expected Busy, got {other:?}"),
     }
 }
 
 #[test]
-fn can_delete_batch_with_chunks() {
+fn owner_can_reclaim_their_own_sync_immediately() {
+    // The same principal restarting (e.g. retrying a failed deploy) reclaims
+    // its own non-stale sync and gets a fresh, monotonically larger id.
     let mut state = State::default();
     let system_context = mock_system_context();
+    let owner = some_principal();
 
-    let batch_1 = state.create_batch(&system_context);
+    let id1 = start_session(&mut state, &system_context);
+    let id2 = match state.start_sync(owner, &system_context) {
+        StartSyncResult::Started { session_id } => session_id,
+        other => panic!("expected Started, got {other:?}"),
+    };
+    assert!(id2 > id1, "session ids must be monotonic: {id2} > {id1}");
+}
+
+#[test]
+fn stale_sync_can_be_reclaimed_by_another_principal() {
+    // After the idle timeout, a different principal may take over an abandoned
+    // sync. Reclaiming clears the previous session's staged chunks.
+    let mut state = State::default();
+    let mut system_context = mock_system_context();
+    let owner_b = Principal::from_text("aaaaa-aa").unwrap();
+
+    let id1 = start_session(&mut state, &system_context);
 
     const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
-    let _chunk_1 = state
+    state
         .create_chunks(
             CreateChunksArg {
-                batch_id: batch_1.clone(),
+                session_id: id1,
+                content: vec![ByteBuf::from(BODY.to_vec())],
+            },
+            &system_context,
+        )
+        .unwrap();
+    assert!(!state.chunks.is_empty(), "chunk should be staged");
+
+    // Advance past the idle timeout, then a different principal reclaims it.
+    system_context.current_timestamp_ns += SYNC_IDLE_TIMEOUT_NANOS + 1;
+    match state.start_sync(owner_b, &system_context) {
+        StartSyncResult::Started { session_id } => assert!(session_id > id1),
+        other => panic!("expected Started, got {other:?}"),
+    }
+    assert!(
+        state.chunks.is_empty(),
+        "reclaim must drop the previous session's chunks"
+    );
+
+    // The old session id is no longer valid.
+    let err = state
+        .create_chunks(
+            CreateChunksArg {
+                session_id: id1,
+                content: vec![ByteBuf::from(BODY.to_vec())],
+            },
+            &system_context,
+        )
+        .unwrap_err();
+    assert!(err.contains("no active sync"), "got: {err}");
+}
+
+#[test]
+fn cancel_sync_releases_the_lock_for_the_owner_only() {
+    let mut state = State::default();
+    let system_context = mock_system_context();
+    let owner = some_principal();
+    let other = Principal::from_text("aaaaa-aa").unwrap();
+
+    let session_id = start_session(&mut state, &system_context);
+
+    const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
+    state
+        .create_chunks(
+            CreateChunksArg {
+                session_id,
                 content: vec![ByteBuf::from(BODY.to_vec())],
             },
             &system_context,
         )
         .unwrap();
 
-    let delete_args = DeleteBatchArguments { batch_id: batch_1 };
-    assert_eq!(Ok(()), state.delete_batch(delete_args.clone()));
+    // A non-owner cannot cancel someone else's sync.
+    assert!(state
+        .cancel_sync(CancelSyncArguments { session_id }, other)
+        .is_err());
+
+    // The owner can, which clears staged chunks; a second cancel then errors.
     assert_eq!(
-        Err("batch not found".to_string()),
-        state.delete_batch(delete_args)
+        Ok(()),
+        state.cancel_sync(CancelSyncArguments { session_id }, owner)
     );
+    assert!(state.chunks.is_empty());
+    assert!(state
+        .cancel_sync(CancelSyncArguments { session_id }, owner)
+        .is_err());
 }
 
 #[test]
@@ -1462,7 +1522,7 @@ mod last_state_update_timestamp {
     use super::*;
 
     #[test]
-    fn timestamp_updates_on_commit_batch() {
+    fn timestamp_updates_on_execute_operations() {
         let mut state = State::default();
         let system_context = mock_system_context();
 
@@ -1470,23 +1530,17 @@ mod last_state_update_timestamp {
         assert_eq!(state.last_state_update_timestamp_ns(), 0);
 
         // Create and commit a batch with asset operations
-        let batch_id = state.create_batch(&system_context);
-
-        run_computation_until_completion(|progress| {
-            state.commit_batch(
-                &CommitBatchArguments {
-                    batch_id: batch_id.clone(),
-                    operations: vec![BatchOperation::CreateAsset(CreateAssetArguments {
-                        key: "/test.txt".to_string(),
-                        content_type: "text/plain".to_string(),
-                        headers: None,
-                    })],
-                },
-                progress,
-                &system_context,
-            )
-        })
-        .unwrap();
+        let session_id = start_session(&mut state, &system_context);
+        execute_all(
+            &mut state,
+            session_id,
+            vec![BatchOperation::CreateAsset(CreateAssetArguments {
+                key: "/test.txt".to_string(),
+                content_type: "text/plain".to_string(),
+                headers: None,
+            })],
+            &system_context,
+        );
 
         // Timestamp should be updated to system context timestamp
         assert_eq!(
@@ -1505,48 +1559,35 @@ mod last_state_update_timestamp {
 
         // First operation at time T1: create an asset.
         let initial_time = system_context.current_timestamp_ns;
-        let batch_id = state.create_batch(&system_context);
-        run_computation_until_completion(|progress| {
-            state.commit_batch(
-                &CommitBatchArguments {
-                    batch_id: batch_id.clone(),
-                    operations: vec![BatchOperation::CreateAsset(CreateAssetArguments {
-                        key: "/test.txt".to_string(),
-                        content_type: "text/plain".to_string(),
-                        headers: None,
-                    })],
-                },
-                progress,
-                &system_context,
-            )
-        })
-        .unwrap();
+        let session_id = start_session(&mut state, &system_context);
+        execute_all(
+            &mut state,
+            session_id,
+            vec![BatchOperation::CreateAsset(CreateAssetArguments {
+                key: "/test.txt".to_string(),
+                content_type: "text/plain".to_string(),
+                headers: None,
+            })],
+            &system_context,
+        );
         assert_eq!(state.last_state_update_timestamp_ns(), initial_time);
 
         // Second operation at time T2 (advanced)
         system_context.current_timestamp_ns += 1_000_000_000;
         let updated_time = system_context.current_timestamp_ns;
 
-        let batch_id = state.create_batch(&system_context);
-        run_computation_until_completion(|progress| {
-            state.commit_batch(
-                &CommitBatchArguments {
-                    batch_id: batch_id.clone(),
-                    operations: vec![BatchOperation::SetAssetProperties(
-                        SetAssetPropertiesArguments {
-                            key: "/test.txt".to_string(),
-                            headers: Some(Some(vec![(
-                                "x-custom".to_string(),
-                                "value".to_string(),
-                            )])),
-                        },
-                    )],
+        let session_id = start_session(&mut state, &system_context);
+        execute_all(
+            &mut state,
+            session_id,
+            vec![BatchOperation::SetAssetProperties(
+                SetAssetPropertiesArguments {
+                    key: "/test.txt".to_string(),
+                    headers: Some(Some(vec![("x-custom".to_string(), "value".to_string())])),
                 },
-                progress,
-                &system_context,
-            )
-        })
-        .unwrap();
+            )],
+            &system_context,
+        );
 
         // Timestamp should be updated to new time
         assert_eq!(state.last_state_update_timestamp_ns(), updated_time);
@@ -1559,22 +1600,17 @@ mod last_state_update_timestamp {
         let system_context = mock_system_context();
 
         // Commit a batch to update the timestamp.
-        let batch_id = state.create_batch(&system_context);
-        run_computation_until_completion(|progress| {
-            state.commit_batch(
-                &CommitBatchArguments {
-                    batch_id: batch_id.clone(),
-                    operations: vec![BatchOperation::CreateAsset(CreateAssetArguments {
-                        key: "/test.txt".to_string(),
-                        content_type: "text/plain".to_string(),
-                        headers: None,
-                    })],
-                },
-                progress,
-                &system_context,
-            )
-        })
-        .unwrap();
+        let session_id = start_session(&mut state, &system_context);
+        execute_all(
+            &mut state,
+            session_id,
+            vec![BatchOperation::CreateAsset(CreateAssetArguments {
+                key: "/test.txt".to_string(),
+                content_type: "text/plain".to_string(),
+                headers: None,
+            })],
+            &system_context,
+        );
 
         let expected_timestamp = state.last_state_update_timestamp_ns();
         assert_eq!(expected_timestamp, system_context.current_timestamp_ns);
@@ -1817,11 +1853,11 @@ mod set_asset_content_sha256_verification {
             .unwrap();
 
         // Create batch and chunk
-        let batch_id = state.create_batch(&system_context);
+        let session_id = start_session(&mut state, &system_context);
         let chunk_ids = state
             .create_chunks(
                 CreateChunksArg {
-                    batch_id: batch_id.clone(),
+                    session_id,
                     content: vec![ByteBuf::from(CONTENT)],
                 },
                 &system_context,
@@ -1861,11 +1897,11 @@ mod set_asset_content_sha256_verification {
             .unwrap();
 
         // Create batch and chunk
-        let batch_id = state.create_batch(&system_context);
+        let session_id = start_session(&mut state, &system_context);
         let chunk_ids = state
             .create_chunks(
                 CreateChunksArg {
-                    batch_id: batch_id.clone(),
+                    session_id,
                     content: vec![ByteBuf::from(CONTENT)],
                 },
                 &system_context,
@@ -1905,11 +1941,11 @@ mod set_asset_content_sha256_verification {
             .unwrap();
 
         // Create batch and chunk
-        let batch_id = state.create_batch(&system_context);
+        let session_id = start_session(&mut state, &system_context);
         let chunk_ids = state
             .create_chunks(
                 CreateChunksArg {
-                    batch_id: batch_id.clone(),
+                    session_id,
                     content: vec![ByteBuf::from(CONTENT)],
                 },
                 &system_context,
@@ -1962,11 +1998,11 @@ mod set_asset_content_sha256_verification {
             .unwrap();
 
         // Create batch and chunks
-        let batch_id = state.create_batch(&system_context);
+        let session_id = start_session(&mut state, &system_context);
         let chunk_ids = state
             .create_chunks(
                 CreateChunksArg {
-                    batch_id: batch_id.clone(),
+                    session_id,
                     content: vec![ByteBuf::from(CHUNK_1), ByteBuf::from(CHUNK_2)],
                 },
                 &system_context,
@@ -2010,11 +2046,11 @@ mod set_asset_content_sha256_verification {
             .unwrap();
 
         // Create batch and chunk
-        let batch_id = state.create_batch(&system_context);
+        let session_id = start_session(&mut state, &system_context);
         let chunk_ids = state
             .create_chunks(
                 CreateChunksArg {
-                    batch_id: batch_id.clone(),
+                    session_id,
                     content: vec![ByteBuf::from(CHUNK_1)],
                 },
                 &system_context,
@@ -2047,20 +2083,21 @@ mod compute_state_hash {
         let system_context = mock_system_context();
 
         // Setup state
-        let batch_id = state.create_batch(&system_context);
+        let session_id = start_session(&mut state, &system_context);
         let chunk_ids = state
             .create_chunks(
                 CreateChunksArg {
-                    batch_id: batch_id.clone(),
+                    session_id,
                     content: vec![ByteBuf::from(b"content1")],
                 },
                 &system_context,
             )
             .unwrap();
 
-        let args = CommitBatchArguments {
-            batch_id: batch_id.clone(),
-            operations: vec![
+        execute_all(
+            &mut state,
+            session_id,
+            vec![
                 BatchOperation::CreateAsset(CreateAssetArguments {
                     key: "asset1".to_string(),
                     content_type: "text/plain".to_string(),
@@ -2074,32 +2111,27 @@ mod compute_state_hash {
                     sha256: None,
                 }),
             ],
-        };
-        run_computation_until_completion(|progress| {
-            state.commit_batch(&args, progress, &system_context)
-        })
-        .unwrap();
+            &system_context,
+        );
 
         // Reset computation
         run_computation_until_completion(|_progress| state.compute_state_hash()).unwrap(); // Ensure it's done or started
 
-        // Update state using commit_batch to ensure timestamp is updated
-        // We need a new system context with a later timestamp
+        // Update state using execute_operations to ensure timestamp is updated.
+        // We need a new system context with a later timestamp.
         let system_context_later = crate::system_context::SystemContext::new_with_options(200);
 
-        let batch_id = state.create_batch(&system_context_later);
-        let args = CommitBatchArguments {
-            batch_id: batch_id.clone(),
-            operations: vec![BatchOperation::CreateAsset(CreateAssetArguments {
+        let session_id = start_session(&mut state, &system_context_later);
+        execute_all(
+            &mut state,
+            session_id,
+            vec![BatchOperation::CreateAsset(CreateAssetArguments {
                 key: "asset2".to_string(),
                 content_type: "text/plain".to_string(),
                 headers: None,
             })],
-        };
-        run_computation_until_completion(|progress| {
-            state.commit_batch(&args, progress, &system_context_later)
-        })
-        .unwrap();
+            &system_context_later,
+        );
 
         // Since the new API doesn't allow controlling instruction counter per call,
         // we can't easily test interruption. This test now just verifies completion.
@@ -2119,12 +2151,13 @@ mod redirect_rules {
 
     fn commit(state: &mut State, ops: Vec<BatchOperation>) -> Result<(), String> {
         let system_context = mock_system_context();
-        let batch_id = state.create_batch(&system_context);
+        let session_id = start_session(state, &system_context);
         run_computation_until_completion(|progress| {
-            state.commit_batch(
-                &CommitBatchArguments {
-                    batch_id: batch_id.clone(),
+            state.execute_operations(
+                &ExecuteOperationsArguments {
+                    session_id,
                     operations: ops.clone(),
+                    is_final: true,
                 },
                 progress,
                 &system_context,

--- a/crates/canister-core/src/types.rs
+++ b/crates/canister-core/src/types.rs
@@ -3,11 +3,14 @@
 use crate::certification::AssetKey;
 use crate::rc_bytes::RcBytes;
 use crate::redirect::RedirectRule;
-use candid::{CandidType, Deserialize, Nat};
+use candid::{CandidType, Deserialize, Nat, Principal};
 use serde_bytes::ByteBuf;
 
-pub type BatchId = Nat;
-pub type ChunkId = Nat;
+/// Identifies an in-progress sync. Sequential and monotonic across the
+/// canister's whole lifetime (persisted across upgrades), so a session id is
+/// never reused — calls carrying a superseded id are cleanly rejected.
+pub type SessionId = u64;
+pub type ChunkId = u64;
 
 // IDL Types
 
@@ -61,14 +64,18 @@ pub struct SetRedirectRulesArguments {
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct CommitBatchArguments {
-    pub batch_id: BatchId,
+pub struct ExecuteOperationsArguments {
+    pub session_id: SessionId,
     pub operations: Vec<BatchOperation>,
+    /// Set on the last call of a sync. When all operations have been applied,
+    /// the canister finalizes the sync and returns to the "no ongoing sync"
+    /// state. Non-final calls keep the session open for further operations.
+    pub is_final: bool,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct DeleteBatchArguments {
-    pub batch_id: BatchId,
+pub struct CancelSyncArguments {
+    pub session_id: SessionId,
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
@@ -90,14 +97,22 @@ pub struct GetChunkResponse {
     pub content: RcBytes,
 }
 
+/// Result of `start_sync`. `Busy` is a normal, expected outcome — not an error
+/// — so the caller can surface who holds the lock and decide whether to wait.
 #[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct CreateBatchResponse {
-    pub batch_id: BatchId,
+pub enum StartSyncResult {
+    Started {
+        session_id: SessionId,
+    },
+    Busy {
+        owner: Principal,
+        idle_for_secs: u64,
+    },
 }
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct CreateChunksArg {
-    pub batch_id: BatchId,
+    pub session_id: SessionId,
     pub content: Vec<ByteBuf>,
 }
 

--- a/crates/canister/assets.did
+++ b/crates/canister/assets.did
@@ -1,7 +1,7 @@
-type BatchId = nat;
-type ChunkId = nat;
+type SessionId = nat64;
+type ChunkId = nat64;
 type Key = text;
-type Time = int;
+type Time = nat64;
 
 type CreateAssetArguments = record {
   key: Key;
@@ -57,13 +57,23 @@ type RedirectRule = record {
   headers: opt vec HeaderField;
 };
 
-type CommitBatchArguments = record {
-  batch_id: BatchId;
-  operations: vec BatchOperationKind
+type ExecuteOperationsArguments = record {
+  session_id: SessionId;
+  operations: vec BatchOperationKind;
+  // Set on the last call of a sync: once all operations are applied, the
+  // canister finalizes the sync and returns to "no ongoing sync".
+  is_final: bool;
 };
 
-type DeleteBatchArguments = record {
-  batch_id: BatchId;
+type CancelSyncArguments = record {
+  session_id: SessionId;
+};
+
+// Result of start_sync. `Busy` is a normal outcome (not an error): a sync is
+// already in progress and the caller may not take it over yet.
+type StartSyncResult = variant {
+  Started: record { session_id: SessionId };
+  Busy: record { owner: principal; idle_for_secs: nat64 };
 };
 
 type HeaderField = record { text; text; };
@@ -170,20 +180,26 @@ service: {
     tree: blob;
   }) query;
 
-  // ───────── Batch upload ─────────
+  // ───────── Sync ─────────
   //
-  // Assets are only ever mutated through committed batches — there are no
-  // single-asset mutation endpoints. A batch's `operations` carry the
-  // per-asset changes (create, set/unset content, set properties, delete),
-  // applied atomically when the batch is committed.
+  // Assets are only ever mutated through a sync. At most one sync runs at a
+  // time. `start_sync` returns a session id that all subsequent calls of the
+  // sync must carry; the canister rejects calls bearing a superseded id.
+  // Operations (create, set/unset content, set properties, delete) are applied
+  // by `execute_operations`; the sync finalizes on the call flagged `is_final`.
 
-  create_batch : () -> (record { batch_id: BatchId });
-  create_chunks: (record { batch_id: BatchId; content: vec blob }) -> (record { chunk_ids: vec ChunkId });
+  // Begin a sync. Returns a session id, or `Busy` if another non-stale sync is
+  // already in progress (the owner can always reclaim their own sync).
+  start_sync : () -> (StartSyncResult);
+  // Stage content chunks under the sync. Returns ids referenced by
+  // SetAssetContent operations.
+  create_chunks: (record { session_id: SessionId; content: vec blob }) -> (record { chunk_ids: vec ChunkId });
 
-  // Perform all operations successfully, or reject
-  commit_batch: (CommitBatchArguments) -> ();
-  // Delete a batch that has been created but not yet committed
-  delete_batch: (DeleteBatchArguments) -> ();
+  // Apply a group of operations. Perform all successfully, or reject.
+  execute_operations: (ExecuteOperationsArguments) -> ();
+  // Abandon the active sync, releasing the lock without waiting for it to go
+  // stale. Only the sync's owner may cancel it.
+  cancel_sync: (CancelSyncArguments) -> ();
 
   // ───────── Authorization ─────────
   // A set of extra principals authorized to sync assets. Canister controllers

--- a/crates/canister/src/lib.rs
+++ b/crates/canister/src/lib.rs
@@ -10,9 +10,9 @@ use canister_core::{
     redirect::RedirectRule,
     state::CertifiedTree,
     types::{
-        AssetProperties, CommitBatchArguments, CreateBatchResponse, CreateChunksArg,
-        CreateChunksResponse, DeleteBatchArguments, GetArg, GetChunkArg, GetChunkResponse,
-        ListRequest, StateInfo,
+        AssetProperties, CancelSyncArguments, CreateChunksArg, CreateChunksResponse,
+        ExecuteOperationsArguments, GetArg, GetChunkArg, GetChunkResponse, ListRequest,
+        StartSyncResult, StateInfo,
     },
 };
 use ic_cdk::{post_upgrade, pre_upgrade, query, update};
@@ -120,8 +120,8 @@ fn can_sync() -> bool {
 }
 
 #[update(guard = "guard_can_sync")]
-fn create_batch() -> CreateBatchResponse {
-    canister_core::create_batch()
+fn start_sync() -> StartSyncResult {
+    canister_core::start_sync()
 }
 
 #[update(guard = "guard_can_sync")]
@@ -130,8 +130,8 @@ fn create_chunks(arg: CreateChunksArg) -> CreateChunksResponse {
 }
 
 #[update(guard = "guard_can_sync")]
-async fn commit_batch(arg: CommitBatchArguments) {
-    canister_core::commit_batch(arg).await
+async fn execute_operations(arg: ExecuteOperationsArguments) {
+    canister_core::execute_operations(arg).await
 }
 
 #[update]
@@ -140,8 +140,8 @@ async fn compute_state_hash() -> Option<String> {
 }
 
 #[update(guard = "guard_can_sync")]
-fn delete_batch(arg: DeleteBatchArguments) {
-    canister_core::delete_batch(arg)
+fn cancel_sync(arg: CancelSyncArguments) {
+    canister_core::cancel_sync(arg)
 }
 
 ic_cdk::export_candid!();

--- a/crates/sync-core/src/canister.rs
+++ b/crates/sync-core/src/canister.rs
@@ -32,7 +32,7 @@ pub struct CreateAssetArguments {
 pub struct SetAssetContentArguments {
     pub key: String,
     pub content_encoding: String,
-    pub chunk_ids: Vec<Nat>,
+    pub chunk_ids: Vec<u64>,
     pub last_chunk: Option<Vec<u8>>,
     pub sha256: Option<Vec<u8>>,
 }
@@ -84,9 +84,10 @@ pub enum BatchOperationKind {
 }
 
 #[derive(CandidType, Debug)]
-pub struct CommitBatchArguments {
-    pub batch_id: Nat,
+pub struct ExecuteOperationsArguments {
+    pub session_id: u64,
     pub operations: Vec<BatchOperationKind>,
+    pub is_final: bool,
 }
 
 #[derive(CandidType, Clone, Debug, Deserialize, Default)]
@@ -100,23 +101,33 @@ struct ListAssetsRequest {
     length: Option<Nat>,
 }
 
-#[derive(CandidType, Debug)]
-struct CreateBatchRequest {}
-
+/// Result of `start_sync`. `Busy` is a normal outcome — another non-stale sync
+/// holds the lock — not a transport error.
 #[derive(CandidType, Debug, Deserialize)]
-struct CreateBatchResponse {
-    batch_id: Nat,
+enum StartSyncResult {
+    Started {
+        session_id: u64,
+    },
+    Busy {
+        owner: Principal,
+        idle_for_secs: u64,
+    },
 }
 
 #[derive(CandidType, Debug)]
 struct CreateChunksRequest<'a> {
-    batch_id: Nat,
+    session_id: u64,
     content: Vec<&'a [u8]>,
 }
 
 #[derive(CandidType, Debug, Deserialize)]
 struct CreateChunksResponse {
-    chunk_ids: Vec<Nat>,
+    chunk_ids: Vec<u64>,
+}
+
+#[derive(CandidType, Debug)]
+pub struct CancelSyncArguments {
+    pub session_id: u64,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -171,31 +182,52 @@ pub fn list_assets(c: &impl CanisterCall) -> Result<Vec<AssetDetails>, String> {
     Ok(all)
 }
 
-pub fn create_batch(c: &impl CanisterCall) -> Result<Nat, String> {
-    let resp: CreateBatchResponse = c.call(
-        "create_batch",
-        CreateBatchRequest {},
-        CallType::Update,
-        true,
-    )?;
-    Ok(resp.batch_id)
+/// Begins a sync, returning its session id. A `Busy` result (another non-stale
+/// sync is in progress) is surfaced as an error with the holder's principal and
+/// idle time so the caller can decide whether to wait.
+pub fn start_sync(c: &impl CanisterCall) -> Result<u64, String> {
+    let resp: StartSyncResult = c.call("start_sync", (), CallType::Update, true)?;
+    match resp {
+        StartSyncResult::Started { session_id } => Ok(session_id),
+        StartSyncResult::Busy {
+            owner,
+            idle_for_secs,
+        } => Err(format!(
+            "a sync is already in progress on this canister (started by {owner}, \
+             idle for {idle_for_secs}s); retry once it completes, or after it goes stale"
+        )),
+    }
 }
 
 pub fn create_chunks(
     c: &impl CanisterCall,
-    batch_id: &Nat,
+    session_id: u64,
     content: &[&[u8]],
-) -> Result<Vec<Nat>, String> {
+) -> Result<Vec<u64>, String> {
     let req = CreateChunksRequest {
-        batch_id: batch_id.clone(),
+        session_id,
         content: content.to_vec(),
     };
     let resp: CreateChunksResponse = c.call("create_chunks", req, CallType::Update, true)?;
     Ok(resp.chunk_ids)
 }
 
-pub fn commit_batch(c: &impl CanisterCall, args: CommitBatchArguments) -> Result<(), String> {
-    c.call("commit_batch", args, CallType::Update, true)
+pub fn execute_operations(
+    c: &impl CanisterCall,
+    args: ExecuteOperationsArguments,
+) -> Result<(), String> {
+    c.call("execute_operations", args, CallType::Update, true)
+}
+
+/// Abandons the active sync, releasing the lock. Best-effort cleanup on an
+/// aborted sync; a sync left uncancelled is reclaimed once it goes stale.
+pub fn cancel_sync(c: &impl CanisterCall, session_id: u64) -> Result<(), String> {
+    c.call(
+        "cancel_sync",
+        CancelSyncArguments { session_id },
+        CallType::Update,
+        true,
+    )
 }
 
 pub fn get_asset_properties(c: &impl CanisterCall, key: &str) -> Result<AssetProperties, String> {

--- a/crates/sync-core/src/sync.rs
+++ b/crates/sync-core/src/sync.rs
@@ -4,16 +4,16 @@
 //! - synchronous (drives the host's sync `canister-call` import)
 //! - no proposal mode
 
-use candid::{Nat, Principal};
+use candid::Principal;
 use mime::Mime;
 use std::collections::HashMap;
 
 use crate::canister::{
-    api_version, authorize_via_proxy, can_sync, commit_batch, create_batch, create_chunks,
-    get_asset_properties, get_redirect_rules, list_assets, AssetDetails, AssetProperties,
-    BatchOperationKind, CanisterCall, CommitBatchArguments, CreateAssetArguments,
-    DeleteAssetArguments, RedirectRule, SetAssetContentArguments, SetAssetPropertiesArguments,
-    SetRedirectRulesArguments, UnsetAssetContentArguments,
+    api_version, authorize_via_proxy, can_sync, create_chunks, execute_operations,
+    get_asset_properties, get_redirect_rules, list_assets, start_sync, AssetDetails,
+    AssetProperties, BatchOperationKind, CanisterCall, CreateAssetArguments, DeleteAssetArguments,
+    ExecuteOperationsArguments, RedirectRule, SetAssetContentArguments,
+    SetAssetPropertiesArguments, SetRedirectRulesArguments, UnsetAssetContentArguments,
 };
 use crate::content::{encoders_for, Content, Encoder};
 use crate::headers::{self, HeaderRule, HEADERS_FILENAME};
@@ -26,7 +26,7 @@ use std::path::Path;
 const MAX_CHUNK_SIZE: usize = 1_900_000;
 
 struct ProjectAssetEncoding {
-    chunk_ids: Vec<Nat>,
+    chunk_ids: Vec<u64>,
     sha256: Vec<u8>,
     already_in_place: bool,
     // Encoded bytes held until upload; empty when already_in_place or after upload.
@@ -205,11 +205,11 @@ pub fn sync<C: CanisterCall>(
         ));
     }
 
-    // Phase 2: create batch and upload chunks for encodings not already in place.
-    let batch_id = create_batch(canister)?;
-    println!("created batch {batch_id}");
+    // Phase 2: start a sync and upload chunks for encodings not already in place.
+    let session_id = start_sync(canister)?;
+    println!("started sync session {session_id}");
 
-    pack_and_upload_chunks(canister, &batch_id, &mut project_assets)?;
+    pack_and_upload_chunks(canister, session_id, &mut project_assets)?;
 
     let operations = build_operations(
         &project_assets,
@@ -219,9 +219,9 @@ pub fn sync<C: CanisterCall>(
         &canister_rules,
         &project_header_rules,
     );
-    println!("committing {} operation(s)", operations.len());
+    println!("executing {} operation(s)", operations.len());
 
-    commit_in_stages(canister, batch_id, operations)?;
+    execute_in_stages(canister, session_id, operations)?;
 
     Ok(format!(
         "synced {} asset(s) to canister",
@@ -338,7 +338,7 @@ fn encoding_suffix(encoding: &str) -> String {
 /// `enc.chunk_ids[chunk_index]`.
 fn pack_and_upload_chunks<C: CanisterCall>(
     canister: &C,
-    batch_id: &Nat,
+    session_id: u64,
     project_assets: &mut HashMap<String, ProjectAsset>,
 ) -> Result<(), String> {
     struct PendingChunk {
@@ -363,7 +363,7 @@ fn pack_and_upload_chunks<C: CanisterCall>(
             } else {
                 data.chunks(MAX_CHUNK_SIZE).map(|c| c.to_vec()).collect()
             };
-            enc.chunk_ids = vec![Nat::from(0u32); chunks.len()];
+            enc.chunk_ids = vec![0u64; chunks.len()];
             for (i, chunk) in chunks.into_iter().enumerate() {
                 pending.push(PendingChunk {
                     asset_key: key.clone(),
@@ -403,7 +403,7 @@ fn pack_and_upload_chunks<C: CanisterCall>(
         pending = leftovers;
 
         let chunk_refs: Vec<&[u8]> = batch.iter().map(|p| p.data.as_slice()).collect();
-        let ids = create_chunks(canister, batch_id, &chunk_refs)?;
+        let ids = create_chunks(canister, session_id, &chunk_refs)?;
         if ids.len() != batch.len() {
             return Err(format!(
                 "create_chunks returned {} ids for {} chunks",
@@ -430,81 +430,74 @@ fn pack_and_upload_chunks<C: CanisterCall>(
     Ok(())
 }
 
-/// Commits `operations` to the canister, splitting them across multiple
-/// `commit_batch` ingress calls when a single payload would exceed the IC's
-/// 2 MiB per-message ingress limit on application subnets
+/// Applies `operations` to the canister, splitting them across multiple
+/// `execute_operations` ingress calls when a single payload would exceed the
+/// IC's 2 MiB per-message ingress limit on application subnets
 /// (`MAX_INGRESS_BYTES_PER_MESSAGE_APP_SUBNET` in `dfinity/ic`). The local
 /// replica's HTTP boundary accepts up to 4 MiB, but mainnet app subnets cap
 /// the inner ingress message at 2 MiB — so we target the tighter limit.
 ///
-/// Intermediate calls use `batch_id = 0` as a placeholder; the canister's
-/// `commit_batch` does not validate that `batch_id` refers to a live batch
-/// — it just consumes `chunk_ids` referenced by `SetAssetContent` ops and
-/// removes `batch_id` from its batch table at the very end. The chunks
-/// uploaded under the real `batch_id` survive between calls because the
-/// canister only GCs orphaned chunks at `create_batch` time, never inside
-/// `commit_batch`. The trailing call uses the real `batch_id` with empty
-/// operations purely to release that batch entry.
+/// Every call carries the real `session_id`; the canister rejects any that
+/// don't match the active sync. The last group is flagged `is_final`, which
+/// tells the canister to finalize the sync (release the lock and drop staged
+/// chunks) once its operations are applied. Earlier groups leave the sync
+/// open. Staged chunks survive between calls because the canister only drops
+/// them on sync start/finish, not between `execute_operations` calls.
 ///
-/// Trade-off: splitting forfeits cross-batch atomicity. A failure
-/// mid-deploy leaves the canister with the operations from previously
-/// successful calls applied; the next sync run diffs against the canister
-/// and resumes from there.
-fn commit_in_stages<C: CanisterCall>(
+/// Trade-off: splitting forfeits cross-call atomicity. A failure mid-deploy
+/// leaves the canister with the operations from previously successful calls
+/// applied; the next sync run diffs against the canister and resumes from
+/// there.
+fn execute_in_stages<C: CanisterCall>(
     canister: &C,
-    batch_id: Nat,
+    session_id: u64,
     operations: Vec<BatchOperationKind>,
 ) -> Result<(), String> {
-    let groups = create_commit_batches(operations);
-    if groups.len() <= 1 {
-        // Everything fits in one ingress message: skip the placeholder
-        // dance and commit directly under the real `batch_id`, which also
-        // releases the batch entry in the same call.
-        let ops = groups.into_iter().next().unwrap_or_default();
-        return commit_batch(
+    let groups = split_operation_groups(operations);
+    // The caller only reaches this with a non-empty diff, so there is always at
+    // least one group. Guard anyway: we hold a session and must release it.
+    if groups.is_empty() {
+        return execute_operations(
             canister,
-            CommitBatchArguments {
-                batch_id,
-                operations: ops,
+            ExecuteOperationsArguments {
+                session_id,
+                operations: vec![],
+                is_final: true,
             },
         );
     }
     let total = groups.len();
     for (i, ops) in groups.into_iter().enumerate() {
-        println!(
-            "committing group {}/{} ({} operation(s))",
-            i + 1,
-            total,
-            ops.len()
-        );
-        commit_batch(
+        let is_final = i + 1 == total;
+        if total > 1 {
+            println!(
+                "executing group {}/{} ({} operation(s))",
+                i + 1,
+                total,
+                ops.len()
+            );
+        }
+        execute_operations(
             canister,
-            CommitBatchArguments {
-                batch_id: Nat::from(0u32),
+            ExecuteOperationsArguments {
+                session_id,
                 operations: ops,
+                is_final,
             },
         )?;
     }
-    // Empty-ops commit on the real batch_id: the canister's
-    // "all operations processed" branch removes the batch entry.
-    commit_batch(
-        canister,
-        CommitBatchArguments {
-            batch_id,
-            operations: vec![],
-        },
-    )
+    Ok(())
 }
 
 /// Splits `operations` into groups, each small enough that a single
-/// `commit_batch` ingress call stays under the IC's 2 MiB per-message
+/// `execute_operations` ingress call stays under the IC's 2 MiB per-message
 /// limit on application subnets. Greedy in declaration order: walks
 /// operations once, starting a new group whenever the running totals
 /// would exceed either budget.
 ///
 /// Budgets per group:
 /// - **500 operations** — bounds the certified-tree work each
-///   `commit_batch` does and limits the blast radius of a mid-deploy
+///   `execute_operations` does and limits the blast radius of a mid-deploy
 ///   failure.
 /// - **1.5 MiB of inlined header bytes** — leaves ~500 KiB of headroom
 ///   under the 2 MiB ingress cap for fixed per-op overhead (keys,
@@ -516,7 +509,7 @@ fn commit_in_stages<C: CanisterCall>(
 ///
 /// An operation whose own header size exceeds the budget gets a group
 /// to itself — better to ship it alone than to drop it on the floor.
-fn create_commit_batches(operations: Vec<BatchOperationKind>) -> Vec<Vec<BatchOperationKind>> {
+fn split_operation_groups(operations: Vec<BatchOperationKind>) -> Vec<Vec<BatchOperationKind>> {
     const MAX_OPERATIONS_PER_GROUP: usize = 500;
     const MAX_HEADER_BYTES_PER_GROUP: usize = 1_500_000;
 
@@ -782,7 +775,7 @@ mod tests {
     use crate::canister::{
         AssetDetails, AssetEncodingDetails, BatchOperationKind, CallType, CanisterCall,
     };
-    use candid::{CandidType, Nat, Principal};
+    use candid::{CandidType, Principal};
     use serde::de::DeserializeOwned;
     use std::cell::{Cell, RefCell};
     use std::collections::{HashMap, VecDeque};
@@ -791,7 +784,7 @@ mod tests {
     // Mirrors the private CreateChunksResponse — same field name produces the same Candid encoding.
     #[derive(CandidType)]
     struct MockChunksResponse {
-        chunk_ids: Vec<Nat>,
+        chunk_ids: Vec<u64>,
     }
 
     // Counts each `create_chunks` call, returns one fresh id per chunk in the
@@ -816,7 +809,7 @@ mod tests {
     #[derive(CandidType, serde::Deserialize)]
     struct ChunksReqMirror {
         #[allow(dead_code)]
-        batch_id: Nat,
+        session_id: u64,
         content: Vec<serde_bytes::ByteBuf>,
     }
 
@@ -833,7 +826,7 @@ mod tests {
             self.batches.borrow_mut().push(n);
             let start = self.next_id.get();
             self.next_id.set(start + n as u64);
-            let ids: Vec<Nat> = (0..n as u64).map(|i| Nat::from(start + i)).collect();
+            let ids: Vec<u64> = (0..n as u64).map(|i| start + i).collect();
             let reply = candid::encode_one(MockChunksResponse { chunk_ids: ids })
                 .map_err(|e| e.to_string())?;
             candid::decode_one(&reply).map_err(|e| e.to_string())
@@ -873,7 +866,7 @@ mod tests {
             vec![0u8; MAX_CHUNK_SIZE],
         )]);
         let mock = ChunkBatchRecorder::new();
-        pack_and_upload_chunks(&mock, &Nat::from(1u32), &mut assets).unwrap();
+        pack_and_upload_chunks(&mock, 1, &mut assets).unwrap();
         assert_eq!(*mock.batches.borrow(), vec![1]);
         assert_eq!(assets["/f"].encodings["identity"].chunk_ids.len(), 1);
     }
@@ -889,7 +882,7 @@ mod tests {
             vec![0u8; MAX_CHUNK_SIZE * 3 + 1],
         )]);
         let mock = ChunkBatchRecorder::new();
-        pack_and_upload_chunks(&mock, &Nat::from(1u32), &mut assets).unwrap();
+        pack_and_upload_chunks(&mock, 1, &mut assets).unwrap();
         assert_eq!(*mock.batches.borrow(), vec![1, 1, 1, 1]);
         assert_eq!(assets["/big"].encodings["identity"].chunk_ids.len(), 4);
     }
@@ -902,7 +895,7 @@ mod tests {
             .map(|i| mk_pending_asset(&format!("/f{i}"), "identity", vec![0u8; 1024]))
             .collect();
         let mock = ChunkBatchRecorder::new();
-        pack_and_upload_chunks(&mock, &Nat::from(1u32), &mut assets).unwrap();
+        pack_and_upload_chunks(&mock, 1, &mut assets).unwrap();
         assert_eq!(*mock.batches.borrow(), vec![100]);
     }
 
@@ -925,7 +918,7 @@ mod tests {
             )]);
         }
         let mock = ChunkBatchRecorder::new();
-        pack_and_upload_chunks(&mock, &Nat::from(1u32), &mut assets).unwrap();
+        pack_and_upload_chunks(&mock, 1, &mut assets).unwrap();
         // Two calls total: one for the big chunk, one for the ten tinies.
         let batches = mock.batches.borrow().clone();
         assert_eq!(batches.len(), 2);
@@ -943,16 +936,13 @@ mod tests {
             mk_pending_asset("/b", "identity", vec![0u8; 500]),                  // 1 chunk
         ]);
         let mock = ChunkBatchRecorder::new();
-        pack_and_upload_chunks(&mock, &Nat::from(1u32), &mut assets).unwrap();
+        pack_and_upload_chunks(&mock, 1, &mut assets).unwrap();
         let a_ids = &assets["/a"].encodings["identity"].chunk_ids;
         let b_ids = &assets["/b"].encodings["identity"].chunk_ids;
         assert_eq!(a_ids.len(), 2);
         assert_eq!(b_ids.len(), 1);
-        let mut all: Vec<&Nat> = a_ids.iter().chain(b_ids.iter()).collect();
-        all.sort_by(|x, y| {
-            // Nat doesn't impl Ord; compare textually.
-            x.to_string().cmp(&y.to_string())
-        });
+        let mut all: Vec<u64> = a_ids.iter().chain(b_ids.iter()).copied().collect();
+        all.sort_unstable();
         all.dedup();
         assert_eq!(all.len(), 3, "ids must be distinct");
     }
@@ -963,7 +953,7 @@ mod tests {
         // has something to reference.
         let mut assets = HashMap::from([mk_pending_asset("/empty", "identity", vec![])]);
         let mock = ChunkBatchRecorder::new();
-        pack_and_upload_chunks(&mock, &Nat::from(1u32), &mut assets).unwrap();
+        pack_and_upload_chunks(&mock, 1, &mut assets).unwrap();
         assert_eq!(assets["/empty"].encodings["identity"].chunk_ids.len(), 1);
     }
 
@@ -975,11 +965,11 @@ mod tests {
         pa.encodings.get_mut("identity").unwrap().data = Vec::new();
         let mut assets = HashMap::from([(k, pa)]);
         let mock = ChunkBatchRecorder::new();
-        pack_and_upload_chunks(&mock, &Nat::from(1u32), &mut assets).unwrap();
+        pack_and_upload_chunks(&mock, 1, &mut assets).unwrap();
         assert!(mock.batches.borrow().is_empty());
     }
 
-    // ── commit_batch splitting ──────────────────────────────────────────────
+    // ── execute_operations splitting ──────────────────────────────────────────────
 
     fn create_asset_with_headers(key: &str, hdr_bytes: usize) -> BatchOperationKind {
         // One header whose name+value bytes sum to `hdr_bytes`.
@@ -996,7 +986,7 @@ mod tests {
         BatchOperationKind::SetAssetContent(SetAssetContentArguments {
             key: key.to_string(),
             content_encoding: "identity".to_string(),
-            chunk_ids: vec![Nat::from(0u32)],
+            chunk_ids: vec![0u64],
             last_chunk: None,
             sha256: Some(vec![0u8; 32]),
         })
@@ -1056,29 +1046,29 @@ mod tests {
     }
 
     #[test]
-    fn create_commit_batches_empty_input_returns_empty() {
-        assert!(create_commit_batches(vec![]).is_empty());
+    fn split_operation_groups_empty_input_returns_empty() {
+        assert!(split_operation_groups(vec![]).is_empty());
     }
 
     #[test]
-    fn create_commit_batches_small_input_stays_single_group() {
+    fn split_operation_groups_small_input_stays_single_group() {
         // 100 small ops with tiny headers → fits both budgets in one group.
         let ops: Vec<BatchOperationKind> = (0..100)
             .map(|i| create_asset_with_headers(&format!("/f{i}"), 10))
             .collect();
-        let groups = create_commit_batches(ops);
+        let groups = split_operation_groups(ops);
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].len(), 100);
     }
 
     #[test]
-    fn create_commit_batches_splits_at_500_ops() {
+    fn split_operation_groups_splits_at_500_ops() {
         // 1200 headerless ops should split into 500/500/200 — three groups
         // driven purely by the operation-count cap.
         let ops: Vec<BatchOperationKind> = (0..1200)
             .map(|i| set_content_op(&format!("/f{i}")))
             .collect();
-        let groups = create_commit_batches(ops);
+        let groups = split_operation_groups(ops);
         assert_eq!(
             groups.iter().map(|g| g.len()).collect::<Vec<_>>(),
             vec![500, 500, 200]
@@ -1086,13 +1076,13 @@ mod tests {
     }
 
     #[test]
-    fn create_commit_batches_splits_at_header_budget() {
+    fn split_operation_groups_splits_at_header_budget() {
         // 4 ops × 500 KB headers = 2 MB > 1.5 MB cap. Split happens before
         // the 500-op cap could kick in.
         let ops: Vec<BatchOperationKind> = (0..4)
             .map(|i| create_asset_with_headers(&format!("/f{i}"), 500_000))
             .collect();
-        let groups = create_commit_batches(ops);
+        let groups = split_operation_groups(ops);
         // 3 ops × 500 KB = 1.5 MB fits exactly; the 4th would push over → split.
         assert_eq!(groups.len(), 2);
         assert_eq!(groups[0].len(), 3);
@@ -1100,7 +1090,7 @@ mod tests {
     }
 
     #[test]
-    fn create_commit_batches_oversized_op_gets_own_group() {
+    fn split_operation_groups_oversized_op_gets_own_group() {
         // One op alone exceeds the header budget. The greedy loop must still
         // emit it (in its own group) rather than skip it.
         let ops = vec![
@@ -1108,7 +1098,7 @@ mod tests {
             create_asset_with_headers("/huge", 2_000_000),
             create_asset_with_headers("/small2", 10),
         ];
-        let groups = create_commit_batches(ops);
+        let groups = split_operation_groups(ops);
         // First group flushes when /huge would overflow it → [/small], then
         // /huge alone (oversized but emitted), then /small2 alone (since /huge
         // already pushed header_bytes way over budget).
@@ -1118,12 +1108,12 @@ mod tests {
         assert_eq!(groups[2].len(), 1);
     }
 
-    // Mock that records every `commit_batch` call's `(batch_id, op_count)`.
-    // Used to verify that `commit_in_stages` issues the right shape of
-    // call sequence (placeholder batch_id for splits, real batch_id for
-    // cleanup).
+    // Mock that records every `execute_operations` call's
+    // `(session_id, op_count, is_final)`. Used to verify that
+    // `execute_in_stages` issues the right call sequence: every call carries
+    // the real session id, and only the last is flagged final.
     struct CommitRecorder {
-        calls: RefCell<Vec<(Nat, usize)>>,
+        calls: RefCell<Vec<(u64, usize, bool)>>,
     }
 
     impl CommitRecorder {
@@ -1136,8 +1126,9 @@ mod tests {
 
     #[derive(CandidType, serde::Deserialize)]
     struct CommitArgsMirror {
-        batch_id: Nat,
+        session_id: u64,
         operations: Vec<candid::Reserved>,
+        is_final: bool,
     }
 
     impl CanisterCall for CommitRecorder {
@@ -1146,49 +1137,43 @@ mod tests {
             A: CandidType,
             R: CandidType + DeserializeOwned,
         {
-            assert_eq!(method, "commit_batch");
+            assert_eq!(method, "execute_operations");
             let bytes = candid::encode_one(&arg).map_err(|e| e.to_string())?;
             let req: CommitArgsMirror = candid::decode_one(&bytes).map_err(|e| e.to_string())?;
             self.calls
                 .borrow_mut()
-                .push((req.batch_id, req.operations.len()));
+                .push((req.session_id, req.operations.len(), req.is_final));
             let reply = candid::encode_one(()).map_err(|e| e.to_string())?;
             candid::decode_one(&reply).map_err(|e| e.to_string())
         }
     }
 
     #[test]
-    fn commit_in_stages_single_group_uses_real_batch_id() {
-        // Small enough to fit in one group → one commit_batch call carrying
-        // the real batch_id, no placeholder dance.
+    fn execute_in_stages_single_group_is_final() {
+        // Small enough to fit in one group → one execute_operations call
+        // carrying the real session id and flagged final.
         let ops: Vec<BatchOperationKind> =
             (0..10).map(|i| set_content_op(&format!("/f{i}"))).collect();
         let mock = CommitRecorder::new();
-        commit_in_stages(&mock, Nat::from(42u32), ops).unwrap();
+        execute_in_stages(&mock, 42, ops).unwrap();
         let calls = mock.calls.borrow();
         assert_eq!(calls.len(), 1);
-        assert_eq!(calls[0], (Nat::from(42u32), 10));
+        assert_eq!(calls[0], (42, 10, true));
     }
 
     #[test]
-    fn commit_in_stages_multi_group_uses_placeholder_then_real_cleanup() {
-        // 1200 ops → three 500/500/200 splits using placeholder batch_id 0,
-        // then a final empty-ops call on the real batch_id to release the
-        // canister-side batch entry.
+    fn execute_in_stages_multi_group_flags_only_last_final() {
+        // 1200 ops → three 500/500/200 groups, all carrying the real session
+        // id; only the last is flagged final (which finalizes the sync).
         let ops: Vec<BatchOperationKind> = (0..1200)
             .map(|i| set_content_op(&format!("/f{i}")))
             .collect();
         let mock = CommitRecorder::new();
-        commit_in_stages(&mock, Nat::from(42u32), ops).unwrap();
+        execute_in_stages(&mock, 42, ops).unwrap();
         let calls = mock.calls.borrow().clone();
         assert_eq!(
             calls,
-            vec![
-                (Nat::from(0u32), 500),
-                (Nat::from(0u32), 500),
-                (Nat::from(0u32), 200),
-                (Nat::from(42u32), 0),
-            ]
+            vec![(42, 500, false), (42, 500, false), (42, 200, true)]
         );
     }
 
@@ -1203,7 +1188,7 @@ mod tests {
             let chunk_ids = if *already_in_place {
                 vec![]
             } else {
-                vec![Nat::from(1u32)]
+                vec![1u64]
             };
             enc_map.insert(
                 name.to_string(),
@@ -1528,7 +1513,7 @@ mod tests {
     fn sync_short_circuits_when_redirects_file_only_matches_canister() {
         // Drive sync() end-to-end with a _redirects file that matches what
         // the canister already has. The "nothing to commit" short-circuit
-        // must trigger, with no create_batch / commit_batch calls.
+        // must trigger, with no start_sync / execute_operations calls.
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("_redirects"), b"/old /new 301\n").unwrap();
 
@@ -1551,16 +1536,23 @@ mod tests {
             &Principal::anonymous().to_text(),
             None,
         );
-        // No create_batch / commit_batch programmed — if sync reached them
+        // No start_sync / execute_operations programmed — if sync reached them
         // SyncMock would panic with "no programmed response".
         assert!(result.is_ok(), "expected success, got: {result:?}");
     }
 
-    // Mirrors the private `CreateBatchResponse` in canister.rs — same field
-    // name gives the same Candid encoding, so the test mock can decode it.
+    // Mirrors the private `StartSyncResult` in canister.rs — same variant and
+    // field names give the same Candid encoding, so the test mock can decode it.
     #[derive(CandidType)]
-    struct CreateBatchOk {
-        batch_id: Nat,
+    enum StartSyncOk {
+        Started {
+            session_id: u64,
+        },
+        #[allow(dead_code)]
+        Busy {
+            owner: Principal,
+            idle_for_secs: u64,
+        },
     }
 
     #[test]
@@ -1576,13 +1568,8 @@ mod tests {
         mock.push_ok("can_sync", true);
         mock.push_ok("list", Vec::<AssetDetails>::new());
         mock.push_ok("get_redirect_rules", Vec::<RedirectRule>::new());
-        mock.push_ok(
-            "create_batch",
-            CreateBatchOk {
-                batch_id: Nat::from(1u32),
-            },
-        );
-        mock.push_ok("commit_batch", ());
+        mock.push_ok("start_sync", StartSyncOk::Started { session_id: 1 });
+        mock.push_ok("execute_operations", ());
 
         let result = sync(
             &mock,
@@ -2259,7 +2246,7 @@ mod tests {
             &Principal::anonymous().to_text(),
             None,
         );
-        // No create_batch / commit_batch programmed — would panic if reached.
+        // No start_sync / execute_operations programmed — would panic if reached.
         assert!(result.is_ok(), "expected success, got: {result:?}");
     }
 
@@ -2280,19 +2267,14 @@ mod tests {
         mock.push_ok("can_sync", true);
         mock.push_ok("list", Vec::<AssetDetails>::new());
         mock.push_ok("get_redirect_rules", Vec::<RedirectRule>::new());
-        mock.push_ok(
-            "create_batch",
-            CreateBatchOk {
-                batch_id: Nat::from(1u32),
-            },
-        );
+        mock.push_ok("start_sync", StartSyncOk::Started { session_id: 1 });
         mock.push_ok(
             "create_chunks",
             MockChunksResponse {
-                chunk_ids: vec![Nat::from(0u32)],
+                chunk_ids: vec![0u64],
             },
         );
-        mock.push_ok("commit_batch", ());
+        mock.push_ok("execute_operations", ());
 
         let result = sync(
             &mock,
@@ -2367,7 +2349,7 @@ mod tests {
         // The canister already stores the rules synthesis would produce.
         // No SetRedirectRules op should be emitted, and with the asset
         // already up to date the sync should short-circuit before
-        // create_batch.
+        // start_sync.
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("index.html"), b"<html></html>").unwrap();
 
@@ -2400,26 +2382,26 @@ mod tests {
             &Principal::anonymous().to_text(),
             None,
         );
-        // No create_batch / commit_batch programmed — would panic if reached.
+        // No start_sync / execute_operations programmed — would panic if reached.
         assert!(result.is_ok(), "expected success, got: {result:?}");
     }
 
     // Direct mode: identity passes the early authorization check, but a later
-    // create_batch failure (e.g. the authorized set changed under us) must
+    // start_sync failure (e.g. the authorized set changed under us) must
     // still propagate.
     #[test]
-    fn sync_propagates_error_from_create_batch() {
+    fn sync_propagates_error_from_start_sync() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("index.html"), b"<html></html>").unwrap();
 
         let mock = SyncMock::new();
         mock.push_ok("api_version", 2u16);
         mock.push_ok("can_sync", true);
-        // Empty canister → build_operations will produce work → create_batch is called.
+        // Empty canister → build_operations will produce work → start_sync is called.
         mock.push_ok("list", Vec::<AssetDetails>::new());
         mock.push_ok("get_redirect_rules", Vec::<RedirectRule>::new());
         mock.push_err(
-            "create_batch",
+            "start_sync",
             "Caller is not authorized to sync assets and is not a controller.",
         );
 
@@ -2433,7 +2415,7 @@ mod tests {
         let err = result.unwrap_err();
         assert!(
             err.contains("not authorized"),
-            "expected create_batch error to propagate, got: {err}"
+            "expected start_sync error to propagate, got: {err}"
         );
     }
 

--- a/crates/sync-core/tests/bench_sync.rs
+++ b/crates/sync-core/tests/bench_sync.rs
@@ -15,7 +15,7 @@
 //!
 //! Tests are `#[ignore]`'d so they don't slow down the regular suite.
 
-use candid::{CandidType, Decode, Encode, Nat, Principal};
+use candid::{CandidType, Decode, Encode, Principal};
 use serde::Deserialize;
 use std::cell::{Cell, RefCell};
 use std::collections::BTreeMap;
@@ -24,14 +24,21 @@ use sync_core::canister::{AssetDetails, AssetProperties, CallType, CanisterCall,
 use sync_core::sync::sync;
 
 // Wire-compatible mirrors of the response types defined privately in
-// sync_core::canister. Same field name → same Candid encoding.
+// sync_core::canister. Same variant/field names → same Candid encoding.
 #[derive(CandidType)]
-struct CreateBatchOk {
-    batch_id: Nat,
+enum StartSyncOk {
+    Started {
+        session_id: u64,
+    },
+    #[allow(dead_code)]
+    Busy {
+        owner: Principal,
+        idle_for_secs: u64,
+    },
 }
 #[derive(CandidType)]
 struct CreateChunksOk {
-    chunk_ids: Vec<Nat>,
+    chunk_ids: Vec<u64>,
 }
 
 // Wire-compatible mirror of CreateChunksRequest so the mock can count chunks
@@ -40,7 +47,7 @@ struct CreateChunksOk {
 #[derive(CandidType, Deserialize)]
 struct CreateChunksReqMirror {
     #[allow(dead_code)]
-    batch_id: Nat,
+    session_id: u64,
     content: Vec<serde_bytes::ByteBuf>,
 }
 
@@ -97,19 +104,17 @@ impl CanisterCall for BenchMock {
             "list" => Encode!(&Vec::<AssetDetails>::new()),
             "get_redirect_rules" => Encode!(&Vec::<RedirectRule>::new()),
             "get_asset_properties" => Encode!(&AssetProperties { headers: None }),
-            "create_batch" => Encode!(&CreateBatchOk {
-                batch_id: Nat::from(1u32),
-            }),
+            "start_sync" => Encode!(&StartSyncOk::Started { session_id: 1 }),
             "create_chunks" => {
                 let req = Decode!(&arg_bytes, CreateChunksReqMirror)
                     .map_err(|e| format!("decode create_chunks req: {e}"))?;
                 let n = req.content.len() as u64;
                 let start = self.next_chunk_id.get();
                 self.next_chunk_id.set(start + n);
-                let ids: Vec<Nat> = (0..n).map(|i| Nat::from(start + i)).collect();
+                let ids: Vec<u64> = (0..n).map(|i| start + i).collect();
                 Encode!(&CreateChunksOk { chunk_ids: ids })
             }
-            "commit_batch" => Encode!(&()),
+            "execute_operations" => Encode!(&()),
             // The bench drives sync() in direct mode, which checks can_sync up
             // front; report the identity as allowed so it proceeds.
             "can_sync" => Encode!(&true),


### PR DESCRIPTION
Assets used to be mutated through a multi-batch upload protocol: create a batch, upload chunks, commit operations. The canister supported many concurrent batches even though the plugin only ever used one, and large commits needed a `batch_id = 0` placeholder hack plus a trailing empty-ops call to release the batch.

This replaces that with a single in-progress **sync**, identified by a session id:

- **`start_sync`** — at most one sync runs at a time. The owner can reclaim their own sync immediately (retrying a failed deploy); a different caller only after it goes stale (30s idle), otherwise gets `Busy` so a teammate can't barge into an active deploy.
- **`execute_operations`** — every call carries the session id (validated by the canister); the last call sets `is_final` to finalize the sync. This removes the placeholder-batch hack.
- **`cancel_sync`** — owner-only release of the lock on abort.

Also unifies the wire types for what are just counters/timestamps: ids `nat → nat64`, `Time` `int → nat64`, dropping the `Nat`/`Int` conversion helpers and overflow panics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)