### PR TITLE
feat: plugin-side 404 convention + certified canister fallback floor

### DIFF
--- a/crates/canister-core/src/certification.rs
+++ b/crates/canister-core/src/certification.rs
@@ -112,6 +112,10 @@ impl AssetPath {
         hash_path.push(NestedTreeKey::Hash(response_hash));
         HashTreePath(hash_path)
     }
+
+    pub fn fallback_path() -> Self {
+        Self(vec!["http_expr".into(), "<*>".into()])
+    }
 }
 
 /// AssetPath that is ready to be inserted into asset_hashes.
@@ -386,6 +390,39 @@ impl CertifiedResponses {
             .collect()
     }
 
+    /// Certifies a response that can be used if no certified response is available for the requested path.
+    ///
+    /// # Arguments
+    /// * `status_code`: HTTP status code of the response
+    /// * `headers`: All certified headers. It is possible to respond with additional headers, but only the ones supplied in this argument are certified
+    /// * `body`: Response body. Ignored if `body_hash.is_some()`
+    /// * `body_hash`: Hash of the response body. If supplied the response body will not be hashed, which can save a lot of computation
+    ///
+    /// # Return Value
+    /// * `HashTreePath`: `HashTreePath` corresponding to the supplied response. Can be used to remove or re-insert certification for this specific response without having to re-compute the full path
+    pub fn certify_fallback_response(
+        &mut self,
+        status_code: u16,
+        headers: &[(String, Value)],
+        body: &[u8],
+        body_hash: Option<[u8; 32]>,
+    ) -> HashTreePath {
+        let certificate_expression = build_ic_certificate_expression_from_headers(headers);
+        let cert_expr_header = build_ic_certificate_expression_header(&certificate_expression);
+        let cert_expr_header = (cert_expr_header.0, Value::String(cert_expr_header.1));
+        let mut certified_headers = Vec::from(headers);
+        certified_headers.push(cert_expr_header);
+        let request_hash = RequestHash::default(); // request certification currently not supported
+        let body_hash = body_hash.unwrap_or_else(|| sha2::Sha256::digest(body).into());
+        let response_hash = response_hash(&certified_headers, status_code, &body_hash);
+
+        let asset_path = AssetPath::fallback_path();
+        let hash_tree_path =
+            asset_path.hash_tree_path(&certificate_expression, &request_hash, response_hash);
+        self.certify_response_precomputed(&hash_tree_path);
+        hash_tree_path
+    }
+
     /// Certifies a response. Expects a finished `HashTreePath`, skipping the (sometimes expensive) computation of the `HashTreePath`.
     pub fn certify_response_precomputed(&mut self, path: &HashTreePath) {
         self.insert(path.as_vec(), Vec::new());
@@ -395,6 +432,16 @@ impl CertifiedResponses {
     pub fn remove_responses_for_path(&mut self, path: &str) {
         let key = AssetPath::from(path);
         self.delete(key.asset_hash_path_root().as_vec());
+    }
+
+    /// True if a fallback (`<*>`) response is currently certified.
+    pub fn has_fallback_response(&self) -> bool {
+        self.contains_path(HashTreePath::not_found_base_path().as_vec())
+    }
+
+    /// Removes all certified fallback responses.
+    pub fn remove_fallback_responses(&mut self) {
+        self.delete(HashTreePath::not_found_base_path().as_vec());
     }
 
     /// Removes a specific response from the certified responses. Expects a finished `HashTreePath`, skipping the (sometimes expensive) computation of the `HashTreePath`.

--- a/crates/canister-core/src/certification.rs
+++ b/crates/canister-core/src/certification.rs
@@ -112,10 +112,6 @@ impl AssetPath {
         hash_path.push(NestedTreeKey::Hash(response_hash));
         HashTreePath(hash_path)
     }
-
-    pub fn fallback_path() -> Self {
-        Self(vec!["http_expr".into(), "<*>".into()])
-    }
 }
 
 /// AssetPath that is ready to be inserted into asset_hashes.
@@ -390,39 +386,6 @@ impl CertifiedResponses {
             .collect()
     }
 
-    /// Certifies a response that can be used if no certified response is available for the requested path.
-    ///
-    /// # Arguments
-    /// * `status_code`: HTTP status code of the response
-    /// * `headers`: All certified headers. It is possible to respond with additional headers, but only the ones supplied in this argument are certified
-    /// * `body`: Response body. Ignored if `body_hash.is_some()`
-    /// * `body_hash`: Hash of the response body. If supplied the response body will not be hashed, which can save a lot of computation
-    ///
-    /// # Return Value
-    /// * `HashTreePath`: `HashTreePath` corresponding to the supplied response. Can be used to remove or re-insert certification for this specific response without having to re-compute the full path
-    pub fn certify_fallback_response(
-        &mut self,
-        status_code: u16,
-        headers: &[(String, Value)],
-        body: &[u8],
-        body_hash: Option<[u8; 32]>,
-    ) -> HashTreePath {
-        let certificate_expression = build_ic_certificate_expression_from_headers(headers);
-        let cert_expr_header = build_ic_certificate_expression_header(&certificate_expression);
-        let cert_expr_header = (cert_expr_header.0, Value::String(cert_expr_header.1));
-        let mut certified_headers = Vec::from(headers);
-        certified_headers.push(cert_expr_header);
-        let request_hash = RequestHash::default(); // request certification currently not supported
-        let body_hash = body_hash.unwrap_or_else(|| sha2::Sha256::digest(body).into());
-        let response_hash = response_hash(&certified_headers, status_code, &body_hash);
-
-        let asset_path = AssetPath::fallback_path();
-        let hash_tree_path =
-            asset_path.hash_tree_path(&certificate_expression, &request_hash, response_hash);
-        self.certify_response_precomputed(&hash_tree_path);
-        hash_tree_path
-    }
-
     /// Certifies a response. Expects a finished `HashTreePath`, skipping the (sometimes expensive) computation of the `HashTreePath`.
     pub fn certify_response_precomputed(&mut self, path: &HashTreePath) {
         self.insert(path.as_vec(), Vec::new());
@@ -432,11 +395,6 @@ impl CertifiedResponses {
     pub fn remove_responses_for_path(&mut self, path: &str) {
         let key = AssetPath::from(path);
         self.delete(key.asset_hash_path_root().as_vec());
-    }
-
-    /// Removes all certified fallback responses.
-    pub fn remove_fallback_responses(&mut self) {
-        self.delete(HashTreePath::not_found_base_path().as_vec());
     }
 
     /// Removes a specific response from the certified responses. Expects a finished `HashTreePath`, skipping the (sometimes expensive) computation of the `HashTreePath`.

--- a/crates/canister-core/src/http.rs
+++ b/crates/canister-core/src/http.rs
@@ -79,16 +79,6 @@ impl HttpRequest {
 }
 
 impl HttpResponse {
-    pub fn build_400(err_msg: &str) -> Self {
-        HttpResponse {
-            status_code: 400,
-            headers: vec![],
-            body: RcBytes::from(ByteBuf::from(err_msg)),
-            upgrade: None,
-            streaming_strategy: None,
-        }
-    }
-
     pub fn build_404(certificate_header: HeaderField) -> HttpResponse {
         let base_404 = Self::uncertified_404();
         let mut headers = base_404.headers.clone();

--- a/crates/canister-core/src/redirect.rs
+++ b/crates/canister-core/src/redirect.rs
@@ -209,9 +209,8 @@ pub(crate) fn build_synthetic_entry(rule: &RedirectRule) -> CertifiedRuleEntry {
 
     let expression = build_ic_certificate_expression_from_headers(&header_values);
 
-    // Mirror `certify_fallback_response`: the synthesized
-    // `ic-certificateexpression` header is itself part of the certified
-    // response.
+    // The synthesized `ic-certificateexpression` header is itself part of the
+    // certified response, so fold it into the hashed headers.
     let cert_expr_header = build_ic_certificate_expression_header(&expression);
     let mut certified = header_values.clone();
     certified.push((cert_expr_header.0, Value::String(cert_expr_header.1)));

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -811,9 +811,9 @@ impl State {
     // ---- upgrade ----
 
     /// Rebuilds all derived heap state from the durable stable-memory state
-    /// after an upgrade: the certified-response tree for every asset, the
-    /// redirect-rule certified entries, and the built-in 404 fallback. The
-    /// caller publishes `certified_data` afterwards.
+    /// after an upgrade: the certified-response tree for every asset and the
+    /// redirect-rule certified entries. The caller publishes `certified_data`
+    /// afterwards.
     pub fn post_upgrade_rebuild(&mut self) {
         let keys: Vec<AssetKey> = self.metadata.keys().collect();
         for key in keys {
@@ -822,6 +822,5 @@ impl State {
             }
         }
         self.on_redirect_rules_change();
-        self.certify_404_if_required();
     }
 }

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -655,6 +655,13 @@ impl State {
 
         match url_decode(path) {
             Ok(path) => self.build_http_response(certificate, &path, encodings, 0, callback, etags),
+            // Malformed percent-encoding (invalid UTF-8 once decoded). This 400
+            // is intentionally uncertified: the body is per-request (it echoes
+            // the bad path), so it can't be pinned to a certified hash, and a
+            // malformed URL has no certifiable response anyway. The HTTP gateway
+            // rejects uncertified responses, so a browser never sees this body —
+            // it surfaces only to a direct query call of `http_request` (e.g.
+            // `dfx canister call`), where it serves as a diagnostic.
             Err(err) => HttpResponse {
                 status_code: 400,
                 headers: vec![],

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -714,12 +714,23 @@ impl State {
     /// Status-200 rules borrow each encoding's certificate expression and
     /// response hash from the target asset, so this also has to run after any
     /// asset change that could affect those values.
+    ///
+    /// This is also the single owner of the root `<*>` fallback slot: a root
+    /// `/*` rule and the built-in 404 are mutually exclusive occupants of it, so
+    /// after rebuilding the rules we (re)certify the built-in 404 exactly when
+    /// no active rule claims `<*>`. That keeps `build_http_response`'s
+    /// fallthrough certified — the gateway rejects uncertified responses, so an
+    /// uncertified fallback 404 would be unservable.
     pub(crate) fn on_redirect_rules_change(&mut self) {
         for entry in self.rule_certified_entries.drain(..).flatten() {
             for tp in &entry.tree_paths {
                 self.asset_hashes.remove_response_precomputed(tp);
             }
         }
+        // Drop any built-in 404 before rebuilding so a rule taking over `<*>`
+        // doesn't leave a stale fallback hash beside it (and removing it now is
+        // safe — we re-add below if `<*>` ends up rule-free).
+        self.asset_hashes.remove_fallback_responses();
 
         let rules = self.redirect_rules.get().0.clone();
         let mut new_entries: Vec<Option<crate::redirect::CertifiedRuleEntry>> =
@@ -728,6 +739,28 @@ impl State {
             new_entries.push(self.build_rule_entry(rule));
         }
         self.rule_certified_entries = new_entries;
+
+        if !self.asset_hashes.has_fallback_response() {
+            self.certify_not_found_fallback();
+        }
+    }
+
+    /// Certifies the canister's built-in last-resort 404 ("not found") at the
+    /// root `<*>` fallback path. Callers must ensure `<*>` is otherwise free;
+    /// `on_redirect_rules_change` is the only caller and gates on that.
+    fn certify_not_found_fallback(&mut self) {
+        let response = HttpResponse::uncertified_404();
+        let headers: Vec<_> = response
+            .headers
+            .into_iter()
+            .map(|(k, v)| (k, Value::String(v)))
+            .collect();
+        self.asset_hashes.certify_fallback_response(
+            response.status_code,
+            &headers,
+            &response.body,
+            None,
+        );
     }
 
     /// Replaces the redirect rules and rebuilds their certified entries.
@@ -811,8 +844,9 @@ impl State {
     // ---- upgrade ----
 
     /// Rebuilds all derived heap state from the durable stable-memory state
-    /// after an upgrade: the certified-response tree for every asset and the
-    /// redirect-rule certified entries. The caller publishes `certified_data`
+    /// after an upgrade: the certified-response tree for every asset, the
+    /// redirect-rule certified entries, and the built-in 404 fallback (the last
+    /// two via `on_redirect_rules_change`). The caller publishes `certified_data`
     /// afterwards.
     pub fn post_upgrade_rebuild(&mut self) {
         let keys: Vec<AssetKey> = self.metadata.keys().collect();

--- a/crates/canister-core/src/sync.rs
+++ b/crates/canister-core/src/sync.rs
@@ -10,8 +10,6 @@
 //! helpers they rely on. State methods unrelated to syncing stay in the
 //! state machine module.
 
-use crate::certification::HashTreePath;
-use crate::http::HttpResponse;
 use crate::rc_bytes::RcBytes;
 use crate::redirect;
 use crate::state::State;
@@ -21,7 +19,6 @@ use crate::types::{
     UploadChunksArguments,
 };
 use candid::Principal;
-use ic_representation_independent_hash::Value;
 use sha2::Digest;
 
 /// How long a sync may sit idle (no calls carrying its session id) before a
@@ -192,7 +189,6 @@ impl State {
                         self.sync_session = None;
                         self.chunks.clear();
                     }
-                    self.certify_404_if_required();
                     // Asset ops in this call may have clobbered tree entries
                     // that redirect rules own (any rule whose source path
                     // collides with an asset's `<$>` slot). Re-cert them so
@@ -308,26 +304,6 @@ impl State {
                     ComputationStatus::InProgress(progress)
                 }
             }
-        }
-    }
-
-    pub(crate) fn certify_404_if_required(&mut self) {
-        if !self
-            .asset_hashes
-            .contains_path(HashTreePath::not_found_base_path().as_vec())
-        {
-            let response = HttpResponse::uncertified_404();
-            let headers: Vec<_> = response
-                .headers
-                .into_iter()
-                .map(|(k, v)| (k, Value::String(v)))
-                .collect();
-            self.asset_hashes.certify_fallback_response(
-                response.status_code,
-                &headers,
-                &response.body,
-                None,
-            );
         }
     }
 }

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -404,19 +404,18 @@ fn serve_correct_encoding() {
     assert_eq!(gzip_response.body.as_ref(), GZIP_BODY);
     assert!(lookup_header(&gzip_response, "IC-Certificate").is_some());
 
-    // An asset with no encodings has nothing to serve → plain 404. With no
-    // catch-all rule covering the path this 404 is uncertified, so request it
-    // directly rather than through the certifying helper.
-    let no_encoding_response = state.http_request(
+    // An asset with no encodings has nothing to serve → the built-in certified
+    // 404 (no rule occupies `<*>`, so the fallback is certified there).
+    let no_encoding_response = certified_http_request(
+        &state,
         RequestBuilder::get("/no-encoding.html")
             .with_header("Accept-Encoding", "identity")
             .with_certificate_version(2)
             .build(),
-        &[],
-        unused_callback(),
     );
     assert_eq!(no_encoding_response.status_code, 404);
     assert_eq!(no_encoding_response.body.as_ref(), "not found".as_bytes());
+    assert!(lookup_header(&no_encoding_response, "IC-Certificate").is_some());
 }
 
 #[test]
@@ -2294,11 +2293,11 @@ mod redirect_rules {
     }
 
     #[test]
-    fn no_rules_returns_uncertified_404() {
-        // No `_redirects` rules at all: missing paths return a plain 404
-        // ("not found" body). The canister no longer certifies a built-in
-        // fallback, so to get a *certified* 404 a user adds a catch-all rule
-        // (`/* /404.html 404`); without one the 404 is served uncertified.
+    fn no_rules_falls_through_to_builtin_404() {
+        // No `_redirects` rules at all: missing paths return the canister's
+        // built-in *certified* 404 ("not found" body). With no rule occupying
+        // the `<*>` slot, `on_redirect_rules_change` certifies the fallback
+        // there, so the response verifies (via `certified_http_request`).
         let mut state = State::default();
         let system_context = mock_system_context();
         const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
@@ -2310,17 +2309,49 @@ mod redirect_rules {
             ],
         );
 
-        let response =
-            state.http_request(RequestBuilder::get("/missing").build(), &[], unused_callback());
+        let response = certified_http_request(&state, RequestBuilder::get("/missing").build());
         assert_eq!(response.status_code, 404);
         assert_eq!(response.body.as_ref(), b"not found");
-        // The response advertises the `<*>` fallback expr_path, but nothing is
-        // certified there anymore, so the verifier rejects it: an uncertified
-        // 404 cannot pass verification.
-        assert!(
-            verify_response(&state, &RequestBuilder::get("/missing").build(), &response).is_err(),
-            "404 with no catch-all rule must not be certifiable"
+    }
+
+    #[test]
+    fn builtin_404_yields_to_root_rule_then_returns_when_removed() {
+        // The built-in 404 and a root `/*` rule are mutually exclusive
+        // occupants of `<*>`. Adding a root rule must hand the slot to the
+        // rule; removing it must restore the *certified* built-in 404. Both
+        // directions verify, which guards the rebuild ordering in
+        // `on_redirect_rules_change`.
+        let mut state = State::default();
+        let system_context = mock_system_context();
+        const INDEX: &[u8] = b"<!DOCTYPE html><html>spa</html>";
+        create_assets(
+            &mut state,
+            &system_context,
+            vec![AssetBuilder::new("/index.html", "text/html")
+                .with_encoding("identity", vec![INDEX])],
         );
+
+        // No rule → certified built-in 404 on a missing path.
+        let before = certified_http_request(&state, RequestBuilder::get("/missing").build());
+        assert_eq!(before.status_code, 404);
+        assert_eq!(before.body.as_ref(), b"not found");
+
+        // Root `/*` 200 rule takes over `<*>` → the missing path serves the SPA
+        // index (certified), not the built-in 404.
+        set_root_spa_rule(&mut state, "/index.html");
+        let via_rule = certified_http_request(&state, RequestBuilder::get("/missing").build());
+        assert_eq!(via_rule.status_code, 200);
+        assert_eq!(via_rule.body.as_ref(), INDEX);
+
+        // Remove all rules → the certified built-in 404 returns.
+        commit(
+            &mut state,
+            vec![Operation::SetRedirectRules(SetRedirectRulesArguments { rules: vec![] })],
+        )
+        .unwrap();
+        let after = certified_http_request(&state, RequestBuilder::get("/missing").build());
+        assert_eq!(after.status_code, 404);
+        assert_eq!(after.body.as_ref(), b"not found");
     }
 
     #[test]

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -2346,7 +2346,9 @@ mod redirect_rules {
         // Remove all rules → the certified built-in 404 returns.
         commit(
             &mut state,
-            vec![Operation::SetRedirectRules(SetRedirectRulesArguments { rules: vec![] })],
+            vec![Operation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: vec![],
+            })],
         )
         .unwrap();
         let after = certified_http_request(&state, RequestBuilder::get("/missing").build());

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -404,16 +404,19 @@ fn serve_correct_encoding() {
     assert_eq!(gzip_response.body.as_ref(), GZIP_BODY);
     assert!(lookup_header(&gzip_response, "IC-Certificate").is_some());
 
-    let no_encoding_response = certified_http_request(
-        &state,
+    // An asset with no encodings has nothing to serve → plain 404. With no
+    // catch-all rule covering the path this 404 is uncertified, so request it
+    // directly rather than through the certifying helper.
+    let no_encoding_response = state.http_request(
         RequestBuilder::get("/no-encoding.html")
             .with_header("Accept-Encoding", "identity")
             .with_certificate_version(2)
             .build(),
+        &[],
+        unused_callback(),
     );
     assert_eq!(no_encoding_response.status_code, 404);
     assert_eq!(no_encoding_response.body.as_ref(), "not found".as_bytes());
-    assert!(lookup_header(&no_encoding_response, "IC-Certificate").is_some());
 }
 
 #[test]
@@ -2291,9 +2294,11 @@ mod redirect_rules {
     }
 
     #[test]
-    fn no_rules_falls_through_to_builtin_404() {
-        // No `_redirects` rules at all: missing paths return the canister's
-        // built-in certified 404 ("not found" body).
+    fn no_rules_returns_uncertified_404() {
+        // No `_redirects` rules at all: missing paths return a plain 404
+        // ("not found" body). The canister no longer certifies a built-in
+        // fallback, so to get a *certified* 404 a user adds a catch-all rule
+        // (`/* /404.html 404`); without one the 404 is served uncertified.
         let mut state = State::default();
         let system_context = mock_system_context();
         const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
@@ -2305,9 +2310,17 @@ mod redirect_rules {
             ],
         );
 
-        let response = certified_http_request(&state, RequestBuilder::get("/missing").build());
+        let response =
+            state.http_request(RequestBuilder::get("/missing").build(), &[], unused_callback());
         assert_eq!(response.status_code, 404);
         assert_eq!(response.body.as_ref(), b"not found");
+        // The response advertises the `<*>` fallback expr_path, but nothing is
+        // certified there anymore, so the verifier rejects it: an uncertified
+        // 404 cannot pass verification.
+        assert!(
+            verify_response(&state, &RequestBuilder::get("/missing").build(), &response).is_err(),
+            "404 with no catch-all rule must not be certifiable"
+        );
     }
 
     #[test]

--- a/crates/e2e/tests/redirects.rs
+++ b/crates/e2e/tests/redirects.rs
@@ -266,6 +266,45 @@ fn html_handling_with_catchall_redirect() {
     );
 }
 
+/// A project that ships no `404.html` and declares no `/*` rule still gets a
+/// *certified* 404 for unknown paths: the sync plugin injects a branded default
+/// `/404.html` asset plus a `/* /404.html 404` catch-all (see
+/// `sync-core::not_found`). The subdomain-style URL forces full v2 verification
+/// at the gateway, so a returned 404 body — rather than a 503 verification
+/// error — is proof the injected fallback is certified.
+#[test]
+fn branded_404_injected_when_project_ships_none() {
+    // The `basic` fixture is just index.html + style.css: no 404.html, no
+    // _redirects.
+    let tmp = setup_project("tests/fixture/basic");
+    let project = tmp.path();
+    let _network = LocalNetwork::start(project);
+    icp_cmd(project).arg("deploy").assert().success();
+
+    // Unknown path → certified branded 404.
+    let r = http_fetch_subdomain(project, "/no/such/page");
+    assert_eq!(
+        r.status(),
+        StatusCode::NOT_FOUND,
+        "unknown path expected a certified 404 (a 503 here means it wasn't certified), got {}",
+        r.status()
+    );
+    let body = r.text().expect("read body");
+    assert!(
+        body.contains("default page served by the assets canister"),
+        "expected the branded default 404 body, got: {body}"
+    );
+
+    // The injected page is a real asset, directly fetchable at /404.html (200).
+    let r = http_fetch_subdomain(project, "/404.html");
+    assert_eq!(
+        r.status(),
+        StatusCode::OK,
+        "/404.html should serve 200, got {}",
+        r.status()
+    );
+}
+
 fn expect_307(project: &std::path::Path, path: &str, location: &str) {
     let r = http_fetch(project, path);
     assert_eq!(

--- a/crates/sync-core/src/lib.rs
+++ b/crates/sync-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod content;
 pub mod glob;
 pub mod headers;
 pub mod html_handling;
+pub mod not_found;
 pub mod redirects;
 pub mod scan;
 pub mod sync;

--- a/crates/sync-core/src/not_found.rs
+++ b/crates/sync-core/src/not_found.rs
@@ -1,0 +1,218 @@
+//! Plugin-side "always certified 404" convention (root-only).
+//!
+//! The canister has no built-in 404 fallback: an HTTP request for a path with
+//! no matching asset and no matching redirect rule produces an *uncertified*
+//! response, which the HTTP gateway rejects. To guarantee that every request
+//! resolves to a certified response, the plugin ensures the root wildcard
+//! (`/*`) is always backed by a real `404.html` asset plus a redirect rule.
+//!
+//! Mirrors Netlify's `404.html` convention, entirely plugin-side — the canister
+//! stays a dumb "assets + rules" store:
+//!
+//! - If the project ships a root `/404.html`, append `/* /404.html 404` so it
+//!   serves as the site-wide not-found page.
+//! - If it does not — and the user has not declared their own root `/*` rule
+//!   (e.g. a SPA `/* /index.html 200`) — inject a branded default `/404.html`
+//!   asset and append the same catch-all rule.
+//! - If the user already declares a root `/*` rule, leave everything alone:
+//!   their rule covers the whole path space, so the certified-response
+//!   guarantee already holds (and a SPA's `/* … 200` must win, not a 404).
+//!
+//! The catch-all is appended **after** the user's `_redirects` so explicit user
+//! rules (and the prepended html-handling rules) win first; it only fires for
+//! paths nothing else claims.
+
+use crate::canister::{RedirectRule, RulePattern};
+
+/// Asset key for the site-wide not-found page.
+pub const ROOT_404_KEY: &str = "/404.html";
+
+/// Default not-found page injected when a project ships no root `404.html`.
+/// Self-contained (no external assets) so it renders even when nothing else
+/// on the site resolves.
+pub const DEFAULT_404_HTML: &str = r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>404 — Not Found</title>
+<style>
+  :root { color-scheme: light dark; }
+  html, body { height: 100%; margin: 0; }
+  body {
+    display: flex; align-items: center; justify-content: center;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    background: Canvas; color: CanvasText;
+  }
+  main { text-align: center; padding: 2rem; max-width: 32rem; }
+  h1 { font-size: 4rem; margin: 0; font-weight: 700; letter-spacing: -0.05em; }
+  p { margin: 0.5rem 0 0; font-size: 1.1rem; opacity: 0.8; }
+  .hint { margin-top: 1.5rem; font-size: 0.85rem; opacity: 0.55; }
+  code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+</style>
+</head>
+<body>
+<main>
+  <h1>404</h1>
+  <p>The page you requested could not be found.</p>
+  <p class="hint">This is the default page served by the assets canister. Add a <code>404.html</code> to your project to customize it.</p>
+</main>
+</body>
+</html>
+"#;
+
+/// True if `rules` already contain a root-wildcard (`/*`) rule. Such a rule
+/// matches the entire path space, so it already covers the root `<*>` slot and
+/// makes a synthesized catch-all redundant (and, for a SPA `/* … 200`, the
+/// user's rule must be the one that wins).
+pub fn has_root_catchall(rules: &[RedirectRule]) -> bool {
+    rules
+        .iter()
+        .any(|r| matches!(&r.from, RulePattern::Subtree(p) if p == "/"))
+}
+
+/// What the root-only 404 convention should do for a given project.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Plan {
+    /// Upload a branded default `/404.html` asset (the project ships none).
+    pub inject_branded_asset: bool,
+    /// Append the `/* /404.html 404` catch-all rule.
+    pub append_catchall: bool,
+}
+
+/// Decide the 404 actions from the scanned asset keys and the user's parsed
+/// `_redirects` rules:
+///
+/// - User already declares a root `/*` rule → do nothing (their rule covers the
+///   whole path space and must win).
+/// - Otherwise append the catch-all, and inject the branded `/404.html` unless
+///   the project already ships a root `404.html`.
+pub fn plan(asset_keys: &[String], user_rules: &[RedirectRule]) -> Plan {
+    if has_root_catchall(user_rules) {
+        return Plan {
+            inject_branded_asset: false,
+            append_catchall: false,
+        };
+    }
+    let ships_root_404 = asset_keys.iter().any(|k| k == ROOT_404_KEY);
+    Plan {
+        inject_branded_asset: !ships_root_404,
+        append_catchall: true,
+    }
+}
+
+/// The catch-all rule mapping every otherwise-unmatched path to the root
+/// not-found page with a 404 status.
+pub fn catchall_rule() -> RedirectRule {
+    RedirectRule {
+        from: RulePattern::Subtree("/".to_string()),
+        to: ROOT_404_KEY.to_string(),
+        status: 404,
+        headers: vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::redirects;
+
+    #[test]
+    fn catchall_rule_targets_root_404() {
+        let r = catchall_rule();
+        assert_eq!(r.from, RulePattern::Subtree("/".to_string()));
+        assert_eq!(r.to, ROOT_404_KEY);
+        assert_eq!(r.status, 404);
+        assert!(r.headers.is_empty());
+    }
+
+    #[test]
+    fn has_root_catchall_detects_user_root_wildcard() {
+        // `/*` parses to a root subtree, regardless of the target/status.
+        let spa = redirects::parse("/* /index.html 200\n").unwrap();
+        assert!(has_root_catchall(&spa));
+        let custom_404 = redirects::parse("/* /404.html 404\n").unwrap();
+        assert!(has_root_catchall(&custom_404));
+    }
+
+    #[test]
+    fn has_root_catchall_ignores_non_root_rules() {
+        // A nested subtree and exact rules do not cover the whole path space.
+        let nested = redirects::parse("/blog/* /blog/index.html 200\n").unwrap();
+        assert!(!has_root_catchall(&nested));
+        let exact = redirects::parse("/old /new 301\n").unwrap();
+        assert!(!has_root_catchall(&exact));
+        assert!(!has_root_catchall(&[]));
+    }
+
+    fn keys(ks: &[&str]) -> Vec<String> {
+        ks.iter().map(|k| k.to_string()).collect()
+    }
+
+    #[test]
+    fn plan_injects_and_appends_when_no_404_and_no_catchall() {
+        // Bare project: must both inject the branded page and append the rule.
+        let p = plan(&keys(&["/index.html"]), &[]);
+        assert_eq!(
+            p,
+            Plan {
+                inject_branded_asset: true,
+                append_catchall: true
+            }
+        );
+    }
+
+    #[test]
+    fn plan_appends_only_when_project_ships_root_404() {
+        // A user-supplied root 404.html is wired up by the catch-all, but we
+        // must not overwrite it with the branded default.
+        let p = plan(&keys(&["/index.html", ROOT_404_KEY]), &[]);
+        assert_eq!(
+            p,
+            Plan {
+                inject_branded_asset: false,
+                append_catchall: true
+            }
+        );
+    }
+
+    #[test]
+    fn plan_does_nothing_when_user_declares_root_catchall() {
+        // A SPA `/* … 200` (or the user's own `/* … 404`) already covers the
+        // whole path space — leave it untouched, even with no 404.html.
+        let spa = redirects::parse("/* /index.html 200\n").unwrap();
+        let p = plan(&keys(&["/index.html"]), &spa);
+        assert_eq!(
+            p,
+            Plan {
+                inject_branded_asset: false,
+                append_catchall: false
+            }
+        );
+    }
+
+    #[test]
+    fn plan_ignores_a_nested_404_for_root_coverage() {
+        // A `404.html` in a subdirectory does not cover the root, so the root
+        // path still needs the branded default + catch-all.
+        let p = plan(&keys(&["/blog/404.html"]), &[]);
+        assert_eq!(
+            p,
+            Plan {
+                inject_branded_asset: true,
+                append_catchall: true
+            }
+        );
+    }
+
+    #[test]
+    fn catchall_rule_passes_redirect_parser_shape() {
+        // The synthesized rule must be a shape the canister accepts: a root
+        // subtree (`/`, trailing slash) with an absolute 4xx target. Confirm
+        // it matches what the parser produces for the equivalent `_redirects`
+        // line, so the canister validates it identically.
+        let parsed = redirects::parse("/* /404.html 404\n").unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0], catchall_rule());
+    }
+}

--- a/crates/sync-core/src/sync.rs
+++ b/crates/sync-core/src/sync.rs
@@ -1574,7 +1574,8 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("_redirects"), b"/old /new 301\n").unwrap();
 
-        let mut canister_rules = crate::html_handling::synthesize(&[not_found::ROOT_404_KEY.into()]);
+        let mut canister_rules =
+            crate::html_handling::synthesize(&[not_found::ROOT_404_KEY.into()]);
         canister_rules.push(mk_rule(
             crate::canister::RulePattern::Exact("/old".into()),
             "/new",
@@ -2228,7 +2229,8 @@ mod tests {
         // /404.html (which the `/*` _headers rule also covers) plus its
         // html-handling rules and the `/*` catch-all; the canister must already
         // hold all of it for the short-circuit to fire.
-        let header_rules = crate::headers::parse(std::str::from_utf8(headers_file).unwrap()).unwrap();
+        let header_rules =
+            crate::headers::parse(std::str::from_utf8(headers_file).unwrap()).unwrap();
         let mut synth = crate::html_handling::synthesize(&[not_found::ROOT_404_KEY.into()]);
         synth.push(not_found::catchall_rule());
         // The canister stores rules with `_headers` resolved into 3xx rules, so

--- a/crates/sync-core/src/sync.rs
+++ b/crates/sync-core/src/sync.rs
@@ -19,9 +19,10 @@ use crate::canister::{
 use crate::content::{encoders_for, Content, Encoder};
 use crate::headers::{self, HeaderRule, HEADERS_FILENAME};
 use crate::html_handling;
+use crate::not_found;
 use crate::redirects::{self, REDIRECTS_FILENAME};
 use crate::scan::AssetSource;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 // Stay safely under the canister's ingress message limit (~2 MB).
 const MAX_CHUNK_SIZE: usize = 1_900_000;
@@ -151,7 +152,21 @@ pub fn sync<C: CanisterCall>(
         user_rules.len()
     );
 
-    let asset_keys: Vec<String> = sources.iter().map(|s| s.key.clone()).collect();
+    let mut asset_keys: Vec<String> = sources.iter().map(|s| s.key.clone()).collect();
+
+    // 404 fallback convention (root-only). The canister has no built-in 404, so
+    // guarantee the root `<*>` slot is always backed by a real rule: append a
+    // `/* /404.html 404` catch-all, injecting a branded default `/404.html`
+    // asset when the project ships none. Skipped entirely when the user already
+    // declares a root `/*` rule (their rule — e.g. a SPA `/* … 200` — covers
+    // the whole path space and must win). See `not_found`.
+    let not_found_plan = not_found::plan(&asset_keys, &user_rules);
+    if not_found_plan.inject_branded_asset {
+        // Add the key before html-handling synthesis so the branded page picks
+        // up the same `/404` clean-URL rules a user-supplied `404.html` would.
+        asset_keys.push(not_found::ROOT_404_KEY.to_string());
+    }
+
     let synthesised = html_handling::synthesize(&asset_keys);
     if !synthesised.is_empty() {
         println!(
@@ -162,6 +177,16 @@ pub fn sync<C: CanisterCall>(
     }
     let mut project_rules = synthesised;
     project_rules.extend(user_rules);
+    if not_found_plan.append_catchall {
+        if not_found_plan.inject_branded_asset {
+            println!(
+                "no root {} found — injecting a default certified 404 page",
+                not_found::ROOT_404_KEY
+            );
+        }
+        // Lowest priority: only fires for paths no asset or earlier rule claims.
+        project_rules.push(not_found::catchall_rule());
+    }
 
     let project_header_rules = load_header_rules(dir)?;
     println!(
@@ -182,6 +207,10 @@ pub fn sync<C: CanisterCall>(
     let mut project_assets: HashMap<String, ProjectAsset> = HashMap::new();
     for source in sources {
         let asset = prepare_asset(source, &project_header_rules, &canister_assets)?;
+        project_assets.insert(asset.source.key.clone(), asset);
+    }
+    if not_found_plan.inject_branded_asset {
+        let asset = prepare_branded_404(&canister_assets)?;
         project_assets.insert(asset.source.key.clone(), asset);
     }
 
@@ -238,6 +267,39 @@ fn prepare_asset(
     if let Some(override_mime) = headers::content_type_for(&source.key, header_rules) {
         content.media_type = override_mime;
     }
+    prepare_content_asset(source, content, canister_assets)
+}
+
+/// Builds the in-memory branded `/404.html` asset injected when a project ships
+/// no root `404.html` (see `not_found`). Treated like any other HTML asset —
+/// it gets the same encoders and html-handling rules — but its bytes come from
+/// a constant instead of disk, and `_headers` content-type overrides are not
+/// applied (the default page is always `text/html`).
+fn prepare_branded_404(
+    canister_assets: &HashMap<String, AssetDetails>,
+) -> Result<ProjectAsset, String> {
+    let source = AssetSource {
+        // Never read from disk — content is supplied inline below. Kept only so
+        // the key flows through the normal asset path; not used for I/O.
+        path: PathBuf::from(not_found::ROOT_404_KEY),
+        key: not_found::ROOT_404_KEY.to_string(),
+    };
+    let content = Content {
+        data: not_found::DEFAULT_404_HTML.as_bytes().to_vec(),
+        media_type: mime_guess::from_path(not_found::ROOT_404_KEY)
+            .first()
+            .unwrap_or(mime::TEXT_HTML),
+    };
+    prepare_content_asset(source, content, canister_assets)
+}
+
+/// Shared tail of `prepare_asset`: pick encoders for `content`, encode each,
+/// and record which encodings the canister already holds.
+fn prepare_content_asset(
+    source: AssetSource,
+    content: Content,
+    canister_assets: &HashMap<String, AssetDetails>,
+) -> Result<ProjectAsset, String> {
     // gzip for text/* and js/html, identity for everything else.
     let encoders: Vec<Encoder> = encoders_for(&content.media_type);
 
@@ -653,17 +715,7 @@ fn build_operations(
     //    canister has no headers to inherit from. Populate `RedirectRule.headers`
     //    by resolving `_headers` against the rule's `from` pattern. 200/4xx
     //    rules borrow headers from their target asset, so no plumbing here.
-    let project_rules_with_headers: Vec<RedirectRule> = project_rules
-        .iter()
-        .map(|rule| {
-            let mut rule = rule.clone();
-            if is_3xx(rule.status) {
-                let key = redirect_pattern_to_key(&rule.from);
-                rule.headers = headers::resolve(&key, project_header_rules);
-            }
-            rule
-        })
-        .collect();
+    let project_rules_with_headers = resolve_3xx_rule_headers(project_rules, project_header_rules);
     if project_rules_with_headers != canister_rules {
         ops.push(Operation::SetRedirectRules(SetRedirectRulesArguments {
             rules: project_rules_with_headers,
@@ -675,6 +727,28 @@ fn build_operations(
 
 fn is_3xx(status: u16) -> bool {
     (300..400).contains(&status)
+}
+
+/// Inlines `_headers` into the `headers` of every 3xx rule by resolving them
+/// against the rule's `from` pattern — 3xx rules synthesize their own response
+/// and have no target asset to inherit headers from. 200/4xx rules borrow
+/// headers from their target asset, so they pass through untouched. This is the
+/// canonical form the canister stores, so a re-sync diffs cleanly against it.
+fn resolve_3xx_rule_headers(
+    rules: &[RedirectRule],
+    header_rules: &[HeaderRule],
+) -> Vec<RedirectRule> {
+    rules
+        .iter()
+        .map(|rule| {
+            let mut rule = rule.clone();
+            if is_3xx(rule.status) {
+                let key = redirect_pattern_to_key(&rule.from);
+                rule.headers = headers::resolve(&key, header_rules);
+            }
+            rule
+        })
+        .collect()
 }
 
 /// Returns a path-like key suitable for running the header resolver against a
@@ -762,6 +836,31 @@ mod tests {
     use std::cell::RefCell;
     use std::collections::{HashMap, VecDeque};
     use std::path::PathBuf;
+
+    /// The canister-side state a finished sync leaves for the injected branded
+    /// `/404.html`: its `AssetDetails` (content_type + per-encoding shas) derived
+    /// from the same `prepare_branded_404` the sync path runs, with headers
+    /// resolved from `header_rules` exactly as `build_operations` would. Lets the
+    /// short-circuit tests assert "a second sync of a 404-augmented project is a
+    /// no-op" without hard-coding the branded page's bytes.
+    fn branded_404_canister_asset(header_rules: &[HeaderRule]) -> AssetDetails {
+        let asset = prepare_branded_404(&HashMap::new()).expect("prepare branded 404");
+        let mut encodings: Vec<AssetEncodingDetails> = asset
+            .encodings
+            .iter()
+            .map(|(name, enc)| AssetEncodingDetails {
+                content_encoding: name.clone(),
+                sha256: serde_bytes::ByteBuf::from(enc.sha256.clone()),
+            })
+            .collect();
+        encodings.sort_by(|a, b| a.content_encoding.cmp(&b.content_encoding));
+        AssetDetails {
+            key: not_found::ROOT_404_KEY.to_string(),
+            content_type: asset.media_type.to_string(),
+            encodings,
+            headers: headers::resolve(not_found::ROOT_404_KEY, header_rules),
+        }
+    }
 
     // Records the batch sizes the packer produced (chunks per `upload_chunks`
     // call). Used to verify that `pack_and_upload_chunks` collapses many small
@@ -1467,21 +1566,29 @@ mod tests {
         // Drive sync() end-to-end with a _redirects file that matches what
         // the canister already has. The "nothing to commit" short-circuit
         // must trigger, with no start_sync / execute_operations calls.
+        //
+        // The project ships no root 404.html and no `/*` rule, so the sync
+        // path injects a branded /404.html asset, synthesises its html-handling
+        // rules, and appends the `/*` catch-all — all of which the canister
+        // must already hold for the diff to be empty.
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("_redirects"), b"/old /new 301\n").unwrap();
+
+        let mut canister_rules = crate::html_handling::synthesize(&[not_found::ROOT_404_KEY.into()]);
+        canister_rules.push(mk_rule(
+            crate::canister::RulePattern::Exact("/old".into()),
+            "/new",
+            301,
+        ));
+        canister_rules.push(not_found::catchall_rule());
 
         let mock = SyncMock::new();
         mock.push_ok("bundle_tag", wire_types::BUNDLE_TAG);
         mock.push_ok("can_sync", true);
+        mock.push_ok("get_asset_details", vec![branded_404_canister_asset(&[])]);
+        // Trailing empty page terminates list_all_assets' cursor walk.
         mock.push_ok("get_asset_details", Vec::<AssetDetails>::new());
-        mock.push_ok(
-            "get_redirect_rules",
-            vec![mk_rule(
-                crate::canister::RulePattern::Exact("/old".into()),
-                "/new",
-                301,
-            )],
-        );
+        mock.push_ok("get_redirect_rules", canister_rules);
         // Trailing empty page terminates list_all_redirect_rules' cursor walk.
         mock.push_ok("get_redirect_rules", Vec::<RedirectRule>::new());
 
@@ -1512,9 +1619,12 @@ mod tests {
 
     #[test]
     fn sync_emits_rules_op_when_redirects_file_only_changed() {
-        // _redirects has a rule; canister has none. The asset list is also
-        // empty so no asset ops are produced — the only operation must be
-        // SetRedirectRules, exercising the early "nothing to commit" check.
+        // _redirects has a rule; canister is empty. The project ships no root
+        // 404.html and no `/*` rule, so the sync path also injects a branded
+        // /404.html asset and appends the `/*` catch-all — meaning the diff
+        // carries both the asset upload and the SetRedirectRules op. We only
+        // assert the run succeeds end-to-end (the per-op shape is covered by
+        // build_operations unit tests).
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("_redirects"), b"/old /new 301\n").unwrap();
 
@@ -1524,6 +1634,8 @@ mod tests {
         mock.push_ok("get_asset_details", Vec::<AssetDetails>::new());
         mock.push_ok("get_redirect_rules", Vec::<RedirectRule>::new());
         mock.push_ok("start_sync", StartSyncOk::Started { session_id: 1 });
+        // Injected /404.html bytes are uploaded before operations execute.
+        mock.push_ok("upload_chunks", ());
         mock.push_ok("execute_operations", ());
 
         let result = sync(
@@ -2106,32 +2218,44 @@ mod tests {
         // html-handling rules don't get in the way of the comparison.
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(dir.path().join("notes.txt"), b"hello").unwrap();
-        std::fs::write(
-            dir.path().join("_headers"),
-            b"/*\n  X-Frame-Options: DENY\n",
-        )
-        .unwrap();
+        let headers_file = b"/*\n  X-Frame-Options: DENY\n";
+        std::fs::write(dir.path().join("_headers"), headers_file).unwrap();
 
         use sha2::Digest;
         let identity_sha = sha2::Sha256::digest(b"hello").to_vec();
+
+        // No root 404.html and no `/*` rule, so the sync path injects a branded
+        // /404.html (which the `/*` _headers rule also covers) plus its
+        // html-handling rules and the `/*` catch-all; the canister must already
+        // hold all of it for the short-circuit to fire.
+        let header_rules = crate::headers::parse(std::str::from_utf8(headers_file).unwrap()).unwrap();
+        let mut synth = crate::html_handling::synthesize(&[not_found::ROOT_404_KEY.into()]);
+        synth.push(not_found::catchall_rule());
+        // The canister stores rules with `_headers` resolved into 3xx rules, so
+        // mirror that here or the comparison would spuriously differ.
+        let canister_rules = resolve_3xx_rule_headers(&synth, &header_rules);
 
         let mock = SyncMock::new();
         mock.push_ok("bundle_tag", wire_types::BUNDLE_TAG);
         mock.push_ok("can_sync", true);
         mock.push_ok(
             "get_asset_details",
-            vec![AssetDetails {
-                key: "/notes.txt".to_string(),
-                content_type: "text/plain".to_string(),
-                encodings: vec![AssetEncodingDetails {
-                    content_encoding: "identity".to_string(),
-                    sha256: serde_bytes::ByteBuf::from(identity_sha),
-                }],
-                // Matches what `_headers` resolves to, so no SetAssetHeaders.
-                headers: vec![("X-Frame-Options".into(), "DENY".into())],
-            }],
+            vec![
+                AssetDetails {
+                    key: "/notes.txt".to_string(),
+                    content_type: "text/plain".to_string(),
+                    encodings: vec![AssetEncodingDetails {
+                        content_encoding: "identity".to_string(),
+                        sha256: serde_bytes::ByteBuf::from(identity_sha),
+                    }],
+                    // Matches what `_headers` resolves to, so no SetAssetHeaders.
+                    headers: vec![("X-Frame-Options".into(), "DENY".into())],
+                },
+                branded_404_canister_asset(&header_rules),
+            ],
         );
         mock.push_ok("get_asset_details", Vec::<AssetDetails>::new());
+        mock.push_ok("get_redirect_rules", canister_rules);
         mock.push_ok("get_redirect_rules", Vec::<RedirectRule>::new());
 
         let result = sync(
@@ -2245,22 +2369,33 @@ mod tests {
         use sha2::Digest;
         let identity_sha = sha2::Sha256::digest(b"<html></html>").to_vec();
 
-        let canister_rules = crate::html_handling::synthesize(&["/index.html".to_string()]);
+        // The project ships no root 404.html and no `/*` rule, so the injected
+        // branded /404.html joins /index.html in html-handling synthesis, and
+        // the `/*` catch-all is appended. The canister already holds the full
+        // set, so nothing is committed.
+        let mut canister_rules = crate::html_handling::synthesize(&[
+            "/index.html".to_string(),
+            not_found::ROOT_404_KEY.to_string(),
+        ]);
+        canister_rules.push(not_found::catchall_rule());
 
         let mock = SyncMock::new();
         mock.push_ok("bundle_tag", wire_types::BUNDLE_TAG);
         mock.push_ok("can_sync", true);
         mock.push_ok(
             "get_asset_details",
-            vec![AssetDetails {
-                key: "/index.html".to_string(),
-                content_type: "text/html".to_string(),
-                encodings: vec![AssetEncodingDetails {
-                    content_encoding: "identity".to_string(),
-                    sha256: serde_bytes::ByteBuf::from(identity_sha),
-                }],
-                headers: vec![],
-            }],
+            vec![
+                AssetDetails {
+                    key: "/index.html".to_string(),
+                    content_type: "text/html".to_string(),
+                    encodings: vec![AssetEncodingDetails {
+                        content_encoding: "identity".to_string(),
+                        sha256: serde_bytes::ByteBuf::from(identity_sha),
+                    }],
+                    headers: vec![],
+                },
+                branded_404_canister_asset(&[]),
+            ],
         );
         mock.push_ok("get_asset_details", Vec::<AssetDetails>::new());
         mock.push_ok("get_redirect_rules", canister_rules);


### PR DESCRIPTION
## What & why

The canister carried a built-in certified 404 fallback over from the old assets canister. This PR reworks 404 handling so **every HTTP request resolves to a certified response**, split into two clean layers.

**Canister — a certified floor.** The built-in "not found" 404 is now owned entirely by `State::on_redirect_rules_change`, the single owner of the root `<*>` certified slot: after rebuilding the redirect rules it (re)certifies the built-in 404 iff no active rule occupies `<*>`. This folds in (and fixes a latent rebuild-ordering bug of) the old two-call `certify_404_if_required` design, and guarantees the `build_http_response` fallthrough always verifies — the HTTP gateway rejects uncertified responses, so an uncertified fallback would be unservable.

**Plugin — a nicer 404.** New `sync-core::not_found` module implements a root-only, Netlify-style `404.html` convention: on sync, unless the user already declares a root `/*` rule, it appends a `/* /404.html 404` catch-all and — when the project ships no root `404.html` — injects a branded default page. A `/*` rule owns `<*>` (canister floor skipped, the rule's `/404.html` served); no `/*` rule → the certified plain-text floor applies. SPA stays an explicit `/* … 200` rule, which suppresses both.

Also: documented the intentionally-uncertified malformed-URL 400 (dynamic body can't be pinned to a certified hash; only a direct `http_request` query call ever sees it) and removed the now-dead `build_400` helper.

## Tested
- `canister-core`: 86 unit tests, incl. a transition test (rule takes `<*>` → built-in yields → returns certified when the rule is removed)
- `sync-core`: 199 unit tests, incl. `not_found::plan` cases
- `e2e`: 17 tests against a live replica + gateway, incl. `branded_404_injected_when_project_ships_none` (proves the injected fallback verifies via the gateway's full v2 path) and a deterministic `no_op_sync`
- `cargo clippy --workspace --all-targets -- -D warnings`: clean

Per-subtree (Cloudflare tree-walk) 404 is deliberately deferred as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)