### PR TITLE
refactor: split Settings into per-field stable cells

### DIFF
--- a/crates/canister-core/src/stable_store.rs
+++ b/crates/canister-core/src/stable_store.rs
@@ -1,11 +1,15 @@
 //! Stable-memory storage types for the assets canister.
 //!
 //! These are the `Storable` representations persisted directly in stable memory
-//! via `ic-stable-structures`, replacing the old CBOR-blob `StableState`. The
-//! layout is split across three memory regions:
+//! via `ic-stable-structures`, replacing the old CBOR-blob `StableState`. Each
+//! independently-written piece of state lives in its own memory region so a
+//! write touches only that piece:
 //!
-//! - [`Settings`] — one `StableCell`: the small scalar/collection state that is
-//!   always read and written together.
+//! - [`AuthorizedSet`] / [`RedirectRules`] — one `StableCell` each. Kept apart
+//!   from the counters because they're written rarely but `redirect_rules` can
+//!   be large, and we don't want a frequent counter bump to reserialize it.
+//! - the two monotonic counters — a `StableCell<u64>` each (bumped on every
+//!   sync / content write, so they must be cheap to write).
 //! - [`AssetMeta`] — `StableBTreeMap<AssetKey, AssetMeta>`: per-asset metadata,
 //!   no content bytes.
 //! - content chunks — `StableBTreeMap<ContentChunkKey, Vec<u8>>`: raw bytes,
@@ -24,20 +28,18 @@ use serde::{Deserialize, Serialize};
 
 use crate::redirect::RedirectRule;
 
-/// Small scalar/collection state persisted as a single `StableCell`. Everything
-/// here is tiny and read/written together, so serializing it as one value is
-/// cheap — unlike asset content, which must live one entry per chunk.
+/// Principals authorized to sync (controllers are always allowed and are not
+/// stored here). Newtype so it can carry a `Storable` impl (the orphan rule
+/// forbids implementing it for the bare `BTreeSet<Principal>`).
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
-pub struct Settings {
-    /// Principals authorized to sync (controllers are always allowed and are
-    /// not stored here).
-    pub authorized: BTreeSet<Principal>,
-    pub redirect_rules: Vec<RedirectRule>,
-    /// Monotonic, never-reused sync session id allocator.
-    pub next_session_id: u64,
-    /// Monotonic, never-reused allocator for chunk groups; see [`ContentChunkKey`].
-    pub next_content_id: u64,
-}
+pub struct AuthorizedSet(pub BTreeSet<Principal>);
+
+/// The ordered redirect-rule list. Newtype for the same `Storable` reason as
+/// [`AuthorizedSet`]. Stored as one cell (not a per-rule map) because serving
+/// scans the whole list in order on every request and reads the cached value
+/// for free, and `SetRedirectRules` replaces the list wholesale.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct RedirectRules(pub Vec<RedirectRule>);
 
 /// Per-asset metadata. Content bytes live in the chunk store, grouped by each
 /// encoding's `content_id`.
@@ -134,7 +136,8 @@ macro_rules! impl_cbor_storable {
     };
 }
 
-impl_cbor_storable!(Settings);
+impl_cbor_storable!(AuthorizedSet);
+impl_cbor_storable!(RedirectRules);
 impl_cbor_storable!(AssetMeta);
 
 #[cfg(test)]
@@ -158,14 +161,15 @@ mod tests {
     }
 
     #[test]
-    fn settings_cbor_roundtrips() {
-        let s = Settings {
-            next_session_id: 7,
-            next_content_id: 42,
-            ..Default::default()
-        };
-        let restored = Settings::from_bytes(s.to_bytes());
-        assert_eq!(restored.next_session_id, 7);
-        assert_eq!(restored.next_content_id, 42);
+    fn redirect_rules_cbor_roundtrips() {
+        use crate::redirect::{RedirectRule, RulePattern};
+        let rules = RedirectRules(vec![RedirectRule {
+            from: RulePattern::Exact("/old".into()),
+            to: "/new".into(),
+            status: 301,
+            headers: vec![],
+        }]);
+        let restored = RedirectRules::from_bytes(rules.to_bytes());
+        assert_eq!(restored.0, rules.0);
     }
 }

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -26,7 +26,7 @@ use crate::http::{
     StreamingCallbackToken, StreamingStrategy,
 };
 use crate::rc_bytes::RcBytes;
-use crate::stable_store::{AssetMeta, ContentChunkKey, EncodingMeta, Settings};
+use crate::stable_store::{AssetMeta, AuthorizedSet, ContentChunkKey, EncodingMeta, RedirectRules};
 use crate::sync::{Chunk, SyncSession};
 use crate::types::*;
 use crate::url::url_decode;
@@ -48,14 +48,24 @@ pub(crate) const PAGE_SIZE: usize = 100;
 
 type Mem = VirtualMemory<DefaultMemoryImpl>;
 
-const SETTINGS_MEMORY: MemoryId = MemoryId::new(0);
-const METADATA_MEMORY: MemoryId = MemoryId::new(1);
-const CONTENT_MEMORY: MemoryId = MemoryId::new(2);
+const AUTHORIZED_MEMORY: MemoryId = MemoryId::new(0);
+const REDIRECT_RULES_MEMORY: MemoryId = MemoryId::new(1);
+const NEXT_SESSION_ID_MEMORY: MemoryId = MemoryId::new(2);
+const NEXT_CONTENT_ID_MEMORY: MemoryId = MemoryId::new(3);
+const METADATA_MEMORY: MemoryId = MemoryId::new(4);
+const CONTENT_MEMORY: MemoryId = MemoryId::new(5);
 
 pub struct State {
     // ---- durable (stable memory) ----
-    /// Small scalar/collection state read & written as one unit.
-    settings: StableCell<Settings, Mem>,
+    /// Principals authorized to sync (controllers are always allowed, unstored).
+    authorized: StableCell<AuthorizedSet, Mem>,
+    /// Ordered redirect-rule list. Its own cell so a counter bump doesn't
+    /// reserialize it (it can be large; the counters are bumped frequently).
+    redirect_rules: StableCell<RedirectRules, Mem>,
+    /// Monotonic, never-reused sync session id allocator.
+    next_session_id: StableCell<u64, Mem>,
+    /// Monotonic, never-reused chunk-group id allocator.
+    next_content_id: StableCell<u64, Mem>,
     /// Per-asset metadata, ordered by key so `get_asset_details` can page with a
     /// key cursor (a `range` seek) instead of sorting the keyspace per query.
     metadata: StableBTreeMap<AssetKey, AssetMeta, Mem>,
@@ -100,7 +110,13 @@ impl State {
     pub fn new(memory: DefaultMemoryImpl) -> Self {
         let mm = MemoryManager::init(memory);
         Self {
-            settings: StableCell::init(mm.get(SETTINGS_MEMORY), Settings::default()),
+            authorized: StableCell::init(mm.get(AUTHORIZED_MEMORY), AuthorizedSet::default()),
+            redirect_rules: StableCell::init(
+                mm.get(REDIRECT_RULES_MEMORY),
+                RedirectRules::default(),
+            ),
+            next_session_id: StableCell::init(mm.get(NEXT_SESSION_ID_MEMORY), 0),
+            next_content_id: StableCell::init(mm.get(NEXT_CONTENT_ID_MEMORY), 0),
             metadata: StableBTreeMap::init(mm.get(METADATA_MEMORY)),
             content: StableBTreeMap::init(mm.get(CONTENT_MEMORY)),
             chunks: Vec::new(),
@@ -112,23 +128,18 @@ impl State {
 
     // ---- settings accessors ----
 
-    fn update_settings(&mut self, f: impl FnOnce(&mut Settings)) {
-        let mut settings = self.settings.get().clone();
-        f(&mut settings);
-        self.settings.set(settings);
-    }
-
-    /// Allocates a fresh, never-reused content group id.
+    /// Allocates a fresh, never-reused content group id. Bumps only the
+    /// counter's own cell — no other state is reserialized.
     fn alloc_content_id(&mut self) -> u64 {
-        let id = self.settings.get().next_content_id;
-        self.update_settings(|s| s.next_content_id = id + 1);
+        let id = *self.next_content_id.get();
+        self.next_content_id.set(id + 1);
         id
     }
 
     /// Allocates a fresh, never-reused sync session id.
     pub(crate) fn alloc_session_id(&mut self) -> SessionId {
-        let id = self.settings.get().next_session_id;
-        self.update_settings(|s| s.next_session_id = id + 1);
+        let id = *self.next_session_id.get();
+        self.next_session_id.set(id + 1);
         id
     }
 
@@ -138,23 +149,23 @@ impl State {
     }
 
     pub fn authorize(&mut self, principal: Principal) {
-        self.update_settings(|s| {
-            s.authorized.insert(principal);
-        });
+        let mut authorized = self.authorized.get().clone();
+        authorized.0.insert(principal);
+        self.authorized.set(authorized);
     }
 
     pub fn deauthorize(&mut self, principal: &Principal) {
-        self.update_settings(|s| {
-            s.authorized.remove(principal);
-        });
+        let mut authorized = self.authorized.get().clone();
+        authorized.0.remove(principal);
+        self.authorized.set(authorized);
     }
 
     pub fn list_authorized(&self) -> Vec<Principal> {
-        self.settings.get().authorized.iter().copied().collect()
+        self.authorized.get().0.iter().copied().collect()
     }
 
     pub fn is_authorized(&self, principal: &Principal) -> bool {
-        self.settings.get().authorized.contains(principal)
+        self.authorized.get().0.contains(principal)
     }
 
     pub fn root_hash(&self) -> Hash {
@@ -398,9 +409,9 @@ impl State {
     /// at or after `start_index`.
     pub fn get_redirect_rules(&self, start_index: u64) -> Vec<crate::redirect::RedirectRule> {
         let start = start_index as usize;
-        self.settings
+        self.redirect_rules
             .get()
-            .redirect_rules
+            .0
             .get(start..)
             .unwrap_or_default()
             .iter()
@@ -439,8 +450,8 @@ impl State {
         }
 
         // Scan redirect rules in declaration order; first match wins.
-        let settings = self.settings.get();
-        for (idx, rule) in settings.redirect_rules.iter().enumerate() {
+        let redirect_rules = self.redirect_rules.get();
+        for (idx, rule) in redirect_rules.0.iter().enumerate() {
             if !crate::redirect::matches(rule, path) {
                 continue;
             }
@@ -710,7 +721,7 @@ impl State {
             }
         }
 
-        let rules = self.settings.get().redirect_rules.clone();
+        let rules = self.redirect_rules.get().0.clone();
         let mut new_entries: Vec<Option<crate::redirect::CertifiedRuleEntry>> =
             Vec::with_capacity(rules.len());
         for rule in &rules {
@@ -721,7 +732,7 @@ impl State {
 
     /// Replaces the redirect rules and rebuilds their certified entries.
     pub(crate) fn set_redirect_rules(&mut self, rules: Vec<crate::redirect::RedirectRule>) {
-        self.update_settings(|s| s.redirect_rules = rules);
+        self.redirect_rules.set(RedirectRules(rules));
         self.on_redirect_rules_change();
     }
 


### PR DESCRIPTION
Follow-up to #86.

The single `StableCell<Settings>` introduced there meant **every write reserialized the whole struct** — including `redirect_rules`, which can grow to hundreds/thousands of entries. That hit the hot path: `alloc_content_id` bumps a counter *once per encoding* on every deploy, and each bump reserialized the entire rule list.

## Change

Split the one `Settings` cell into **four cells**, each over its own memory region:

| Cell | Type | Written |
|---|---|---|
| `authorized` | `AuthorizedSet(BTreeSet<Principal>)` | rarely (controller ops) |
| `redirect_rules` | `RedirectRules(Vec<RedirectRule>)` | once per deploy that changes rules |
| `next_session_id` | `u64` | once per `start_sync` |
| `next_content_id` | `u64` | **once per encoding** (the hot path) |

A counter bump now serializes only its own 8-byte cell. **Reads are unaffected** — `StableCell` caches its value in the heap, so serving still scans `redirect_rules` for free (zero deserialization), and the counters are read from cache too.

`authorized`/`redirect_rules` are thin newtypes so they can carry the `serde_cbor` `Storable` impl (the orphan rule forbids implementing it on the bare `BTreeSet`/`Vec`); the counters use the built-in `u64` `Storable`. `update_settings` is gone.

`redirect_rules` stays a single `Cell<Vec>` rather than a per-rule map on purpose: serving scans the whole ordered list (first-match-wins) and `SetRedirectRules` replaces it wholesale, so a map would force a per-rule `from_bytes` on every request and lose the free-read property.

## ⚠️ Layout change → reinstall

New memory ids, so — like #86 — the first deploy of this change must be a **reinstall**, not an upgrade. Still pre-launch, no prod instances.

## Testing

- `cargo test -p canister-core` — 85 pass (incl. upgrade-roundtrip over the new cell layout)
- `cargo test -p canister` — candid compat unchanged
- `cargo build -p canister --target wasm32-unknown-unknown`
- `cargo test -p e2e` — 16 pass, incl. `assets_persist_across_canister_upgrade`
- clippy + fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)