### PR TITLE
refactor: drop the unused cancel_sync endpoint

### DIFF
--- a/candid/assets.did
+++ b/candid/assets.did
@@ -140,10 +140,6 @@ type ExecuteOperationsArguments = record {
   is_final: bool;
 };
 
-type CancelSyncArguments = record {
-  session_id: SessionId;
-};
-
 service: {
   // ───────── Canister metadata ─────────
 
@@ -192,9 +188,6 @@ service: {
 
   // Apply a group of operations. Perform all successfully, or reject.
   execute_operations: (ExecuteOperationsArguments) -> ();
-  // Abandon the active sync, releasing the lock without waiting for it to go
-  // stale. Only the sync's owner may cancel it.
-  cancel_sync: (CancelSyncArguments) -> ();
 
   // ───────── Authorization ─────────
   // A set of extra principals authorized to sync assets. Canister controllers

--- a/crates/canister-core/src/lib.rs
+++ b/crates/canister-core/src/lib.rs
@@ -89,13 +89,6 @@ pub async fn execute_operations(arg: ExecuteOperationsArguments) {
     with_state_mut(|s| certified_data_set(s.root_hash()));
 }
 
-pub fn cancel_sync(arg: CancelSyncArguments) {
-    let caller = msg_caller();
-    if let Err(msg) = with_state_mut(|s| s.cancel_sync(arg, caller)) {
-        trap(&msg);
-    }
-}
-
 pub fn get_asset_details(start_after: Option<String>) -> Vec<AssetDetails> {
     with_state(|s| s.get_asset_details(start_after))
 }

--- a/crates/canister-core/src/sync.rs
+++ b/crates/canister-core/src/sync.rs
@@ -6,7 +6,7 @@
 //! calls ([`ComputationStatus`], [`ExecuteOperationsProgress`]).
 //!
 //! The State methods that drive a sync — `start_sync`, `upload_chunks`,
-//! `execute_operations`, `cancel_sync` — live here too, alongside the small
+//! `execute_operations` — live here too, alongside the small
 //! helpers they rely on. State methods unrelated to syncing stay in the
 //! state machine module.
 
@@ -17,8 +17,8 @@ use crate::redirect;
 use crate::state::State;
 use crate::system_context::SystemContext;
 use crate::types::{
-    CancelSyncArguments, ExecuteOperationsArguments, Operation, SessionId,
-    SetAssetContentArguments, StartSyncResult, UploadChunksArguments,
+    ExecuteOperationsArguments, Operation, SessionId, SetAssetContentArguments, StartSyncResult,
+    UploadChunksArguments,
 };
 use candid::Principal;
 use ic_representation_independent_hash::Value;
@@ -319,25 +319,6 @@ impl State {
                     ComputationStatus::InProgress(progress)
                 }
             }
-        }
-    }
-
-    /// Cancels the active sync, if it matches `session_id` and is owned by
-    /// `caller`. Lets a client cleanly release the sync lock on abort instead
-    /// of waiting for it to go stale. A caller cannot cancel someone else's
-    /// sync (a stale one is reclaimed via `start_sync` instead).
-    pub fn cancel_sync(
-        &mut self,
-        arg: CancelSyncArguments,
-        caller: Principal,
-    ) -> Result<(), String> {
-        match &self.sync_session {
-            Some(s) if s.id == arg.session_id && s.owner == caller => {
-                self.sync_session = None;
-                self.chunks.clear();
-                Ok(())
-            }
-            _ => Err("no active sync for this session id".to_string()),
         }
     }
 

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -6,8 +6,8 @@ use crate::state::State;
 use crate::sync::{ComputationStatus, SYNC_IDLE_TIMEOUT_NANOS};
 use crate::system_context::SystemContext;
 use crate::types::{
-    CreateAssetArguments, DeleteAssetArguments, ExecuteOperationsArguments,
-    Operation, SessionId, SetAssetContentArguments, SetAssetHeadersArguments, StartSyncResult,
+    CreateAssetArguments, DeleteAssetArguments, ExecuteOperationsArguments, Operation, SessionId,
+    SetAssetContentArguments, SetAssetHeadersArguments, StartSyncResult,
 };
 use crate::url::{url_decode, UrlDecodeError};
 use crate::UploadChunksArguments;

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -604,6 +604,99 @@ fn stale_sync_can_be_reclaimed_by_another_principal() {
 }
 
 #[test]
+fn active_sync_idle_clock_resets_on_each_call() {
+    // Staleness is measured from the last call, not from sync start: a deploy
+    // that keeps making calls must never become reclaimable, however long it
+    // runs in total. Without the touch_session reset a different principal
+    // could steal an actively-progressing sync mid-flight.
+    let mut state = State::default();
+    let mut system_context = mock_system_context();
+    let owner_b = Principal::from_text("aaaaa-aa").unwrap();
+
+    let session_id = start_session(&mut state, &system_context);
+
+    // Advance to just under the timeout, then make a call that touches the
+    // session and resets its idle clock.
+    system_context.current_timestamp_ns += SYNC_IDLE_TIMEOUT_NANOS - 1;
+    state
+        .upload_chunks(
+            UploadChunksArguments {
+                session_id,
+                chunks: vec![ByteBuf::from(b"x".to_vec())],
+            },
+            &system_context,
+        )
+        .unwrap();
+
+    // Advance again by just under the timeout. Total elapsed since start now
+    // far exceeds the timeout, but only `TIMEOUT - 1` has passed since the
+    // last call, so the sync is still active and a different principal is
+    // refused rather than allowed to reclaim it.
+    system_context.current_timestamp_ns += SYNC_IDLE_TIMEOUT_NANOS - 1;
+    match state.start_sync(owner_b, &system_context) {
+        StartSyncResult::Busy { owner, .. } => assert_eq!(owner, some_principal()),
+        other => panic!("expected Busy while the sync is being actively touched, got {other:?}"),
+    }
+}
+
+#[test]
+fn reclaim_boundary_is_inclusive_at_the_idle_timeout() {
+    // The reclaim guard is `idle >= SYNC_IDLE_TIMEOUT_NANOS`: a different
+    // principal is refused one nanosecond before the timeout and reclaims at
+    // exactly the timeout.
+    let owner_b = Principal::from_text("aaaaa-aa").unwrap();
+
+    // Just under the timeout: still Busy.
+    {
+        let mut state = State::default();
+        let mut system_context = mock_system_context();
+        start_session(&mut state, &system_context);
+        system_context.current_timestamp_ns += SYNC_IDLE_TIMEOUT_NANOS - 1;
+        match state.start_sync(owner_b, &system_context) {
+            StartSyncResult::Busy { .. } => {}
+            other => panic!("expected Busy one ns before the timeout, got {other:?}"),
+        }
+    }
+
+    // Exactly at the timeout: reclaimable.
+    {
+        let mut state = State::default();
+        let mut system_context = mock_system_context();
+        let id1 = start_session(&mut state, &system_context);
+        system_context.current_timestamp_ns += SYNC_IDLE_TIMEOUT_NANOS;
+        match state.start_sync(owner_b, &system_context) {
+            StartSyncResult::Started { session_id } => assert!(session_id > id1),
+            other => panic!("expected Started at exactly the timeout, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn busy_reports_holders_idle_seconds() {
+    // The Busy variant reports how long the holder has been idle, in whole
+    // seconds (sub-second nanos truncated toward zero).
+    let mut state = State::default();
+    let mut system_context = mock_system_context();
+    let owner_b = Principal::from_text("aaaaa-aa").unwrap();
+
+    start_session(&mut state, &system_context);
+
+    // 5.5s of idle time, still under the timeout; the reported value truncates
+    // to whole seconds.
+    system_context.current_timestamp_ns += 5_500_000_000;
+    match state.start_sync(owner_b, &system_context) {
+        StartSyncResult::Busy {
+            owner,
+            idle_for_secs,
+        } => {
+            assert_eq!(owner, some_principal());
+            assert_eq!(idle_for_secs, 5);
+        }
+        other => panic!("expected Busy, got {other:?}"),
+    }
+}
+
+#[test]
 fn returns_index_file_for_missing_assets_via_rule() {
     let mut state = State::default();
     let system_context = mock_system_context();

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -6,7 +6,7 @@ use crate::state::State;
 use crate::sync::{ComputationStatus, SYNC_IDLE_TIMEOUT_NANOS};
 use crate::system_context::SystemContext;
 use crate::types::{
-    CancelSyncArguments, CreateAssetArguments, DeleteAssetArguments, ExecuteOperationsArguments,
+    CreateAssetArguments, DeleteAssetArguments, ExecuteOperationsArguments,
     Operation, SessionId, SetAssetContentArguments, SetAssetHeadersArguments, StartSyncResult,
 };
 use crate::url::{url_decode, UrlDecodeError};
@@ -601,42 +601,6 @@ fn stale_sync_can_be_reclaimed_by_another_principal() {
         )
         .unwrap_err();
     assert!(err.contains("no active sync"), "got: {err}");
-}
-
-#[test]
-fn cancel_sync_releases_the_lock_for_the_owner_only() {
-    let mut state = State::default();
-    let system_context = mock_system_context();
-    let owner = some_principal();
-    let other = Principal::from_text("aaaaa-aa").unwrap();
-
-    let session_id = start_session(&mut state, &system_context);
-
-    const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
-    state
-        .upload_chunks(
-            UploadChunksArguments {
-                session_id,
-                chunks: vec![ByteBuf::from(BODY.to_vec())],
-            },
-            &system_context,
-        )
-        .unwrap();
-
-    // A non-owner cannot cancel someone else's sync.
-    assert!(state
-        .cancel_sync(CancelSyncArguments { session_id }, other)
-        .is_err());
-
-    // The owner can, which clears staged chunks; a second cancel then errors.
-    assert_eq!(
-        Ok(()),
-        state.cancel_sync(CancelSyncArguments { session_id }, owner)
-    );
-    assert!(state.chunks.is_empty());
-    assert!(state
-        .cancel_sync(CancelSyncArguments { session_id }, owner)
-        .is_err());
 }
 
 #[test]

--- a/crates/canister-core/src/types.rs
+++ b/crates/canister-core/src/types.rs
@@ -6,7 +6,7 @@
 
 // Shared wire types (defined once in `wire-types`, used by both sides).
 pub use wire_types::{
-    AssetDetails, AssetEncodingDetails, CancelSyncArguments, ChunkId, CreateAssetArguments,
+    AssetDetails, AssetEncodingDetails, ChunkId, CreateAssetArguments,
     DeleteAssetArguments, ExecuteOperationsArguments, Operation, SessionId,
     SetAssetContentArguments, SetAssetHeadersArguments, SetRedirectRulesArguments, StartSyncResult,
     UnsetAssetContentArguments, UploadChunksArguments,

--- a/crates/canister-core/src/types.rs
+++ b/crates/canister-core/src/types.rs
@@ -6,8 +6,8 @@
 
 // Shared wire types (defined once in `wire-types`, used by both sides).
 pub use wire_types::{
-    AssetDetails, AssetEncodingDetails, ChunkId, CreateAssetArguments,
-    DeleteAssetArguments, ExecuteOperationsArguments, Operation, SessionId,
-    SetAssetContentArguments, SetAssetHeadersArguments, SetRedirectRulesArguments, StartSyncResult,
+    AssetDetails, AssetEncodingDetails, ChunkId, CreateAssetArguments, DeleteAssetArguments,
+    ExecuteOperationsArguments, Operation, SessionId, SetAssetContentArguments,
+    SetAssetHeadersArguments, SetRedirectRulesArguments, StartSyncResult,
     UnsetAssetContentArguments, UploadChunksArguments,
 };

--- a/crates/canister/src/lib.rs
+++ b/crates/canister/src/lib.rs
@@ -6,8 +6,7 @@ use canister_core::{
     http::{HttpRequest, HttpResponse, StreamingCallbackHttpResponse, StreamingCallbackToken},
     redirect::RedirectRule,
     types::{
-        AssetDetails, CancelSyncArguments, ExecuteOperationsArguments, StartSyncResult,
-        UploadChunksArguments,
+        AssetDetails, ExecuteOperationsArguments, StartSyncResult, UploadChunksArguments,
     },
 };
 use ic_cdk::{post_upgrade, pre_upgrade, query, update};
@@ -97,11 +96,6 @@ fn upload_chunks(arg: UploadChunksArguments) {
 #[update(guard = "guard_can_sync")]
 async fn execute_operations(arg: ExecuteOperationsArguments) {
     canister_core::execute_operations(arg).await
-}
-
-#[update(guard = "guard_can_sync")]
-fn cancel_sync(arg: CancelSyncArguments) {
-    canister_core::cancel_sync(arg)
 }
 
 ic_cdk::export_candid!();

--- a/crates/canister/src/lib.rs
+++ b/crates/canister/src/lib.rs
@@ -5,9 +5,7 @@ use canister_core::{
     guard_can_sync, guard_is_controller,
     http::{HttpRequest, HttpResponse, StreamingCallbackHttpResponse, StreamingCallbackToken},
     redirect::RedirectRule,
-    types::{
-        AssetDetails, ExecuteOperationsArguments, StartSyncResult, UploadChunksArguments,
-    },
+    types::{AssetDetails, ExecuteOperationsArguments, StartSyncResult, UploadChunksArguments},
 };
 use ic_cdk::{post_upgrade, pre_upgrade, query, update};
 

--- a/crates/sync-core/src/canister.rs
+++ b/crates/sync-core/src/canister.rs
@@ -13,9 +13,9 @@ use serde_bytes::ByteBuf;
 use std::collections::HashMap;
 
 pub use wire_types::{
-    AssetDetails, AssetEncodingDetails, CreateAssetArguments,
-    DeleteAssetArguments, ExecuteOperationsArguments, Operation, RedirectRule, RulePattern,
-    SetAssetContentArguments, SetAssetHeadersArguments, SetRedirectRulesArguments, StartSyncResult,
+    AssetDetails, AssetEncodingDetails, CreateAssetArguments, DeleteAssetArguments,
+    ExecuteOperationsArguments, Operation, RedirectRule, RulePattern, SetAssetContentArguments,
+    SetAssetHeadersArguments, SetRedirectRulesArguments, StartSyncResult,
     UnsetAssetContentArguments, UploadChunksArguments,
 };
 

--- a/crates/sync-core/src/canister.rs
+++ b/crates/sync-core/src/canister.rs
@@ -13,7 +13,7 @@ use serde_bytes::ByteBuf;
 use std::collections::HashMap;
 
 pub use wire_types::{
-    AssetDetails, AssetEncodingDetails, CancelSyncArguments, CreateAssetArguments,
+    AssetDetails, AssetEncodingDetails, CreateAssetArguments,
     DeleteAssetArguments, ExecuteOperationsArguments, Operation, RedirectRule, RulePattern,
     SetAssetContentArguments, SetAssetHeadersArguments, SetRedirectRulesArguments, StartSyncResult,
     UnsetAssetContentArguments, UploadChunksArguments,
@@ -117,17 +117,6 @@ pub fn execute_operations(
     args: ExecuteOperationsArguments,
 ) -> Result<(), String> {
     c.call("execute_operations", args, CallType::Update, true)
-}
-
-/// Abandons the active sync, releasing the lock. Best-effort cleanup on an
-/// aborted sync; a sync left uncancelled is reclaimed once it goes stale.
-pub fn cancel_sync(c: &impl CanisterCall, session_id: u64) -> Result<(), String> {
-    c.call(
-        "cancel_sync",
-        CancelSyncArguments { session_id },
-        CallType::Update,
-        true,
-    )
 }
 
 // Fetch the complete redirect-rule list by paging through `get_redirect_rules`,

--- a/crates/wire-types/src/lib.rs
+++ b/crates/wire-types/src/lib.rs
@@ -117,13 +117,14 @@ pub struct ExecuteOperationsArguments {
     pub is_final: bool,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, CandidType, Serialize, Deserialize)]
-pub struct CancelSyncArguments {
-    pub session_id: SessionId,
-}
-
-/// Result of `start_sync`. `Busy` is a normal, expected outcome — not an error
-/// — so the caller can surface who holds the lock and decide whether to wait.
+/// Result of `start_sync`. `Busy` is a normal, expected outcome — not an error.
+///
+/// `Busy` is returned only when a *different* caller holds an active (not yet
+/// stale) sync: a caller always reclaims their own sync immediately, and any
+/// caller reclaims one that has gone stale, so neither path ever yields `Busy`.
+/// The only recourse is therefore to wait — until the holder finishes, or its
+/// sync goes stale and a retry reclaims it. `owner` and `idle_for_secs` report
+/// who holds the lock and for how long.
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum StartSyncResult {
     Started {


### PR DESCRIPTION
## Summary

`cancel_sync` was never called by the sync plugin, and the lock semantics make it redundant:

- An **owner** reclaims their own sync via `start_sync` unconditionally (no cancel needed).
- A **stale** sync is reclaimed by any caller after the idle timeout.
- The only situation `cancel_sync` could ever act on — force-cancelling **another** user's *active* sync — is deliberately disallowed.

So a `Busy` response can never correspond to a cancellable sync, and the worst case for a blocked user is simply waiting out the idle timeout — the intended behavior.

This removes the endpoint, its `canister-core`/wire-type/plugin call wrappers, the `State::cancel_sync` method, its unit test, and the Candid declaration. The `StartSyncResult` doc is clarified to spell out exactly when `Busy` is returned and that waiting is the only recourse.

## Tests

Adds three `State`-level tests for the `start_sync` reclaim paths that were previously uncovered:

- `active_sync_idle_clock_resets_on_each_call` — staleness is measured from the last call, not from sync start, so an actively-progressing sync can't be stolen mid-flight by another principal.
- `reclaim_boundary_is_inclusive_at_the_idle_timeout` — pins the `idle >= SYNC_IDLE_TIMEOUT_NANOS` guard (Busy one ns before, reclaim at exactly the timeout).
- `busy_reports_holders_idle_seconds` — the `Busy` variant reports the holder's idle time truncated to whole seconds.

`cargo test -p canister-core` passes (83 tests); `candid_interface_compatibility` confirms the hand-maintained `.did` still matches the exported service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)