### PR TITLE
fix: Revert addition of canonicalize

### DIFF
--- a/assets-sync/src/scan.rs
+++ b/assets-sync/src/scan.rs
@@ -31,10 +31,7 @@ pub fn scan(dirs: &[String]) -> Result<Vec<AssetSource>, String> {
     let mut seen_keys = std::collections::HashSet::new();
     for dir in dirs {
         let root = Path::new(dir);
-        let root_abs = root
-            .canonicalize()
-            .map_err(|e| format!("canonicalize {}: {e}", root.display()))?;
-        walk(&root_abs, &root_abs, &mut out, &mut seen_keys)?;
+        walk(root, root, &mut out, &mut seen_keys)?;
     }
     Ok(out)
 }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -13,3 +13,6 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking"] 
 serde.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
+
+[build-dependencies]
+serde_json.workspace = true

--- a/e2e/build.rs
+++ b/e2e/build.rs
@@ -9,34 +9,71 @@ fn main() {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let workspace_root = manifest_dir.parent().expect("e2e/ must have a parent");
 
-    build_wasm(workspace_root, "canister", "wasm32-unknown-unknown");
-    build_wasm(workspace_root, "plugin", "wasm32-wasip2");
+    let canister_wasm = build_wasm(workspace_root, "canister", "wasm32-unknown-unknown");
+    let plugin_wasm = build_wasm(workspace_root, "plugin", "wasm32-wasip2");
 
-    println!(
-        "cargo:rustc-env=CANISTER_WASM={}",
-        workspace_root
-            .join("target/wasm32-unknown-unknown/release/canister.wasm")
-            .display()
-    );
-    println!(
-        "cargo:rustc-env=PLUGIN_WASM={}",
-        workspace_root
-            .join("target/wasm32-wasip2/release/plugin.wasm")
-            .display()
-    );
+    println!("cargo:rustc-env=CANISTER_WASM={}", canister_wasm.display());
+    println!("cargo:rustc-env=PLUGIN_WASM={}", plugin_wasm.display());
 }
 
-fn build_wasm(workspace_root: &Path, package: &str, target: &str) {
-    let status = Command::new("cargo")
-        .args(["build", "-p", package, "--target", target, "--release"])
+/// Build `package` for `target` and return the path to the wasm it produced.
+///
+/// The path is read from Cargo's `--message-format=json` artifact output rather
+/// than assembled by hand, so it is correct wherever the target directory is
+/// configured (`CARGO_TARGET_DIR`, `build.target-dir` in `.cargo/config.toml`,
+/// etc.) instead of assuming `<workspace>/target`.
+fn build_wasm(workspace_root: &Path, package: &str, target: &str) -> PathBuf {
+    let output = Command::new("cargo")
+        .args([
+            "build",
+            "-p",
+            package,
+            "--target",
+            target,
+            "--release",
+            "--message-format=json",
+        ])
         // Prevent the nested cargo from inheriting the jobserver file
         // descriptors that the outer Cargo passes via CARGO_MAKEFLAGS.
         .env_remove("CARGO_MAKEFLAGS")
         .current_dir(workspace_root)
-        .status()
+        .output()
         .unwrap_or_else(|e| panic!("failed to spawn cargo build for {package}: {e}"));
+
     assert!(
-        status.success(),
-        "cargo build -p {package} --target {target} --release failed"
+        output.status.success(),
+        "cargo build -p {package} --target {target} --release failed:\n{}",
+        String::from_utf8_lossy(&output.stderr),
     );
+
+    wasm_artifact(&output.stdout, package)
+        .unwrap_or_else(|| panic!("no wasm artifact for `{package}` in `cargo build` JSON output"))
+}
+
+/// Extracts the wasm path for `package` from a stream of `cargo --message-format=json`
+/// lines: the `compiler-artifact` message for the package's own target carries
+/// the built file in `executable` (or, for a library crate-type, `filenames`).
+fn wasm_artifact(stdout: &[u8], package: &str) -> Option<PathBuf> {
+    for line in stdout.split(|&b| b == b'\n') {
+        let msg: serde_json::Value = match serde_json::from_slice(line) {
+            Ok(msg) => msg,
+            Err(_) => continue, // non-JSON / blank lines
+        };
+        if msg["reason"] != "compiler-artifact" || msg["target"]["name"] != package {
+            continue;
+        }
+        if let Some(exe) = msg["executable"].as_str() {
+            return Some(PathBuf::from(exe));
+        }
+        if let Some(wasm) = msg["filenames"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter_map(|f| f.as_str())
+            .find(|f| f.ends_with(".wasm"))
+        {
+            return Some(PathBuf::from(wasm));
+        }
+    }
+    None
 }

--- a/e2e/tests/fixture/nested-dir/frontend/dist/assets/app.js
+++ b/e2e/tests/fixture/nested-dir/frontend/dist/assets/app.js
@@ -1,0 +1,1 @@
+console.log("nested-dir fixture asset");

--- a/e2e/tests/fixture/nested-dir/frontend/dist/index.html
+++ b/e2e/tests/fixture/nested-dir/frontend/dist/index.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+    <title>nested-dir fixture</title>
+  </head>
+  <body>
+    <h1>Hello from a multi-segment scan directory</h1>
+  </body>
+</html>

--- a/e2e/tests/fixture/nested-dir/icp.yaml
+++ b/e2e/tests/fixture/nested-dir/icp.yaml
@@ -1,0 +1,23 @@
+networks:
+  - name: local
+    mode: managed
+    gateway:
+      port: 0
+
+canisters:
+  - name: frontend
+    build:
+      steps:
+        - type: pre-built
+          path: wasms/canister.wasm
+
+    sync:
+      steps:
+        - type: plugin
+          path: wasms/plugin.wasm
+          dirs:
+            # A multi-segment scan directory. The plugin must traverse this
+            # without `canonicalize`, which cannot resolve a WASI preopen whose
+            # name has more than one component (it ENOENTs on the intermediate
+            # `frontend`). See `nested_scan_dir_deploys` in tests/sync.rs.
+            - frontend/dist

--- a/e2e/tests/sync.rs
+++ b/e2e/tests/sync.rs
@@ -20,6 +20,27 @@ fn basic_deploy() {
     );
 }
 
+/// Regression test for a scan directory with more than one path component
+/// (e.g. `frontend/dist`).
+#[test]
+fn nested_scan_dir_deploys() {
+    let tmp = setup_project("tests/fixture/nested-dir");
+    let project = tmp.path();
+    let _network = LocalNetwork::start(project);
+
+    icp_cmd(project).arg("deploy").assert().success();
+
+    let keys: Vec<String> = list_assets(project).into_iter().map(|a| a.key).collect();
+    assert!(
+        keys.iter().any(|k| k == "/index.html"),
+        "expected /index.html (key relative to frontend/dist); got: {keys:#?}",
+    );
+    assert!(
+        keys.iter().any(|k| k == "/assets/app.js"),
+        "expected /assets/app.js (nested key relative to frontend/dist); got: {keys:#?}",
+    );
+}
+
 #[test]
 fn basic_deploy_with_proxy() {
     let tmp = setup_project("tests/fixture/basic");


### PR DESCRIPTION
wasmtime-wasi doesn't allow you to canonicalize preopened nested paths where the parent is not preopened. This removes the canonicalize step, added in 44a0aa8f.