### PR TITLE
feat: certified ETag and If-None-Match 304 handling

### DIFF
--- a/crates/canister-core/src/asset.rs
+++ b/crates/canister-core/src/asset.rs
@@ -57,10 +57,38 @@ pub fn is_html_content_type(content_type: &str) -> bool {
         .eq_ignore_ascii_case("text/html")
 }
 
+/// The canister-managed strong validator for an encoding: the content's
+/// SHA-256 as a quoted hex string, per RFC 7232 §2.3. The canister owns the
+/// `ETag` header outright — a custom `etag` in an asset's `_headers` is rejected
+/// at sync time (see `sync-core`), so the certified header set always carries
+/// exactly this value. That makes `If-None-Match` revalidation correct by
+/// construction: the validator *is* the content hash the 304 logic compares
+/// against.
+pub fn etag_value(sha256: &[u8; 32]) -> String {
+    format!("\"{}\"", hex::encode(sha256))
+}
+
+/// `effective_headers` with the canister-managed `etag` folded in. Any stray
+/// `etag` is stripped first so exactly one — ours — ends up certified and on
+/// the wire.
+fn effective_headers_with_etag(
+    effective_headers: &[(String, String)],
+    sha256: &[u8; 32],
+) -> Vec<(String, String)> {
+    let mut headers: Vec<(String, String)> = effective_headers
+        .iter()
+        .filter(|(name, _)| !name.eq_ignore_ascii_case("etag"))
+        .cloned()
+        .collect();
+    headers.push(("etag".to_string(), etag_value(sha256)));
+    headers
+}
+
 /// The certificate expression for an encoding, derived from the response's
 /// effective headers and the encoding name. The certified header set is
 /// `content-type` (implied by the expression template), plus `content-encoding`
-/// for non-identity encodings, plus the effective headers.
+/// for non-identity encodings, the effective headers, and the canister-managed
+/// `etag` (see [`etag_value`]).
 ///
 /// `effective_headers` is [`crate::state::State::effective_headers`]: the asset's
 /// own `_headers`, plus the canister-injected `ic_env` `set-cookie` on
@@ -69,16 +97,18 @@ pub fn is_html_content_type(content_type: &str) -> bool {
 pub fn certificate_expression_for(
     effective_headers: &[(String, String)],
     encoding: Encoding,
+    sha256: &[u8; 32],
 ) -> CertificateExpression {
+    let effective_headers = effective_headers_with_etag(effective_headers, sha256);
     build_ic_certificate_expression_from_headers_and_encoding(
-        effective_headers,
+        &effective_headers,
         encoding.header_name(),
     )
 }
 
 /// The full response header list for an encoding: `content-type`,
-/// `content-encoding` (non-identity), the effective headers, and the
-/// `IC-CertificateExpression` header.
+/// `content-encoding` (non-identity), the effective headers, the canister-managed
+/// `etag`, and the `IC-CertificateExpression` header.
 ///
 /// `effective_headers` (see [`certificate_expression_for`]) carries the asset's
 /// `_headers` **and** the canister-injected `ic_env` `set-cookie` on `text/html`
@@ -87,8 +117,10 @@ pub fn headers_for(
     effective_headers: &[(String, String)],
     content_type: &str,
     encoding: Encoding,
+    sha256: &[u8; 32],
 ) -> Vec<(String, String)> {
-    let cert_expr = certificate_expression_for(effective_headers, encoding);
+    let cert_expr = certificate_expression_for(effective_headers, encoding, sha256);
+    let effective_headers = effective_headers_with_etag(effective_headers, sha256);
     build_headers(
         effective_headers.iter().map(|(k, v)| (k, v)),
         content_type,
@@ -107,6 +139,7 @@ pub fn response_hashes_for(
     cert_expr: &CertificateExpression,
     sha256: &[u8; 32],
 ) -> HashMap<u16, [u8; 32]> {
+    let effective_headers = effective_headers_with_etag(effective_headers, sha256);
     let base_headers: Vec<(String, Value)> = build_headers(
         effective_headers.iter().map(|(k, v)| (k, v)),
         content_type,

--- a/crates/canister-core/src/redirect.rs
+++ b/crates/canister-core/src/redirect.rs
@@ -9,6 +9,11 @@ use ic_representation_independent_hash::Value;
 use sha2::Digest;
 use wire_types::{RedirectRule, RulePattern};
 
+// Convention: `http::StatusCode` is used wherever this module *reasons about* a
+// status — `from_u16` to validate untrusted rule input, `is_redirection` /
+// `is_client_error` to classify it. The serving and certification paths instead
+// use plain `u16` literals, since there a status is just a number emitted onto
+// the Candid wire or folded into a response hash. Pick by role, not for uniformity.
 const SUPPORTED_STATUS_CODES: &[StatusCode] = &[
     StatusCode::OK,
     StatusCode::MOVED_PERMANENTLY,

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -49,6 +49,26 @@ use wire_types::{
 /// until it sees a short or empty page; it never needs to know this value.
 pub const PAGE_SIZE: usize = 100;
 
+/// Parse an `If-None-Match` request header into the content hashes the client
+/// already holds. Our `ETag` is `"<hex sha256>"` (see [`crate::asset::etag_value`]),
+/// so each token is unquoted and hex-decoded back to a 32-byte hash; the weak
+/// prefix `W/` is stripped first (RFC 7232 §3.2 mandates the weak comparison for
+/// `If-None-Match`). Tokens we can't read as a 32-byte hash — `*`, or any
+/// validator we didn't mint — simply don't match, so the client gets a normal
+/// 200.
+fn parse_if_none_match(value: &str) -> Vec<Hash> {
+    value
+        .split(',')
+        .filter_map(|token| {
+            let token = token.trim();
+            let token = token.strip_prefix("W/").unwrap_or(token).trim();
+            let token = token.strip_prefix('"')?.strip_suffix('"')?;
+            let bytes = hex::decode(token).ok()?;
+            <[u8; 32]>::try_from(bytes.as_slice()).ok()
+        })
+        .collect()
+}
+
 type Mem = VirtualMemory<DefaultMemoryImpl>;
 
 const AUTHORIZED_MEMORY: MemoryId = MemoryId::new(0);
@@ -374,7 +394,7 @@ impl State {
         let effective_headers = self.effective_headers(meta);
         let path = AssetPath::from(key.as_str());
         for (&encoding, enc) in &meta.encodings {
-            let cert_expr = certificate_expression_for(&effective_headers, encoding);
+            let cert_expr = certificate_expression_for(&effective_headers, encoding, &enc.sha256);
             let response_hashes = response_hashes_for(
                 &effective_headers,
                 &meta.content_type,
@@ -570,7 +590,12 @@ impl State {
         etags: &[Hash],
         status_override: Option<u16>,
     ) -> HttpResponse {
-        let mut headers = headers_for(&self.effective_headers(meta), &meta.content_type, encoding);
+        let mut headers = headers_for(
+            &self.effective_headers(meta),
+            &meta.content_type,
+            encoding,
+            &enc.sha256,
+        );
         if let Some(head) = certificate_header {
             headers.push((head.0.clone(), head.1.clone()));
         }
@@ -587,21 +612,24 @@ impl State {
             token,
         });
 
-        let (status_code, body) = if let Some(status) = status_override {
-            (status, self.chunk_bytes(enc.content_id, chunk_index))
+        // The canister-managed `etag` header is already in `headers` (and in the
+        // certified set), so both the 200 and the 304 carry it.
+        let (status_code, body, streaming_strategy) = if let Some(status) = status_override {
+            (
+                status,
+                self.chunk_bytes(enc.content_id, chunk_index),
+                streaming_strategy,
+            )
         } else if etags.contains(&enc.sha256) {
-            (304, RcBytes::default())
+            // Conditional request matched: serve the certified 304 — empty body,
+            // no streaming. Its response hash is certified alongside the 200.
+            (304, RcBytes::default(), None)
         } else {
-            if !headers
-                .iter()
-                .any(|(header_name, _)| header_name.eq_ignore_ascii_case("etag"))
-            {
-                headers.push((
-                    "etag".to_string(),
-                    format!("\"{}\"", hex::encode(enc.sha256)),
-                ));
-            }
-            (200, self.chunk_bytes(enc.content_id, chunk_index))
+            (
+                200,
+                self.chunk_bytes(enc.content_id, chunk_index),
+                streaming_strategy,
+            )
         };
 
         HttpResponse {
@@ -672,11 +700,12 @@ impl State {
         callback: CallbackFunc,
     ) -> HttpResponse {
         let mut encodings: Vec<Encoding> = vec![];
-        // waiting for https://dfinity.atlassian.net/browse/BOUN-446
-        let etags = Vec::new();
+        let mut etags: Vec<Hash> = vec![];
         for (name, value) in req.headers.iter() {
             if name.eq_ignore_ascii_case("Accept-Encoding") {
                 encodings.extend(Encoding::parse_accept_encoding(value));
+            } else if name.eq_ignore_ascii_case("If-None-Match") {
+                etags.extend(parse_if_none_match(value));
             }
         }
 
@@ -849,7 +878,7 @@ impl State {
         let location = crate::redirect::tree_location(rule);
         let mut tree_paths = Vec::new();
         for (&encoding, enc) in &meta.encodings {
-            let cert_expr = certificate_expression_for(&effective_headers, encoding);
+            let cert_expr = certificate_expression_for(&effective_headers, encoding, &enc.sha256);
             let resp_hash = if status == 200 {
                 // The encoding's already-certified 200 response hash.
                 response_hashes_for(
@@ -862,11 +891,15 @@ impl State {
             } else {
                 // 4xx custom error page: re-certify with the override status
                 // using the same headers and body the asset would serve at 200.
-                let base_headers: Vec<(String, Value)> =
-                    headers_for(&effective_headers, &meta.content_type, encoding)
-                        .into_iter()
-                        .map(|(k, v)| (k, Value::String(v)))
-                        .collect();
+                let base_headers: Vec<(String, Value)> = headers_for(
+                    &effective_headers,
+                    &meta.content_type,
+                    encoding,
+                    &enc.sha256,
+                )
+                .into_iter()
+                .map(|(k, v)| (k, Value::String(v)))
+                .collect();
                 response_hash(&base_headers, status, &enc.sha256).0
             };
             let tp =

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -1406,7 +1406,7 @@ mod certificate_expression {
         );
         assert_eq!(
             lookup_header(&response, "ic-certificateexpression").unwrap(),
-            r#"default_certification(ValidationArgs{certification: Certification{no_request_certification: Empty{}, response_certification: ResponseCertification{certified_response_headers: ResponseHeaderList{headers: ["content-type", "Access-Control-Allow-Origin"]}}}})"#,
+            r#"default_certification(ValidationArgs{certification: Certification{no_request_certification: Empty{}, response_certification: ResponseCertification{certified_response_headers: ResponseHeaderList{headers: ["content-type", "Access-Control-Allow-Origin", "etag"]}}}})"#,
             "Missing ic-certifiedexpression header in response: {response:#?}",
         );
     }
@@ -1440,7 +1440,7 @@ mod certificate_expression {
         );
         assert_eq!(
             lookup_header(&response, "ic-certificateexpression").unwrap(),
-            r#"default_certification(ValidationArgs{certification: Certification{no_request_certification: Empty{}, response_certification: ResponseCertification{certified_response_headers: ResponseHeaderList{headers: ["content-type", "content-encoding", "Access-Control-Allow-Origin"]}}}})"#,
+            r#"default_certification(ValidationArgs{certification: Certification{no_request_certification: Empty{}, response_certification: ResponseCertification{certified_response_headers: ResponseHeaderList{headers: ["content-type", "content-encoding", "Access-Control-Allow-Origin", "etag"]}}}})"#,
             "Missing ic-certificateexpression header in response: {response:#?}",
         );
 
@@ -1463,7 +1463,7 @@ mod certificate_expression {
         );
         assert_eq!(
             lookup_header(&response, "ic-certificateexpression").unwrap(),
-            r#"default_certification(ValidationArgs{certification: Certification{no_request_certification: Empty{}, response_certification: ResponseCertification{certified_response_headers: ResponseHeaderList{headers: ["content-type", "content-encoding", "custom-header"]}}}})"#,
+            r#"default_certification(ValidationArgs{certification: Certification{no_request_certification: Empty{}, response_certification: ResponseCertification{certified_response_headers: ResponseHeaderList{headers: ["content-type", "content-encoding", "custom-header", "etag"]}}}})"#,
             "Missing ic-certifiedexpression header in response: {response:#?}",
         );
     }
@@ -1531,13 +1531,14 @@ mod certification {
 
     #[test]
     fn etag() {
-        // For now only checks that defining a custom etag doesn't break certification.
-        // Serving HTTP 304 responses if the etag matches is part of https://dfinity.atlassian.net/browse/SDK-191
-
+        // The canister owns the `ETag`: it emits a certified `"<hex sha256>"`,
+        // and a custom `etag` smuggled into the asset headers is stripped (it
+        // does not appear on the wire) rather than served.
         let mut state = State::default();
         let system_context = mock_system_context();
 
         const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
+        let expected_etag = format!("\"{}\"", hex::encode(sha2::Sha256::digest(BODY)));
 
         create_assets(
             &mut state,
@@ -1553,10 +1554,59 @@ mod certification {
                 .with_header("Accept-Encoding", "gzip,identity")
                 .build(),
         );
+        assert_eq!(response.status_code, 200);
         assert_eq!(
-            lookup_header(&response, "etag").expect("ic-certificate header missing"),
-            "my-etag"
+            lookup_header(&response, "etag").expect("etag header missing"),
+            expected_etag,
+            "canister must serve its content-hash etag, not the custom one"
         );
+    }
+
+    #[test]
+    fn conditional_request_serves_certified_304() {
+        // A request whose `If-None-Match` carries the asset's current etag gets a
+        // certified 304 with an empty body; `certified_http_request` verifies the
+        // certificate, so this also proves the 304 is cryptographically valid (as
+        // a real HTTP gateway would require).
+        let mut state = State::default();
+        let system_context = mock_system_context();
+
+        const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
+        let etag = format!("\"{}\"", hex::encode(sha2::Sha256::digest(BODY)));
+
+        create_assets(
+            &mut state,
+            &system_context,
+            vec![AssetBuilder::new("/contents.html", "text/html")
+                .with_encoding("identity", vec![BODY])],
+        );
+
+        // Matching etag -> certified 304, empty body, no streaming.
+        let not_modified = certified_http_request(
+            &state,
+            RequestBuilder::get("/contents.html")
+                .with_header("Accept-Encoding", "identity")
+                .with_header("If-None-Match", &etag)
+                .build(),
+        );
+        assert_eq!(not_modified.status_code, 304);
+        assert!(not_modified.body.is_empty());
+        assert!(not_modified.streaming_strategy.is_none());
+        assert_eq!(lookup_header(&not_modified, "etag").unwrap(), etag);
+
+        // A stale etag still serves the full, certified 200.
+        let modified = certified_http_request(
+            &state,
+            RequestBuilder::get("/contents.html")
+                .with_header("Accept-Encoding", "identity")
+                .with_header(
+                    "If-None-Match",
+                    "\"0000000000000000000000000000000000000000000000000000000000000000\"",
+                )
+                .build(),
+        );
+        assert_eq!(modified.status_code, 200);
+        assert_eq!(modified.body.as_ref(), BODY);
     }
 }
 

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -148,15 +148,29 @@ pub fn gateway_url(project: &Path) -> String {
 /// `IC-Certificate` — if certification fails, the gateway short-circuits
 /// before the response reaches the caller.
 pub fn http_fetch(project: &Path, path: &str) -> reqwest::blocking::Response {
+    http_fetch_with_headers(project, path, &[])
+}
+
+/// Like [`http_fetch`], but attaches arbitrary request headers — e.g. an
+/// `If-None-Match` to exercise conditional-request / 304 handling end to end
+/// through the gateway.
+pub fn http_fetch_with_headers(
+    project: &Path,
+    path: &str,
+    headers: &[(&str, &str)],
+) -> reqwest::blocking::Response {
     let cid = frontend_canister_id(project);
     let base = gateway_url(project);
     let url = format!("{base}{path}?canisterId={cid}");
-    reqwest::blocking::Client::builder()
+    let mut req = reqwest::blocking::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .build()
         .expect("build reqwest client")
-        .get(&url)
-        .send()
+        .get(&url);
+    for (name, value) in headers {
+        req = req.header(*name, *value);
+    }
+    req.send()
         .unwrap_or_else(|e| panic!("GET {url} failed: {e}"))
 }
 

--- a/crates/e2e/tests/etag.rs
+++ b/crates/e2e/tests/etag.rs
@@ -1,0 +1,62 @@
+//! End-to-end test for ETag / conditional requests through the HTTP gateway.
+//!
+//! The gateway validates the response's `IC-Certificate` before returning it,
+//! so a 304 that reaches the caller is proof the canister served a *certified*
+//! 304 — exactly the property that lets ETag work without any gateway-side
+//! support (BOUN-446 was closed "won't do" for this reason).
+
+use e2e::{http_fetch, http_fetch_with_headers, icp_cmd, setup_project, LocalNetwork};
+use reqwest::StatusCode;
+
+fn etag_of(headers: &reqwest::header::HeaderMap) -> String {
+    headers
+        .get("etag")
+        .and_then(|v| v.to_str().ok())
+        .expect("response must carry an ETag")
+        .to_string()
+}
+
+/// Deploy, read an asset's ETag, then revalidate with `If-None-Match`:
+/// a matching validator yields a certified 304 with an empty body, while a
+/// stale validator still serves the full 200.
+#[test]
+fn conditional_request_yields_certified_304() {
+    let tmp = setup_project("tests/fixture/basic");
+    let project = tmp.path();
+    let _network = LocalNetwork::start(project);
+
+    icp_cmd(project).arg("deploy").assert().success();
+
+    // First load: full body + a canister-minted ETag (the content hash).
+    let r = http_fetch(project, "/index.html");
+    assert_eq!(r.status(), StatusCode::OK);
+    let etag = etag_of(r.headers());
+    assert!(
+        etag.starts_with('"') && etag.ends_with('"'),
+        "ETag should be a quoted strong validator, got {etag}"
+    );
+    assert!(!r.bytes().unwrap().is_empty(), "200 should carry a body");
+
+    // Revalidate with the matching ETag: certified 304, empty body. The fetch
+    // succeeding at all means the gateway accepted the certified 304.
+    let not_modified = http_fetch_with_headers(project, "/index.html", &[("If-None-Match", &etag)]);
+    assert_eq!(not_modified.status(), StatusCode::NOT_MODIFIED);
+    assert_eq!(
+        etag_of(not_modified.headers()),
+        etag,
+        "304 should echo the ETag (RFC 7232 §4.1)"
+    );
+    assert!(
+        not_modified.bytes().unwrap().is_empty(),
+        "304 must have an empty body"
+    );
+
+    // A stale validator does not match: full, certified 200 again.
+    let stale = "\"0000000000000000000000000000000000000000000000000000000000000000\"";
+    let modified = http_fetch_with_headers(project, "/index.html", &[("If-None-Match", stale)]);
+    assert_eq!(modified.status(), StatusCode::OK);
+    assert!(
+        !modified.bytes().unwrap().is_empty(),
+        "stale If-None-Match should serve the full body"
+    );
+}

--- a/crates/sync-core/src/headers.rs
+++ b/crates/sync-core/src/headers.rs
@@ -248,6 +248,13 @@ fn parse_header(stripped: &str) -> Result<ParsedHeader, String> {
             .map_err(|e| format!("invalid `Content-Type` value '{value}': {e}"))?;
         return Ok(ParsedHeader::ContentType(mime));
     }
+    if name.eq_ignore_ascii_case("etag") {
+        return Err(
+            "`ETag` is managed by the canister (it is derived from the content hash); \
+             remove it from `_headers`"
+                .to_string(),
+        );
+    }
     if value.contains(":splat") || value.contains(":placeholder") {
         return Err(format!(
             "':splat' / ':placeholder' substitution in header value ('{value}') \
@@ -486,6 +493,17 @@ mod tests {
             rules[0].content_type.as_ref().unwrap().to_string(),
             "text/markdown; charset=utf-8"
         );
+    }
+
+    #[test]
+    fn rejects_custom_etag() {
+        // `ETag` is canister-managed (derived from the content hash); a custom
+        // one in `_headers` is rejected so there is exactly one, trustworthy
+        // validator on the wire.
+        for line in ["  ETag: \"v1\"\n", "  etag: \"v1\"\n"] {
+            let e = err(&format!("/app.js\n{line}"));
+            assert!(e.message.contains("ETag"), "{}", e.message);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Turns the parked ETag plumbing into a live, certified mechanism. The HTTP gateway needs no special support — [BOUN-446 was closed "won't do"](https://dfinity.atlassian.net/browse/BOUN-446) for exactly this reason: the canister owns conditional requests and replies with a **certified 304** when the client's `If-None-Match` matches the asset's content hash.

## What changed

- **The canister owns the `ETag` outright.** A custom `etag` in `_headers` is now rejected at sync time (the `sync-core` parser), so there is exactly one strong validator on the wire: `"<hex sha256>"`, derived from the content hash. This keeps the 304 match correct by construction (the validator *is* the content hash) and removes a stale-cache footgun.
- **The `ETag` is now part of the _certified_ header set.** Generation moved from a serve-time append into the shared `build_headers` chokepoint, threading the encoding `sha256` through `certificate_expression_for` / `headers_for` / `response_hashes_for`. Cert and serve agree by construction, and the `ETag` is certified on 200, 304, and alias (200/404/410) responses. Synthetic 3xx redirects correctly don't carry one.
- **`If-None-Match` is now honored.** `http_request` parses the header (strips `W/`, unquotes, hex-decodes to a 32-byte hash) and populates the previously-dead `etags` vec, so the existing 304 branch fires. Streaming is suppressed on the 304 (a latent bug — a multi-chunk 304 would otherwise carry a callback token).

## Tests

- Reworked the `etag` unit test: the canister serves its content-hash etag and *strips* a smuggled custom one.
- New `conditional_request_serves_certified_304` unit test, cryptographically verified via `ic_response_verification` (matching → 304 empty body / no streaming; stale → 200).
- New e2e test that drives a real conditional request through icp-cli's bundled gateway and gets a 304 back — proof the certified 304 is gateway-valid.

All green: canister-core (99), sync-core (196), full e2e suite (incl. redirects/aliases which now carry the etag), clippy clean.

## Notes

- `If-None-Match: *` for GET is intentionally not special-cased (rare for a static host; documented in `parse_if_none_match`).
- Includes a convention note near `SUPPORTED_STATUS_CODES` documenting when to use `http::StatusCode` (validate/classify) vs numeric `u16` (emit on the wire / in hashes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)