### PR TITLE
feat: model encoding as a typed variant and activate Brotli

### DIFF
--- a/candid/README.md
+++ b/candid/README.md
@@ -44,7 +44,7 @@ We fill that placeholder in with the assets canister's concrete token:
 ```candid
 type StreamingToken = record {
   key: text;
-  content_encoding: text;
+  encoding: text;
   index: nat;
   sha256: opt blob;
 };

--- a/candid/assets.did
+++ b/candid/assets.did
@@ -19,7 +19,7 @@ type Key = text;
 
 // One encoding of an asset, as the `get_asset_details` query reports it.
 type AssetEncodingDetails = record {
-  content_encoding: text;
+  encoding: Encoding;
   sha256: blob; // sha256 of the entire encoded asset
 };
 
@@ -75,7 +75,7 @@ type CreateAssetArguments = record {
 // must match the hash of those chunks concatenated.
 type SetAssetContentArguments = record {
   key: Key;
-  content_encoding: text;
+  encoding: Encoding;
   chunk_ids: vec ChunkId;
   sha256: blob;
 };
@@ -84,7 +84,7 @@ type SetAssetContentArguments = record {
 // other encodings exist.
 type UnsetAssetContentArguments = record {
   key: Key;
-  content_encoding: text;
+  encoding: Encoding;
 };
 
 // Replace an asset's per-asset response headers. The whole list is overwritten,

--- a/candid/http-gateway.did
+++ b/candid/http-gateway.did
@@ -23,13 +23,21 @@ type HttpResponse = record {
   streaming_strategy: opt StreamingStrategy;
 };
 
+// The content encodings the canister and sync plugin support — a deliberately
+// small, closed set (see `wire-types::Encoding`). Carried as a variant
+// (one byte on the wire) rather than a string. `Identity` is the uncompressed
+// form; it is a real stored encoding but never emitted as a `Content-Encoding`
+// header. Defined here, in the imported base interface, so the asset types below
+// and the streaming token can both reference it.
+type Encoding = variant { Identity; Gzip; Brotli };
+
 // Each canister that uses the streaming feature gets to choose their concrete
 // type; the HTTP Gateway will treat it as an opaque value that is only fed to
 // the callback method. This is the assets canister's concrete token.
 
 type StreamingToken = record {
   key: text;
-  content_encoding: text;
+  encoding: Encoding;
   index: nat;
   sha256: blob;
 };

--- a/crates/canister-core/src/asset.rs
+++ b/crates/canister-core/src/asset.rs
@@ -15,26 +15,7 @@ use crate::certification::{
 use ic_representation_independent_hash::Value;
 use sha2::Digest;
 use std::collections::HashMap;
-
-/// The preferred order in which we pick encodings.
-const ENCODING_CERTIFICATION_ORDER: &[&str] = &["identity", "gzip", "compress", "deflate", "br"];
-
-/// All encodings get certified; this returns them in preference order (preferred
-/// names first, then any remaining encodings in iteration order).
-pub fn encoding_certification_order<'a>(
-    actual_encodings: impl Iterator<Item = &'a String>,
-) -> Vec<String> {
-    let mut order: Vec<String> = ENCODING_CERTIFICATION_ORDER
-        .iter()
-        .map(|enc| enc.to_string())
-        .collect();
-    order.extend(
-        actual_encodings
-            .filter(|encoding| !ENCODING_CERTIFICATION_ORDER.contains(&encoding.as_str()))
-            .map(|s| s.to_owned()),
-    );
-    order
-}
+use wire_types::Encoding;
 
 /// Status codes we certify for every asset encoding.
 pub(crate) const STATUS_CODES_TO_CERTIFY: [u16; 2] = [200, 304];
@@ -45,9 +26,12 @@ pub(crate) const STATUS_CODES_TO_CERTIFY: [u16; 2] = [200, 304];
 /// non-identity encodings, plus the custom headers.
 pub(crate) fn certificate_expression_for(
     custom_headers: &[(String, String)],
-    encoding_name: &str,
+    encoding: Encoding,
 ) -> CertificateExpression {
-    build_ic_certificate_expression_from_headers_and_encoding(custom_headers, Some(encoding_name))
+    build_ic_certificate_expression_from_headers_and_encoding(
+        custom_headers,
+        encoding.header_name(),
+    )
 }
 
 /// The full response header list for an encoding: `content-type`,
@@ -56,13 +40,13 @@ pub(crate) fn certificate_expression_for(
 pub(crate) fn headers_for(
     custom_headers: &[(String, String)],
     content_type: &str,
-    encoding_name: &str,
+    encoding: Encoding,
 ) -> Vec<(String, String)> {
-    let cert_expr = certificate_expression_for(custom_headers, encoding_name);
+    let cert_expr = certificate_expression_for(custom_headers, encoding);
     build_headers(
         custom_headers.iter().map(|(k, v)| (k, v)),
         content_type,
-        encoding_name,
+        encoding,
         Some(&cert_expr),
     )
 }
@@ -71,14 +55,14 @@ pub(crate) fn headers_for(
 pub(crate) fn response_hashes_for(
     custom_headers: &[(String, String)],
     content_type: &str,
-    encoding_name: &str,
+    encoding: Encoding,
     cert_expr: &CertificateExpression,
     sha256: &[u8; 32],
 ) -> HashMap<u16, [u8; 32]> {
     let base_headers: Vec<(String, Value)> = build_headers(
         custom_headers.iter().map(|(k, v)| (k, v)),
         content_type,
-        encoding_name,
+        encoding,
         Some(cert_expr),
     )
     .into_iter()
@@ -104,14 +88,14 @@ pub(crate) fn response_hashes_for(
 fn build_headers(
     custom_headers: impl Iterator<Item = (impl Into<String>, impl Into<String>)>,
     content_type: impl Into<String>,
-    encoding_name: impl Into<String>,
+    encoding: Encoding,
     cert_expr: Option<&CertificateExpression>,
 ) -> Vec<(String, String)> {
     let mut headers: Vec<(String, String)> =
         vec![("content-type".to_string(), content_type.into())];
-    let encoding_name = encoding_name.into();
-    if encoding_name != "identity" {
-        headers.push(("content-encoding".to_string(), encoding_name));
+    // Identity carries no `Content-Encoding` header; every other encoding does.
+    if let Some(name) = encoding.header_name() {
+        headers.push(("content-encoding".to_string(), name.to_string()));
     }
     for (k, v) in custom_headers {
         headers.push((k.into().to_lowercase(), v.into()));

--- a/crates/canister-core/src/certification.rs
+++ b/crates/canister-core/src/certification.rs
@@ -301,17 +301,17 @@ pub fn response_hash(
 
 pub fn build_ic_certificate_expression_from_headers_and_encoding<T>(
     headers: &[(String, T)],
-    encoding_name: Option<&str>,
+    encoding_header_value: Option<&str>,
 ) -> CertificateExpression {
     let mut headers = headers
         .iter()
         .map(|(h, _)| format!(", \"{h}\""))
         .collect::<Vec<_>>()
         .join("");
-    if let Some(encoding) = encoding_name {
-        if encoding != "identity" {
-            headers = format!(", \"content-encoding\"{headers}");
-        }
+    // `Some` carries a real `Content-Encoding` header value (identity passes
+    // `None`), so its presence alone decides whether the header is certified.
+    if encoding_header_value.is_some() {
+        headers = format!(", \"content-encoding\"{headers}");
     }
 
     let expression = IC_CERTIFICATE_EXPRESSION_VALUE.replace("{headers}", &headers);

--- a/crates/canister-core/src/http.rs
+++ b/crates/canister-core/src/http.rs
@@ -4,6 +4,7 @@ use crate::certification::{
 use crate::rc_bytes::RcBytes;
 use candid::{define_function, CandidType, Deserialize, Nat};
 use serde_bytes::ByteBuf;
+use wire_types::Encoding;
 
 pub type HeaderField = (String, String);
 
@@ -28,7 +29,7 @@ pub struct HttpResponse {
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct StreamingCallbackToken {
     pub key: String,
-    pub content_encoding: String,
+    pub encoding: Encoding,
     pub index: Nat,
     pub sha256: ByteBuf,
 }
@@ -50,7 +51,7 @@ pub struct StreamingCallbackHttpResponse {
 
 impl StreamingCallbackToken {
     pub fn create_token(
-        enc_name: &str,
+        encoding: Encoding,
         content_chunks_count: usize,
         content_sha256: [u8; 32],
         key: &str,
@@ -61,7 +62,7 @@ impl StreamingCallbackToken {
         } else {
             Some(StreamingCallbackToken {
                 key: key.to_string(),
-                content_encoding: enc_name.to_string(),
+                encoding,
                 index: Nat::from(chunk_index + 1),
                 sha256: ByteBuf::from(content_sha256),
             })

--- a/crates/canister-core/src/stable_store.rs
+++ b/crates/canister-core/src/stable_store.rs
@@ -27,6 +27,7 @@ use ic_stable_structures::Storable;
 use serde::{Deserialize, Serialize};
 
 use crate::redirect::RedirectRule;
+use wire_types::Encoding;
 
 /// Principals authorized to sync (controllers are always allowed and are not
 /// stored here). Newtype so it can carry a `Storable` impl (the orphan rule
@@ -47,7 +48,7 @@ pub struct RedirectRules(pub Vec<RedirectRule>);
 pub struct AssetMeta {
     pub content_type: String,
     pub headers: Vec<(String, String)>,
-    pub encodings: BTreeMap<String, EncodingMeta>,
+    pub encodings: BTreeMap<Encoding, EncodingMeta>,
 }
 
 /// Per-encoding metadata. The certificate expression and response hashes are

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -15,8 +15,7 @@
 //! upgrade roundtrip over a shared memory handle).
 
 use crate::asset::{
-    certificate_expression_for, encoding_certification_order, headers_for, response_hashes_for,
-    STATUS_CODES_TO_CERTIFY,
+    certificate_expression_for, headers_for, response_hashes_for, STATUS_CODES_TO_CERTIFY,
 };
 use crate::certification::{
     response_hash, AssetKey, AssetPath, CertifiedResponses, RequestHash, ResponseHash,
@@ -266,7 +265,7 @@ impl State {
             .ok_or_else(|| "asset not found".to_string())?;
 
         // Free the chunks of any encoding we're replacing.
-        if let Some(old) = meta.encodings.get(&arg.content_encoding) {
+        if let Some(old) = meta.encodings.get(&arg.encoding) {
             self.delete_content(old.content_id);
         }
 
@@ -281,7 +280,7 @@ impl State {
         }
 
         meta.encodings.insert(
-            arg.content_encoding,
+            arg.encoding,
             EncodingMeta {
                 content_id,
                 num_chunks,
@@ -300,7 +299,7 @@ impl State {
             .get(&arg.key)
             .ok_or_else(|| "asset not found".to_string())?;
 
-        if let Some(old) = meta.encodings.remove(&arg.content_encoding) {
+        if let Some(old) = meta.encodings.remove(&arg.encoding) {
             self.delete_content(old.content_id);
             self.recertify_asset(&arg.key, &meta);
             self.metadata.insert(arg.key, meta);
@@ -341,12 +340,12 @@ impl State {
         }
 
         let path = AssetPath::from(key.as_str());
-        for (enc_name, enc) in &meta.encodings {
-            let cert_expr = certificate_expression_for(&meta.headers, enc_name);
+        for (&encoding, enc) in &meta.encodings {
+            let cert_expr = certificate_expression_for(&meta.headers, encoding);
             let response_hashes = response_hashes_for(
                 &meta.headers,
                 &meta.content_type,
-                enc_name,
+                encoding,
                 &cert_expr,
                 &enc.sha256,
             );
@@ -384,12 +383,12 @@ impl State {
                 let mut encodings: Vec<_> = meta
                     .encodings
                     .iter()
-                    .map(|(enc_name, enc)| AssetEncodingDetails {
-                        content_encoding: enc_name.clone(),
+                    .map(|(&encoding, enc)| AssetEncodingDetails {
+                        encoding,
                         sha256: ByteBuf::from(enc.sha256),
                     })
                     .collect();
-                encodings.sort_by(|l, r| l.content_encoding.cmp(&r.content_encoding));
+                encodings.sort_by_key(|l| l.encoding);
 
                 AssetDetails {
                     key,
@@ -427,7 +426,7 @@ impl State {
         &self,
         certificate: &[u8],
         path: &str,
-        requested_encodings: Vec<String>,
+        requested_encodings: Vec<Encoding>,
         chunk_index: usize,
         callback: CallbackFunc,
         etags: Vec<Hash>,
@@ -486,7 +485,7 @@ impl State {
     fn build_asset_response(
         &self,
         meta: &AssetMeta,
-        requested_encodings: &[String],
+        requested_encodings: &[Encoding],
         key: &str,
         chunk_index: usize,
         certificate_header: Option<&HeaderField>,
@@ -494,19 +493,21 @@ impl State {
         etags: &[Hash],
         status_override: Option<u16>,
     ) -> Option<HttpResponse> {
-        let enc_name = requested_encodings
+        // Honour the client's listed order first; if it expressed no acceptable
+        // encoding, fall back to our preference order (identity-first).
+        let encoding = requested_encodings
             .iter()
-            .find(|e| meta.encodings.contains_key(*e))
-            .cloned()
+            .copied()
+            .find(|e| meta.encodings.contains_key(e))
             .or_else(|| {
-                encoding_certification_order(meta.encodings.keys())
+                Encoding::PREFERENCE_ORDER
                     .into_iter()
                     .find(|e| meta.encodings.contains_key(e))
             })?;
-        let enc = meta.encodings.get(&enc_name)?;
+        let enc = meta.encodings.get(&encoding)?;
         Some(self.build_ok_http_response(
             meta,
-            &enc_name,
+            encoding,
             enc,
             key,
             chunk_index,
@@ -527,7 +528,7 @@ impl State {
     fn build_ok_http_response(
         &self,
         meta: &AssetMeta,
-        enc_name: &str,
+        encoding: Encoding,
         enc: &EncodingMeta,
         key: &str,
         chunk_index: usize,
@@ -536,13 +537,13 @@ impl State {
         etags: &[Hash],
         status_override: Option<u16>,
     ) -> HttpResponse {
-        let mut headers = headers_for(&meta.headers, &meta.content_type, enc_name);
+        let mut headers = headers_for(&meta.headers, &meta.content_type, encoding);
         if let Some(head) = certificate_header {
             headers.push((head.0.clone(), head.1.clone()));
         }
 
         let streaming_strategy = StreamingCallbackToken::create_token(
-            enc_name,
+            encoding,
             enc.num_chunks as usize,
             enc.sha256,
             key,
@@ -586,7 +587,7 @@ impl State {
         entry: &crate::redirect::CertifiedRuleEntry,
         path: &str,
         certificate: &[u8],
-        requested_encodings: &[String],
+        requested_encodings: &[Encoding],
         chunk_index: usize,
         callback: &CallbackFunc,
         etags: &[Hash],
@@ -637,14 +638,12 @@ impl State {
         certificate: &[u8],
         callback: CallbackFunc,
     ) -> HttpResponse {
-        let mut encodings = vec![];
+        let mut encodings: Vec<Encoding> = vec![];
         // waiting for https://dfinity.atlassian.net/browse/BOUN-446
         let etags = Vec::new();
         for (name, value) in req.headers.iter() {
             if name.eq_ignore_ascii_case("Accept-Encoding") {
-                for v in value.split(',') {
-                    encodings.push(v.trim().to_string());
-                }
+                encodings.extend(Encoding::parse_accept_encoding(value));
             }
         }
 
@@ -678,7 +677,7 @@ impl State {
         &self,
         StreamingCallbackToken {
             key,
-            content_encoding,
+            encoding,
             index,
             sha256,
         }: StreamingCallbackToken,
@@ -689,7 +688,7 @@ impl State {
             .ok_or_else(|| "Invalid token on streaming: key not found.".to_string())?;
         let enc = meta
             .encodings
-            .get(&content_encoding)
+            .get(&encoding)
             .ok_or_else(|| "Invalid token on streaming: encoding not found.".to_string())?;
 
         if sha256 != ByteBuf::from(enc.sha256) {
@@ -702,7 +701,7 @@ impl State {
         Ok(StreamingCallbackHttpResponse {
             body: self.chunk_bytes(enc.content_id, chunk_index),
             token: StreamingCallbackToken::create_token(
-                &content_encoding,
+                encoding,
                 enc.num_chunks as usize,
                 enc.sha256,
                 &key,
@@ -812,14 +811,14 @@ impl State {
         let meta = self.metadata.get(&target_key)?;
         let location = crate::redirect::tree_location(rule);
         let mut tree_paths = Vec::new();
-        for (enc_name, enc) in &meta.encodings {
-            let cert_expr = certificate_expression_for(&meta.headers, enc_name);
+        for (&encoding, enc) in &meta.encodings {
+            let cert_expr = certificate_expression_for(&meta.headers, encoding);
             let resp_hash = if status == 200 {
                 // The encoding's already-certified 200 response hash.
                 response_hashes_for(
                     &meta.headers,
                     &meta.content_type,
-                    enc_name,
+                    encoding,
                     &cert_expr,
                     &enc.sha256,
                 )[&200]
@@ -827,7 +826,7 @@ impl State {
                 // 4xx custom error page: re-certify with the override status
                 // using the same headers and body the asset would serve at 200.
                 let base_headers: Vec<(String, Value)> =
-                    headers_for(&meta.headers, &meta.content_type, enc_name)
+                    headers_for(&meta.headers, &meta.content_type, encoding)
                         .into_iter()
                         .map(|(k, v)| (k, Value::String(v)))
                         .collect();

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -5,8 +5,8 @@ use crate::state::State;
 use crate::sync::{ComputationStatus, SYNC_IDLE_TIMEOUT_NANOS};
 use crate::system_context::SystemContext;
 use crate::types::{
-    CreateAssetArguments, DeleteAssetArguments, ExecuteOperationsArguments, Operation, SessionId,
-    SetAssetContentArguments, SetAssetHeadersArguments, StartSyncResult,
+    CreateAssetArguments, DeleteAssetArguments, Encoding, ExecuteOperationsArguments, Operation,
+    SessionId, SetAssetContentArguments, SetAssetHeadersArguments, StartSyncResult,
 };
 use crate::url::{url_decode, UrlDecodeError};
 use crate::UploadChunksArguments;
@@ -143,7 +143,7 @@ fn certified_http_request(state: &State, request: HttpRequest) -> HttpResponse {
 struct AssetBuilder {
     name: String,
     content_type: String,
-    encodings: Vec<(String, Vec<ByteBuf>)>,
+    encodings: Vec<(Encoding, Vec<ByteBuf>)>,
     headers: Vec<(String, String)>,
 }
 
@@ -158,8 +158,10 @@ impl AssetBuilder {
     }
 
     fn with_encoding(mut self, name: impl AsRef<str>, chunks: Vec<impl AsRef<[u8]>>) -> Self {
+        let encoding = Encoding::from_token(name.as_ref())
+            .unwrap_or_else(|| panic!("unsupported test encoding {:?}", name.as_ref()));
         self.encodings.push((
-            name.as_ref().to_string(),
+            encoding,
             chunks
                 .into_iter()
                 .map(|c| ByteBuf::from(c.as_ref().to_vec()))
@@ -304,7 +306,7 @@ fn assemble_create_assets_and_set_contents_operations(
             operations.push(Operation::SetAssetContent({
                 SetAssetContentArguments {
                     key: asset.name.clone(),
-                    content_encoding: enc,
+                    encoding: enc,
                     chunk_ids,
                     sha256,
                 }
@@ -370,6 +372,7 @@ fn serve_correct_encoding() {
 
     const IDENTITY_BODY: &[u8] = b"<!DOCTYPE html><html></html>";
     const GZIP_BODY: &[u8] = b"this is 'gzipped' content";
+    const BROTLI_BODY: &[u8] = b"this is 'brotli' content";
 
     create_assets(
         &mut state,
@@ -377,11 +380,14 @@ fn serve_correct_encoding() {
         vec![
             AssetBuilder::new("/contents.html", "text/html")
                 .with_encoding("identity", vec![IDENTITY_BODY])
-                .with_encoding("gzip", vec![GZIP_BODY]),
+                .with_encoding("gzip", vec![GZIP_BODY])
+                .with_encoding("br", vec![BROTLI_BODY]),
             AssetBuilder::new("/no-encoding.html", "text/html"),
         ],
     );
 
+    // Identity is served verbatim and carries NO `content-encoding` header (the
+    // `identity` token is not a valid response value).
     let identity_response = certified_http_request(
         &state,
         RequestBuilder::get("/contents.html")
@@ -391,6 +397,7 @@ fn serve_correct_encoding() {
     );
     assert_eq!(identity_response.status_code, 200);
     assert_eq!(identity_response.body.as_ref(), IDENTITY_BODY);
+    assert_eq!(lookup_header(&identity_response, "content-encoding"), None);
     assert!(lookup_header(&identity_response, "IC-Certificate").is_some());
 
     let gzip_response = certified_http_request(
@@ -402,7 +409,28 @@ fn serve_correct_encoding() {
     );
     assert_eq!(gzip_response.status_code, 200);
     assert_eq!(gzip_response.body.as_ref(), GZIP_BODY);
+    assert_eq!(
+        lookup_header(&gzip_response, "content-encoding"),
+        Some("gzip")
+    );
     assert!(lookup_header(&gzip_response, "IC-Certificate").is_some());
+
+    // Brotli is selected and labelled `br`, including from a weighted, multi-coding
+    // Accept-Encoding header (the `;q=` parsing that previously matched nothing).
+    let brotli_response = certified_http_request(
+        &state,
+        RequestBuilder::get("/contents.html")
+            .with_header("Accept-Encoding", "br;q=1.0, gzip;q=0.8")
+            .with_certificate_version(2)
+            .build(),
+    );
+    assert_eq!(brotli_response.status_code, 200);
+    assert_eq!(brotli_response.body.as_ref(), BROTLI_BODY);
+    assert_eq!(
+        lookup_header(&brotli_response, "content-encoding"),
+        Some("br")
+    );
+    assert!(lookup_header(&brotli_response, "IC-Certificate").is_some());
 
     // An asset with no encodings has nothing to serve → the built-in certified
     // 404 (no rule occupies `<*>`, so the fallback is certified there).
@@ -870,7 +898,7 @@ fn uses_streaming_for_multichunk_assets() {
         state
             .http_request_streaming_callback(StreamingCallbackToken {
                 key: "/index.html".to_string(),
-                content_encoding: "identity".to_string(),
+                encoding: Encoding::Identity,
                 index: Nat::from(1_u8),
                 sha256: ByteBuf::from([0u8; 32].as_slice()),
             })
@@ -1333,12 +1361,16 @@ mod certificate_expression {
             ("c".into(), Value::String("".into())),
         ]
         .to_vec();
-        let c = build_ic_certificate_expression_from_headers_and_encoding(&h, Some("not identity"));
+        // `Some(value)` certifies a `content-encoding` header (a real encoding,
+        // e.g. `Encoding::Gzip.header_name()` == `Some("gzip")`).
+        let c = build_ic_certificate_expression_from_headers_and_encoding(&h, Some("gzip"));
         assert_eq!(
             c.expression,
             r#"default_certification(ValidationArgs{certification: Certification{no_request_certification: Empty{}, response_certification: ResponseCertification{certified_response_headers: ResponseHeaderList{headers: ["content-type", "content-encoding", "a", "b", "c"]}}}})"#
         );
-        let c2 = build_ic_certificate_expression_from_headers_and_encoding(&h, Some("identity"));
+        // `None` — which identity maps to via `Encoding::header_name` —
+        // omits the `content-encoding` header.
+        let c2 = build_ic_certificate_expression_from_headers_and_encoding(&h, None);
         assert_eq!(
             c2.expression,
             r#"default_certification(ValidationArgs{certification: Certification{no_request_certification: Empty{}, response_certification: ResponseCertification{certified_response_headers: ResponseHeaderList{headers: ["content-type", "a", "b", "c"]}}}})"#
@@ -1671,7 +1703,7 @@ mod set_asset_content_sha256_verification {
         // set_asset_content with correct hash should succeed
         let result = state.set_asset_content(SetAssetContentArguments {
             key: "/test.txt".to_string(),
-            content_encoding: "identity".to_string(),
+            encoding: Encoding::Identity,
             chunk_ids,
             sha256: ByteBuf::from(correct_hash.as_slice()),
         });
@@ -1710,7 +1742,7 @@ mod set_asset_content_sha256_verification {
         // set_asset_content with incorrect hash should fail
         let result = state.set_asset_content(SetAssetContentArguments {
             key: "/test.txt".to_string(),
-            content_encoding: "identity".to_string(),
+            encoding: Encoding::Identity,
             chunk_ids,
             sha256: ByteBuf::from(incorrect_hash.as_slice()),
         });
@@ -1748,7 +1780,7 @@ mod set_asset_content_sha256_verification {
 
         let result = state.set_asset_content(SetAssetContentArguments {
             key: "/test.txt".to_string(),
-            content_encoding: "identity".to_string(),
+            encoding: Encoding::Identity,
             chunk_ids,
             sha256: ByteBuf::from(expected_hash.as_slice()),
         });
@@ -1763,7 +1795,7 @@ mod set_asset_content_sha256_verification {
             .and_then(|a| {
                 a.encodings
                     .iter()
-                    .find(|e| e.content_encoding == "identity")
+                    .find(|e| e.encoding == Encoding::Identity)
             })
             .expect("identity encoding should be listed");
         assert_eq!(encoding.sha256.as_ref(), expected_hash.as_slice());
@@ -1804,7 +1836,7 @@ mod set_asset_content_sha256_verification {
         // set_asset_content with correct hash for combined chunks should succeed
         let result = state.set_asset_content(SetAssetContentArguments {
             key: "/test.txt".to_string(),
-            content_encoding: "identity".to_string(),
+            encoding: Encoding::Identity,
             chunk_ids,
             sha256: ByteBuf::from(correct_hash.as_slice()),
         });

--- a/crates/canister-core/src/types.rs
+++ b/crates/canister-core/src/types.rs
@@ -7,7 +7,7 @@
 // Shared wire types (defined once in `wire-types`, used by both sides).
 pub use wire_types::{
     AssetDetails, AssetEncodingDetails, ChunkId, CreateAssetArguments, DeleteAssetArguments,
-    ExecuteOperationsArguments, Operation, SessionId, SetAssetContentArguments,
+    Encoding, ExecuteOperationsArguments, Operation, SessionId, SetAssetContentArguments,
     SetAssetHeadersArguments, SetRedirectRulesArguments, StartSyncResult,
     UnsetAssetContentArguments, UploadChunksArguments,
 };

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 // Wire types shared with the canister and sync plugin.
-pub use wire_types::{AssetDetails, AssetEncodingDetails};
+pub use wire_types::{AssetDetails, AssetEncodingDetails, Encoding};
 
 /// Build an `icp` subprocess command rooted at `project_dir`.
 ///

--- a/crates/e2e/tests/sync.rs
+++ b/crates/e2e/tests/sync.rs
@@ -1,5 +1,5 @@
 use candid::Principal;
-use e2e::{icp_cmd, list_assets, setup_project, AssetDetails, LocalNetwork};
+use e2e::{icp_cmd, list_assets, setup_project, AssetDetails, Encoding, LocalNetwork};
 use std::fs;
 
 /// Deploy the test fixture to a local replica and verify that `/index.html` appears
@@ -89,8 +89,7 @@ fn no_op_sync() {
     let mut assets_before = list_assets(project);
     assets_before.sort_by(|a, b| a.key.cmp(&b.key));
     for a in assets_before.iter_mut() {
-        a.encodings
-            .sort_by(|x, y| x.content_encoding.cmp(&y.content_encoding));
+        a.encodings.sort_by_key(|x| x.encoding);
     }
 
     let output = icp_cmd(project)
@@ -112,8 +111,7 @@ fn no_op_sync() {
     let mut assets_after = list_assets(project);
     assets_after.sort_by(|a, b| a.key.cmp(&b.key));
     for a in assets_after.iter_mut() {
-        a.encodings
-            .sort_by(|x, y| x.content_encoding.cmp(&y.content_encoding));
+        a.encodings.sort_by_key(|x| x.encoding);
     }
     assert_eq!(
         assets_before, assets_after,
@@ -128,7 +126,7 @@ fn identity_sha(assets: &[AssetDetails], key: &str) -> Option<Vec<u8>> {
         .and_then(|a| {
             a.encodings
                 .iter()
-                .find(|e| e.content_encoding == "identity")
+                .find(|e| e.encoding == Encoding::Identity)
         })
         .map(|e| e.sha256.to_vec())
 }

--- a/crates/e2e/tests/upgrade.rs
+++ b/crates/e2e/tests/upgrade.rs
@@ -13,8 +13,7 @@ fn sorted_assets(project: &std::path::Path) -> Vec<AssetDetails> {
     let mut assets = list_assets(project);
     assets.sort_by(|a, b| a.key.cmp(&b.key));
     for a in assets.iter_mut() {
-        a.encodings
-            .sort_by(|x, y| x.content_encoding.cmp(&y.content_encoding));
+        a.encodings.sort_by_key(|x| x.encoding);
     }
     assets
 }

--- a/crates/sync-core/src/canister.rs
+++ b/crates/sync-core/src/canister.rs
@@ -13,7 +13,7 @@ use serde_bytes::ByteBuf;
 use std::collections::HashMap;
 
 pub use wire_types::{
-    AssetDetails, AssetEncodingDetails, CreateAssetArguments, DeleteAssetArguments,
+    AssetDetails, AssetEncodingDetails, CreateAssetArguments, DeleteAssetArguments, Encoding,
     ExecuteOperationsArguments, Operation, RedirectRule, RulePattern, SetAssetContentArguments,
     SetAssetHeadersArguments, SetRedirectRulesArguments, StartSyncResult,
     UnsetAssetContentArguments, UploadChunksArguments,

--- a/crates/sync-core/src/content.rs
+++ b/crates/sync-core/src/content.rs
@@ -3,30 +3,10 @@
 //! Mirrors `ic-asset`'s `asset/content.rs` and `asset/content_encoder.rs`.
 
 use mime::Mime;
-use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::io::Write;
 use std::path::Path;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum Encoder {
-    Identity,
-    Gzip,
-    /// Serialized as `"brotli"`; also accepted as `"br"` for compatibility.
-    #[serde(alias = "br")]
-    Brotli,
-}
-
-impl Encoder {
-    pub fn name(&self) -> &'static str {
-        match self {
-            Encoder::Identity => "identity",
-            Encoder::Gzip => "gzip",
-            Encoder::Brotli => "br",
-        }
-    }
-}
+use wire_types::Encoding;
 
 #[derive(Clone)]
 pub struct Content {
@@ -43,10 +23,10 @@ impl Content {
         Ok(Content { data, media_type })
     }
 
-    pub fn encode(&self, encoder: Encoder) -> Result<Content, String> {
-        match encoder {
-            Encoder::Identity => Ok(self.clone()),
-            Encoder::Gzip => {
+    pub fn encode(&self, encoding: Encoding) -> Result<Content, String> {
+        match encoding {
+            Encoding::Identity => Ok(self.clone()),
+            Encoding::Gzip => {
                 let mut e =
                     flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
                 e.write_all(&self.data).map_err(|e| format!("gzip: {e}"))?;
@@ -56,7 +36,7 @@ impl Content {
                     media_type: self.media_type.clone(),
                 })
             }
-            Encoder::Brotli => {
+            Encoding::Brotli => {
                 let mut compressed = Vec::new();
                 {
                     let mut w = brotli::CompressorWriter::new(&mut compressed, 4096, 11, 22);
@@ -77,13 +57,52 @@ impl Content {
     }
 }
 
-/// Returns the encoders to apply for a given media type, matching `ic-asset`'s policy.
-pub fn encoders_for(media_type: &Mime) -> Vec<Encoder> {
-    match (media_type.type_(), media_type.subtype()) {
-        (mime::TEXT, _) | (_, mime::JAVASCRIPT) | (_, mime::HTML) => {
-            vec![Encoder::Identity, Encoder::Gzip]
+/// Whether content of this media type is worth compressing.
+///
+/// We deliberately support a small, curated set of encodings (Identity, Gzip,
+/// Brotli) rather than the full IANA list — trading a little bandwidth for
+/// implementation simplicity and bounded canister storage. Compressible:
+/// - all `text/*` (html, css, plain, markdown, csv, …);
+/// - JavaScript and WebAssembly;
+/// - structured types with a `+json` / `+xml` suffix — this one rule catches
+///   `image/svg+xml`, `application/xhtml+xml`, `application/rss+xml`, etc. —
+///   plus the bare `application/json` / `application/xml`;
+/// - uncompressed font containers (`font/ttf`, `font/otf`, `.eot`).
+///
+/// Already-compressed formats are left alone: images/audio/video, archives, and
+/// `font/woff` + `font/woff2` (which embed their own compression — `woff2` is
+/// itself Brotli, so re-compressing only wastes space and CPU).
+pub fn is_compressible(media_type: &Mime) -> bool {
+    let ty = media_type.type_();
+    let subtype = media_type.subtype();
+
+    if ty == mime::TEXT {
+        return true;
+    }
+    if ty == mime::FONT {
+        return !matches!(subtype.as_str(), "woff" | "woff2");
+    }
+    if let Some(suffix) = media_type.suffix() {
+        if suffix == mime::JSON || suffix == mime::XML {
+            return true;
         }
-        _ => vec![Encoder::Identity],
+    }
+    subtype == mime::JAVASCRIPT
+        || subtype == mime::JSON
+        || subtype == mime::XML
+        || matches!(subtype.as_str(), "wasm" | "vnd.ms-fontobject")
+}
+
+/// The encodings to *attempt* for a given media type: every compressible asset
+/// gets Brotli and Gzip alongside the always-present uncompressed Identity copy;
+/// everything else is stored as Identity only. Whether a produced compressed
+/// encoding is actually kept is decided afterwards by a size check against
+/// Identity — see `prepare_content_asset`.
+pub fn encoders_for(media_type: &Mime) -> Vec<Encoding> {
+    if is_compressible(media_type) {
+        vec![Encoding::Identity, Encoding::Gzip, Encoding::Brotli]
+    } else {
+        vec![Encoding::Identity]
     }
 }
 
@@ -99,50 +118,58 @@ mod tests {
         }
     }
 
-    // --- encoders_for ---
+    // --- is_compressible / encoders_for ---
+
+    fn mime_of(s: &str) -> Mime {
+        s.parse().unwrap()
+    }
+
+    const ALL_THREE: [Encoding; 3] = [Encoding::Identity, Encoding::Gzip, Encoding::Brotli];
 
     #[test]
-    fn encoders_for_text_html() {
-        let mime: Mime = "text/html".parse().unwrap();
-        assert_eq!(encoders_for(&mime), vec![Encoder::Identity, Encoder::Gzip]);
+    fn compressible_types() {
+        for s in [
+            "text/html",
+            "text/css",
+            "text/plain",
+            "text/markdown",
+            "application/javascript",
+            "text/javascript",
+            "application/json",
+            "application/vnd.api+json",
+            "application/xml",
+            "text/xml",
+            "image/svg+xml",
+            "application/xhtml+xml",
+            "application/rss+xml",
+            "application/wasm",
+            "font/ttf",
+            "font/otf",
+            "application/vnd.ms-fontobject",
+        ] {
+            let m = mime_of(s);
+            assert!(is_compressible(&m), "{s} should be compressible");
+            assert_eq!(encoders_for(&m), ALL_THREE.to_vec(), "{s}");
+        }
     }
 
     #[test]
-    fn encoders_for_text_css() {
-        let mime: Mime = "text/css".parse().unwrap();
-        assert_eq!(encoders_for(&mime), vec![Encoder::Identity, Encoder::Gzip]);
-    }
-
-    #[test]
-    fn encoders_for_application_javascript() {
-        let mime: Mime = "application/javascript".parse().unwrap();
-        assert_eq!(encoders_for(&mime), vec![Encoder::Identity, Encoder::Gzip]);
-    }
-
-    #[test]
-    fn encoders_for_text_javascript() {
-        let mime: Mime = "text/javascript".parse().unwrap();
-        assert_eq!(encoders_for(&mime), vec![Encoder::Identity, Encoder::Gzip]);
-    }
-
-    #[test]
-    fn encoders_for_image_png() {
-        let mime: Mime = "image/png".parse().unwrap();
-        assert_eq!(encoders_for(&mime), vec![Encoder::Identity]);
-    }
-
-    #[test]
-    fn encoders_for_application_wasm() {
-        let mime: Mime = "application/wasm".parse().unwrap();
-        assert_eq!(encoders_for(&mime), vec![Encoder::Identity]);
-    }
-
-    #[test]
-    fn encoders_for_unknown_uses_octet_stream() {
-        assert_eq!(
-            encoders_for(&mime::APPLICATION_OCTET_STREAM),
-            vec![Encoder::Identity]
-        );
+    fn incompressible_types() {
+        for s in [
+            "image/png",
+            "image/jpeg",
+            "image/webp",
+            "video/mp4",
+            "audio/mpeg",
+            "font/woff",
+            "font/woff2",
+            "application/zip",
+            "application/octet-stream",
+        ] {
+            let m = mime_of(s);
+            assert!(!is_compressible(&m), "{s} should NOT be compressible");
+            assert_eq!(encoders_for(&m), vec![Encoding::Identity], "{s}");
+        }
     }
 
     // --- encode ---
@@ -150,7 +177,7 @@ mod tests {
     #[test]
     fn encode_identity_passthrough() {
         let c = content(b"hello world");
-        let out = c.encode(Encoder::Identity).unwrap();
+        let out = c.encode(Encoding::Identity).unwrap();
         assert_eq!(out.data, b"hello world");
     }
 
@@ -160,7 +187,7 @@ mod tests {
 
         let original = b"hello gzip world, hello gzip world";
         let c = content(original);
-        let compressed = c.encode(Encoder::Gzip).unwrap();
+        let compressed = c.encode(Encoding::Gzip).unwrap();
 
         let mut decoder = GzDecoder::new(compressed.data.as_slice());
         let mut decompressed = Vec::new();
@@ -172,7 +199,7 @@ mod tests {
     fn encode_brotli_round_trip() {
         let original = b"hello brotli world, hello brotli world";
         let c = content(original);
-        let compressed = c.encode(Encoder::Brotli).unwrap();
+        let compressed = c.encode(Encoding::Brotli).unwrap();
 
         let mut decompressed = Vec::new();
         brotli::Decompressor::new(compressed.data.as_slice(), 4096)

--- a/crates/sync-core/src/sync.rs
+++ b/crates/sync-core/src/sync.rs
@@ -12,11 +12,11 @@ use std::collections::HashMap;
 use crate::canister::{
     authorize_via_proxy, bundle_tag, can_sync, execute_operations, list_all_assets,
     list_all_redirect_rules, start_sync, upload_chunks, AssetDetails, CanisterCall,
-    CreateAssetArguments, DeleteAssetArguments, ExecuteOperationsArguments, Operation,
+    CreateAssetArguments, DeleteAssetArguments, Encoding, ExecuteOperationsArguments, Operation,
     RedirectRule, SetAssetContentArguments, SetAssetHeadersArguments, SetRedirectRulesArguments,
     UnsetAssetContentArguments,
 };
-use crate::content::{encoders_for, Content, Encoder};
+use crate::content::{encoders_for, Content};
 use crate::headers::{self, HeaderRule, HEADERS_FILENAME};
 use crate::html_handling;
 use crate::not_found;
@@ -38,7 +38,7 @@ struct ProjectAssetEncoding {
 struct ProjectAsset {
     source: AssetSource,
     media_type: Mime,
-    encodings: HashMap<String, ProjectAssetEncoding>,
+    encodings: HashMap<Encoding, ProjectAssetEncoding>,
 }
 
 /// Ensures the signing identity can sync assets, before any expensive scanning
@@ -300,23 +300,24 @@ fn prepare_content_asset(
     content: Content,
     canister_assets: &HashMap<String, AssetDetails>,
 ) -> Result<ProjectAsset, String> {
-    // gzip for text/* and js/html, identity for everything else.
-    let encoders: Vec<Encoder> = encoders_for(&content.media_type);
+    // Brotli + gzip for compressible types, identity for everything else.
+    let encoders: Vec<Encoding> = encoders_for(&content.media_type);
 
-    let mut encodings: HashMap<String, ProjectAssetEncoding> = HashMap::new();
-    for encoder in encoders {
-        let encoded = content.encode(encoder)?;
-        // Identity is always uploaded. Alternate encodings only get uploaded if
-        // they save bytes vs. identity.
-        if encoder != Encoder::Identity && encoded.data.len() >= content.data.len() {
+    let mut encodings: HashMap<Encoding, ProjectAssetEncoding> = HashMap::new();
+    for encoding in encoders {
+        let encoded = content.encode(encoding)?;
+        // Identity is always uploaded. A compressed encoding is only kept if it
+        // actually saves bytes vs. identity — otherwise storing it just wastes
+        // canister space (e.g. a tiny file where the gzip/brotli framing alone
+        // exceeds the savings).
+        if !encoding.is_identity() && encoded.data.len() >= content.data.len() {
             continue;
         }
-        let name = encoder.name().to_string();
         let sha256 = encoded.sha256();
         let already_in_place = is_already_in_place(
             &source.key,
             &content.media_type,
-            &name,
+            encoding,
             &sha256,
             canister_assets,
         );
@@ -325,14 +326,14 @@ fn prepare_content_asset(
             println!(
                 "  {}{} ({} bytes) sha {} already in place",
                 source.key,
-                encoding_suffix(&name),
+                encoding_suffix(encoding),
                 encoded.data.len(),
                 hex::encode(&sha256)
             );
         }
 
         encodings.insert(
-            name,
+            encoding,
             ProjectAssetEncoding {
                 chunk_ids: Vec::new(),
                 sha256,
@@ -356,7 +357,7 @@ fn prepare_content_asset(
 fn is_already_in_place(
     key: &str,
     media_type: &Mime,
-    encoding: &str,
+    encoding: Encoding,
     sha256: &[u8],
     canister_assets: &HashMap<String, AssetDetails>,
 ) -> bool {
@@ -369,15 +370,15 @@ fn is_already_in_place(
     canister_asset
         .encodings
         .iter()
-        .find(|d| d.content_encoding == encoding)
+        .find(|d| d.encoding == encoding)
         .is_some_and(|d| d.sha256.as_ref() == sha256)
 }
 
-fn encoding_suffix(encoding: &str) -> String {
-    if encoding == "identity" {
+fn encoding_suffix(encoding: Encoding) -> String {
+    if encoding.is_identity() {
         String::new()
     } else {
-        format!(" ({encoding})")
+        format!(" ({})", encoding.label())
     }
 }
 
@@ -404,7 +405,7 @@ fn pack_and_upload_chunks<C: CanisterCall>(
 ) -> Result<(), String> {
     struct PendingChunk {
         asset_key: String,
-        encoding: String,
+        encoding: Encoding,
         chunk_index: usize,
         data: Vec<u8>,
     }
@@ -412,7 +413,7 @@ fn pack_and_upload_chunks<C: CanisterCall>(
     let mut pending: Vec<PendingChunk> = Vec::new();
     for asset in project_assets.values_mut() {
         let key = asset.source.key.clone();
-        for (encoding_name, enc) in &mut asset.encodings {
+        for (&encoding, enc) in &mut asset.encodings {
             if enc.already_in_place {
                 continue;
             }
@@ -428,7 +429,7 @@ fn pack_and_upload_chunks<C: CanisterCall>(
             for (i, chunk) in chunks.into_iter().enumerate() {
                 pending.push(PendingChunk {
                     asset_key: key.clone(),
-                    encoding: encoding_name.clone(),
+                    encoding,
                     chunk_index: i,
                     data: chunk,
                 });
@@ -672,10 +673,10 @@ fn build_operations(
     for (key, ca) in &canister_assets {
         if let Some(pa) = project_assets.get(key) {
             for enc in &ca.encodings {
-                if !pa.encodings.contains_key(&enc.content_encoding) {
+                if !pa.encodings.contains_key(&enc.encoding) {
                     ops.push(Operation::UnsetAssetContent(UnsetAssetContentArguments {
                         key: key.clone(),
-                        content_encoding: enc.content_encoding.clone(),
+                        encoding: enc.encoding,
                     }));
                 }
             }
@@ -684,13 +685,13 @@ fn build_operations(
 
     // 4. Set content for every encoding that wasn't already in place.
     for (key, pa) in project_assets {
-        for (encoding, enc) in &pa.encodings {
+        for (&encoding, enc) in &pa.encodings {
             if enc.already_in_place {
                 continue;
             }
             ops.push(Operation::SetAssetContent(SetAssetContentArguments {
                 key: key.clone(),
-                content_encoding: encoding.clone(),
+                encoding,
                 chunk_ids: enc.chunk_ids.clone(),
                 sha256: ByteBuf::from(enc.sha256.clone()),
             }));
@@ -849,11 +850,11 @@ mod tests {
             .encodings
             .iter()
             .map(|(name, enc)| AssetEncodingDetails {
-                content_encoding: name.clone(),
+                encoding: *name,
                 sha256: serde_bytes::ByteBuf::from(enc.sha256.clone()),
             })
             .collect();
-        encodings.sort_by(|a, b| a.content_encoding.cmp(&b.content_encoding));
+        encodings.sort_by_key(|a| a.encoding);
         AssetDetails {
             key: not_found::ROOT_404_KEY.to_string(),
             content_type: asset.media_type.to_string(),
@@ -904,7 +905,7 @@ mod tests {
     fn mk_pending_asset(key: &str, encoding: &str, data: Vec<u8>) -> (String, ProjectAsset) {
         let mut enc_map = HashMap::new();
         enc_map.insert(
-            encoding.to_string(),
+            Encoding::from_token(encoding).expect("supported test encoding"),
             ProjectAssetEncoding {
                 chunk_ids: Vec::new(),
                 sha256: vec![0; 32],
@@ -936,7 +937,10 @@ mod tests {
         let mock = ChunkBatchRecorder::new();
         pack_and_upload_chunks(&mock, 1, &mut assets).unwrap();
         assert_eq!(*mock.batches.borrow(), vec![1]);
-        assert_eq!(assets["/f"].encodings["identity"].chunk_ids.len(), 1);
+        assert_eq!(
+            assets["/f"].encodings[&Encoding::Identity].chunk_ids.len(),
+            1
+        );
     }
 
     #[test]
@@ -952,7 +956,12 @@ mod tests {
         let mock = ChunkBatchRecorder::new();
         pack_and_upload_chunks(&mock, 1, &mut assets).unwrap();
         assert_eq!(*mock.batches.borrow(), vec![1, 1, 1, 1]);
-        assert_eq!(assets["/big"].encodings["identity"].chunk_ids.len(), 4);
+        assert_eq!(
+            assets["/big"].encodings[&Encoding::Identity]
+                .chunk_ids
+                .len(),
+            4
+        );
     }
 
     #[test]
@@ -1005,8 +1014,8 @@ mod tests {
         ]);
         let mock = ChunkBatchRecorder::new();
         pack_and_upload_chunks(&mock, 1, &mut assets).unwrap();
-        let a_ids = &assets["/a"].encodings["identity"].chunk_ids;
-        let b_ids = &assets["/b"].encodings["identity"].chunk_ids;
+        let a_ids = &assets["/a"].encodings[&Encoding::Identity].chunk_ids;
+        let b_ids = &assets["/b"].encodings[&Encoding::Identity].chunk_ids;
         assert_eq!(a_ids.len(), 2);
         assert_eq!(b_ids.len(), 1);
         let mut all: Vec<u64> = a_ids.iter().chain(b_ids.iter()).copied().collect();
@@ -1022,15 +1031,23 @@ mod tests {
         let mut assets = HashMap::from([mk_pending_asset("/empty", "identity", vec![])]);
         let mock = ChunkBatchRecorder::new();
         pack_and_upload_chunks(&mock, 1, &mut assets).unwrap();
-        assert_eq!(assets["/empty"].encodings["identity"].chunk_ids.len(), 1);
+        assert_eq!(
+            assets["/empty"].encodings[&Encoding::Identity]
+                .chunk_ids
+                .len(),
+            1
+        );
     }
 
     #[test]
     fn pack_skips_already_in_place_encodings() {
         // Nothing to upload → no calls made.
         let (k, mut pa) = mk_pending_asset("/skip", "identity", vec![0u8; 100]);
-        pa.encodings.get_mut("identity").unwrap().already_in_place = true;
-        pa.encodings.get_mut("identity").unwrap().data = Vec::new();
+        pa.encodings
+            .get_mut(&Encoding::Identity)
+            .unwrap()
+            .already_in_place = true;
+        pa.encodings.get_mut(&Encoding::Identity).unwrap().data = Vec::new();
         let mut assets = HashMap::from([(k, pa)]);
         let mock = ChunkBatchRecorder::new();
         pack_and_upload_chunks(&mock, 1, &mut assets).unwrap();
@@ -1053,7 +1070,7 @@ mod tests {
     fn set_content_op(key: &str) -> Operation {
         Operation::SetAssetContent(SetAssetContentArguments {
             key: key.to_string(),
-            content_encoding: "identity".to_string(),
+            encoding: Encoding::Identity,
             chunk_ids: vec![0u64],
             sha256: serde_bytes::ByteBuf::from(vec![0u8; 32]),
         })
@@ -1077,7 +1094,7 @@ mod tests {
         assert_eq!(
             header_bytes_of(&Operation::UnsetAssetContent(UnsetAssetContentArguments {
                 key: "/k".to_string(),
-                content_encoding: "identity".to_string(),
+                encoding: Encoding::Identity,
             })),
             0
         );
@@ -1255,7 +1272,7 @@ mod tests {
                 vec![1u64]
             };
             enc_map.insert(
-                name.to_string(),
+                Encoding::from_token(name).expect("supported test encoding"),
                 ProjectAssetEncoding {
                     chunk_ids,
                     sha256: sha.clone(),
@@ -1285,7 +1302,7 @@ mod tests {
         let encs = encodings
             .iter()
             .map(|(enc, sha)| AssetEncodingDetails {
-                content_encoding: enc.to_string(),
+                encoding: Encoding::from_token(enc).expect("supported test encoding"),
                 sha256: serde_bytes::ByteBuf::from(sha.clone()),
             })
             .collect();
@@ -1662,12 +1679,37 @@ mod tests {
         };
         let asset = prepare_asset(source, &[], &HashMap::new()).unwrap();
         assert!(
-            asset.encodings.contains_key("identity"),
+            asset.encodings.contains_key(&Encoding::Identity),
             "identity must be present"
         );
         assert!(
-            !asset.encodings.contains_key("gzip"),
+            !asset.encodings.contains_key(&Encoding::Gzip),
             "gzip must be absent when not smaller"
+        );
+    }
+
+    // A compressible asset whose content actually shrinks gets all three stored
+    // encodings: identity (always), plus gzip and brotli. This is the headline
+    // behaviour change — brotli is now produced alongside gzip for text-like
+    // content. Highly repetitive text guarantees both compressors beat identity,
+    // so neither is dropped by the keep-if-smaller guard.
+    #[test]
+    fn prepare_asset_keeps_gzip_and_brotli_for_compressible() {
+        use std::io::Write;
+        let mut f = tempfile::Builder::new().suffix(".css").tempfile().unwrap();
+        f.write_all("body { color: red; }\n".repeat(500).as_bytes())
+            .unwrap();
+        let source = AssetSource {
+            path: f.path().to_path_buf(),
+            key: "/style.css".to_string(),
+        };
+        let asset = prepare_asset(source, &[], &HashMap::new()).unwrap();
+        let mut encs: Vec<Encoding> = asset.encodings.keys().copied().collect();
+        encs.sort();
+        assert_eq!(
+            encs,
+            vec![Encoding::Identity, Encoding::Gzip, Encoding::Brotli],
+            "compressible content should store identity + gzip + brotli"
         );
     }
 
@@ -1697,7 +1739,7 @@ mod tests {
         // No override: mime_guess returns octet-stream, gzip is not selected.
         let without = prepare_asset(mk_source(), &[], &HashMap::new()).unwrap();
         assert_eq!(without.media_type.to_string(), "application/octet-stream");
-        assert!(!without.encodings.contains_key("gzip"));
+        assert!(!without.encodings.contains_key(&Encoding::Gzip));
 
         // With override to text/plain via `_headers`, both the media type
         // and the encoder pick change.
@@ -1706,7 +1748,7 @@ mod tests {
         let with = prepare_asset(mk_source(), &rules, &HashMap::new()).unwrap();
         assert_eq!(with.media_type.to_string(), "text/plain; charset=utf-8");
         assert!(
-            with.encodings.contains_key("gzip"),
+            with.encodings.contains_key(&Encoding::Gzip),
             "gzip should be selected for text/* override"
         );
     }
@@ -1725,7 +1767,7 @@ mod tests {
         assert_eq!(count_op(&ops, "SetAssetContent"), 1);
         assert!(!ops.iter().any(|op| matches!(
             op,
-            Operation::SetAssetContent(a) if a.content_encoding == "gzip"
+            Operation::SetAssetContent(a) if a.encoding == Encoding::Gzip
         )));
     }
 
@@ -2247,7 +2289,7 @@ mod tests {
                     key: "/notes.txt".to_string(),
                     content_type: "text/plain".to_string(),
                     encodings: vec![AssetEncodingDetails {
-                        content_encoding: "identity".to_string(),
+                        encoding: Encoding::Identity,
                         sha256: serde_bytes::ByteBuf::from(identity_sha),
                     }],
                     // Matches what `_headers` resolves to, so no SetAssetHeaders.
@@ -2391,7 +2433,7 @@ mod tests {
                     key: "/index.html".to_string(),
                     content_type: "text/html".to_string(),
                     encodings: vec![AssetEncodingDetails {
-                        content_encoding: "identity".to_string(),
+                        encoding: Encoding::Identity,
                         sha256: serde_bytes::ByteBuf::from(identity_sha),
                     }],
                     headers: vec![],

--- a/crates/wire-types/src/lib.rs
+++ b/crates/wire-types/src/lib.rs
@@ -28,6 +28,103 @@ pub use bundle_tag::{format_tag, BUNDLE_TAG};
 pub type SessionId = u64;
 pub type ChunkId = u64;
 
+/// The content encodings the canister and sync plugin support. A deliberately
+/// small, closed set — see `sync-core`'s `content` module for the
+/// simplicity / bandwidth / canister-storage trade-off behind which encodings
+/// are produced. Carried as a Candid variant (one byte on the wire) rather than
+/// a string, and used directly as the per-encoding map key in the canister's
+/// stable state.
+///
+/// `Identity` is the uncompressed form. It is a real, stored encoding (the
+/// fallback body served when nothing else is acceptable), but it is *not* a
+/// valid `Content-Encoding` response value — the IANA `identity` token exists
+/// only in the `Accept-Encoding` context — so it is never emitted as a header
+/// ([`Encoding::header_name`] returns `None`).
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, CandidType, Serialize, Deserialize,
+)]
+pub enum Encoding {
+    Identity,
+    Gzip,
+    Brotli,
+}
+
+impl Encoding {
+    /// Preference order for serving when the client expressed no usable
+    /// `Accept-Encoding`: identity first (uncompressed, maximally compatible),
+    /// then the compressed forms. Also the order encodings are certified in.
+    pub const PREFERENCE_ORDER: [Encoding; 3] =
+        [Encoding::Identity, Encoding::Gzip, Encoding::Brotli];
+
+    /// The HTTP coding token for this encoding (`identity` / `gzip` / `br`).
+    /// Always a real name, including for identity — use [`Self::header_name`]
+    /// when building the `Content-Encoding` response header.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Encoding::Identity => "identity",
+            Encoding::Gzip => "gzip",
+            Encoding::Brotli => "br",
+        }
+    }
+
+    /// The `Content-Encoding` response header value, or `None` for identity
+    /// (which must not carry the header).
+    pub const fn header_name(self) -> Option<&'static str> {
+        match self {
+            Encoding::Identity => None,
+            Encoding::Gzip => Some("gzip"),
+            Encoding::Brotli => Some("br"),
+        }
+    }
+
+    pub const fn is_identity(self) -> bool {
+        matches!(self, Encoding::Identity)
+    }
+
+    /// Parses a single `Accept-Encoding` / `Content-Encoding` coding token
+    /// (case-insensitive), ignoring any `;q=…` parameters. Returns `None` for
+    /// codings we don't support.
+    pub fn from_token(token: &str) -> Option<Self> {
+        let name = token.split(';').next().unwrap_or(token).trim();
+        if name.eq_ignore_ascii_case("identity") {
+            Some(Encoding::Identity)
+        } else if name.eq_ignore_ascii_case("gzip") {
+            Some(Encoding::Gzip)
+        } else if name.eq_ignore_ascii_case("br") {
+            Some(Encoding::Brotli)
+        } else {
+            None
+        }
+    }
+
+    /// Parses an `Accept-Encoding` header value into the supported encodings the
+    /// client will accept, in the client's listed order. Unsupported codings are
+    /// dropped, and a coding with an explicit `q=0` ("not acceptable") is
+    /// excluded. The listed order is preserved so callers can honour client
+    /// preference before falling back to [`Self::PREFERENCE_ORDER`].
+    pub fn parse_accept_encoding(value: &str) -> Vec<Encoding> {
+        value
+            .split(',')
+            .filter_map(|part| {
+                let enc = Encoding::from_token(part)?;
+                (!token_is_rejected(part)).then_some(enc)
+            })
+            .collect()
+    }
+}
+
+/// Whether an `Accept-Encoding` token carries an explicit `q=0`, marking the
+/// coding "not acceptable". Other `q` weights are ignored — we honour the
+/// client's listed order rather than reordering by weight.
+fn token_is_rejected(token: &str) -> bool {
+    token.split(';').skip(1).any(|param| {
+        let mut kv = param.splitn(2, '=');
+        let key = kv.next().unwrap_or("").trim();
+        let val = kv.next().unwrap_or("").trim();
+        key.eq_ignore_ascii_case("q") && val.parse::<f32>().map(|q| q <= 0.0).unwrap_or(false)
+    })
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub struct CreateAssetArguments {
     pub key: String,
@@ -39,7 +136,7 @@ pub struct CreateAssetArguments {
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub struct SetAssetContentArguments {
     pub key: String,
-    pub content_encoding: String,
+    pub encoding: Encoding,
     pub chunk_ids: Vec<ChunkId>,
     pub sha256: ByteBuf,
 }
@@ -48,7 +145,7 @@ pub struct SetAssetContentArguments {
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub struct UnsetAssetContentArguments {
     pub key: String,
-    pub content_encoding: String,
+    pub encoding: Encoding,
 }
 
 /// Delete an asset.
@@ -156,7 +253,7 @@ pub struct UploadChunksArguments {
 /// One encoding of an asset, as the `get_asset_details` query reports it.
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub struct AssetEncodingDetails {
-    pub content_encoding: String,
+    pub encoding: Encoding,
     pub sha256: ByteBuf,
 }
 
@@ -169,4 +266,86 @@ pub struct AssetDetails {
     pub encodings: Vec<AssetEncodingDetails>,
     pub content_type: String,
     pub headers: Vec<(String, String)>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Encoding::{self, Brotli, Gzip, Identity};
+
+    #[test]
+    fn header_name_omits_identity() {
+        assert_eq!(Identity.header_name(), None);
+        assert_eq!(Gzip.header_name(), Some("gzip"));
+        assert_eq!(Brotli.header_name(), Some("br"));
+        assert!(Identity.is_identity());
+        assert!(!Gzip.is_identity());
+    }
+
+    #[test]
+    fn label_is_always_a_name() {
+        assert_eq!(Identity.label(), "identity");
+        assert_eq!(Gzip.label(), "gzip");
+        assert_eq!(Brotli.label(), "br");
+    }
+
+    #[test]
+    fn from_token_is_case_insensitive_and_ignores_params() {
+        assert_eq!(Encoding::from_token("gzip"), Some(Gzip));
+        assert_eq!(Encoding::from_token("GZIP"), Some(Gzip));
+        assert_eq!(Encoding::from_token("br"), Some(Brotli));
+        assert_eq!(Encoding::from_token("identity"), Some(Identity));
+        assert_eq!(Encoding::from_token("  gzip ; q=0.5 "), Some(Gzip));
+        // Unsupported codings.
+        assert_eq!(Encoding::from_token("deflate"), None);
+        assert_eq!(Encoding::from_token("zstd"), None);
+        assert_eq!(Encoding::from_token("*"), None);
+    }
+
+    #[test]
+    fn parse_accept_encoding_keeps_client_order() {
+        assert_eq!(
+            Encoding::parse_accept_encoding("br, gzip, identity"),
+            vec![Brotli, Gzip, Identity]
+        );
+        assert_eq!(
+            Encoding::parse_accept_encoding("gzip, br"),
+            vec![Gzip, Brotli]
+        );
+    }
+
+    #[test]
+    fn parse_accept_encoding_ignores_q_weights_but_drops_q0() {
+        // Non-zero weights are kept, in listed order (we don't reorder by q).
+        assert_eq!(
+            Encoding::parse_accept_encoding("br;q=0.8, gzip;q=1.0"),
+            vec![Brotli, Gzip]
+        );
+        // q=0 means "not acceptable" — the fix for the bug where a weighted
+        // token like `gzip;q=1.0` used to match nothing and silently fall back
+        // to identity.
+        assert_eq!(
+            Encoding::parse_accept_encoding("gzip;q=0, br"),
+            vec![Brotli]
+        );
+        assert_eq!(
+            Encoding::parse_accept_encoding("gzip;q=0.000"),
+            Vec::<Encoding>::new()
+        );
+    }
+
+    #[test]
+    fn parse_accept_encoding_drops_unsupported_and_empty() {
+        assert_eq!(
+            Encoding::parse_accept_encoding("deflate, zstd, *"),
+            Vec::<Encoding>::new()
+        );
+        assert_eq!(Encoding::parse_accept_encoding(""), Vec::<Encoding>::new());
+    }
+
+    #[test]
+    fn preference_order_is_identity_first() {
+        assert_eq!(Encoding::PREFERENCE_ORDER, [Identity, Gzip, Brotli]);
+        // Ord matches declaration order, so it is a valid BTreeMap key ordering.
+        assert!(Identity < Gzip && Gzip < Brotli);
+    }
 }


### PR DESCRIPTION
## What

Replaces the stringly-typed content encoding with a shared **`Encoding`** enum (`{ Identity, Gzip, Brotli }`) in `wire-types`, and **activates Brotli** for compressible assets.

The field is named `encoding` (not `content_encoding`) deliberately: it spans both the `Accept-Encoding` and `Content-Encoding` header contexts — e.g. `Identity` is a valid `Accept-Encoding` value but never a `Content-Encoding` one.

### Type / wire
- `Encoding` is the single source of truth, used as the Candid wire type (a **one-byte variant** instead of `text`), the per-encoding `BTreeMap` key in the canister's stable `AssetMeta`, and the type threaded through `sync-core` (the old `Encoder` enum is gone).
- It owns the canonical mappings: `header_name()` returns `None` for identity, so the `Content-Encoding` header is omitted **structurally** — the `!= "identity"` string checks are retired.

### Behaviour
- **Brotli activated**: produced (q11) alongside gzip for compressible assets. Each compressed copy is kept only if it is actually smaller than identity (size guard), so tiny files don't store a "compressed" copy that's bigger.
- **Broadened the compressible set** to JSON, XML / `+xml` (catches SVG, XHTML, RSS/Atom), WASM, and uncompressed fonts (ttf/otf/eot). Images/media and `woff`/`woff2` (already compressed) stay uncompressed.
- **Fixed an Accept-Encoding bug**: parsing now strips `;q=` weights and drops `q=0`. Previously `Accept-Encoding: gzip;q=1.0` matched nothing and silently fell back to identity.
- Dropped the dead `compress`/`deflate`/`br` entries and the unknown-string tail of the old certification order; selection uses a closed preference order (identity-first fallback, client order honoured first).

Regenerated both `.did` files; the `service_equal` guard test passes.

### Compatibility
Stable-state shape changed (encodings keyed by a variant) and the Candid field was renamed — acceptable pre-launch (no deployed canisters; canister + plugin ship together).

## Storage note
Compressible assets now store a third copy (~25% of identity for text), bounded by the size guard. Images/media aren't compressed, so total storage typically rises only a few percent.

## Test plan
- `wire-types` 10 (Accept-Encoding parsing, q=0, header suppression, ordering)
- `canister-core` 86 — `serve_correct_encoding` asserts `br` selection from a weighted header + identity carries no `content-encoding`
- `sync-core` 195 — new test asserts compressible content stores identity + gzip + brotli
- `e2e` 17 against a live replica
- clippy + rustfmt clean; Candid `service_equal` guard passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)