### PR TITLE
fix: streaming callback returns non-opt StreamingCallbackHttpResponse

### DIFF
--- a/certified-assets.did
+++ b/certified-assets.did
@@ -50,7 +50,7 @@ type StreamingCallbackHttpResponse = record {
 
 type StreamingStrategy = variant {
   Callback: record {
-    callback: func (StreamingToken) -> (opt StreamingCallbackHttpResponse) query;
+    callback: func (StreamingToken) -> (StreamingCallbackHttpResponse) query;
     token: StreamingToken;
   };
 };
@@ -208,7 +208,7 @@ service: {
   // https://docs.internetcomputer.org/references/http-gateway-protocol-spec/
 
   http_request: (request: HttpRequest) -> (HttpResponse) query;
-  http_request_streaming_callback: (token: StreamingToken) -> (opt StreamingCallbackHttpResponse) query;
+  http_request_streaming_callback: (token: StreamingToken) -> (StreamingCallbackHttpResponse) query;
 
   // ───────── Asset queries ─────────
 

--- a/crates/canister-core/src/http.rs
+++ b/crates/canister-core/src/http.rs
@@ -34,7 +34,7 @@ pub struct StreamingCallbackToken {
     pub sha256: ByteBuf,
 }
 
-define_function!(pub CallbackFunc : (StreamingCallbackToken) -> (Option<StreamingCallbackHttpResponse>) query);
+define_function!(pub CallbackFunc : (StreamingCallbackToken) -> (StreamingCallbackHttpResponse) query);
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub enum StreamingStrategy {
     Callback {

--- a/crates/canister-core/src/lib.rs
+++ b/crates/canister-core/src/lib.rs
@@ -127,12 +127,10 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
 
 pub fn http_request_streaming_callback(
     token: StreamingCallbackToken,
-) -> Option<StreamingCallbackHttpResponse> {
+) -> StreamingCallbackHttpResponse {
     STATE.with_borrow(|s| {
-        Some(
-            s.http_request_streaming_callback(token)
-                .unwrap_or_else(|msg| trap(&msg)),
-        )
+        s.http_request_streaming_callback(token)
+            .unwrap_or_else(|msg| trap(&msg))
     })
 }
 

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -915,6 +915,174 @@ fn uses_streaming_for_multichunk_assets() {
 }
 
 #[test]
+fn streams_three_chunks_chaining_continuation_tokens() {
+    let mut state = State::default();
+    let system_context = mock_system_context();
+
+    // Three chunks exercise the mid-stream case a 2-chunk asset never reaches:
+    // the callback must itself return a *continuation* token (not a terminator)
+    // for the middle chunk.
+    const C0: &[u8] = b"chunk-zero-";
+    const C1: &[u8] = b"chunk-one--";
+    const C2: &[u8] = b"chunk-two";
+
+    create_assets(
+        &mut state,
+        &system_context,
+        vec![
+            AssetBuilder::new("/big.html", "text/html").with_encoding("identity", vec![C0, C1, C2])
+        ],
+    );
+
+    let streaming_callback = CallbackFunc::new(some_principal(), "stream".to_string());
+    let response = state.http_request(
+        RequestBuilder::get("/big.html").build(),
+        &[],
+        streaming_callback.clone(),
+    );
+
+    // First response: 200 with chunk 0 inline and a strategy pointing at chunk 1.
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.body.as_ref(), C0);
+    let StreamingStrategy::Callback { callback, token } = response
+        .streaming_strategy
+        .expect("missing streaming strategy");
+    assert_eq!(callback, streaming_callback);
+    assert_eq!(token.index, Nat::from(1_u8));
+
+    // Middle chunk: the callback returns chunk 1 *and* a continuation token for
+    // chunk 2 — the branch that never fires with only two chunks.
+    let second = state.http_request_streaming_callback(token).unwrap();
+    assert_eq!(second.body.as_ref(), C1);
+    let next = second
+        .token
+        .expect("expected a continuation token for the final chunk");
+    assert_eq!(next.index, Nat::from(2_u8));
+
+    // Final chunk: body served, token is None to end the stream.
+    let third = state.http_request_streaming_callback(next).unwrap();
+    assert_eq!(third.body.as_ref(), C2);
+    assert!(
+        third.token.is_none(),
+        "stream must terminate after the last chunk: {third:?}"
+    );
+}
+
+#[test]
+fn streams_multichunk_non_identity_encoding() {
+    let mut state = State::default();
+    let system_context = mock_system_context();
+
+    // A gzip encoding split across two chunks: streaming must work for an
+    // encoding that also emits a `content-encoding` header, not just identity.
+    const GZIP_CHUNK_1: &[u8] = b"\x1f\x8b\x08\x00fake-gzip-bytes-1";
+    const GZIP_CHUNK_2: &[u8] = b"fake-gzip-bytes-2";
+
+    create_assets(
+        &mut state,
+        &system_context,
+        vec![AssetBuilder::new("/app.js", "text/javascript")
+            .with_encoding("gzip", vec![GZIP_CHUNK_1, GZIP_CHUNK_2])],
+    );
+
+    let streaming_callback = CallbackFunc::new(some_principal(), "stream".to_string());
+    let response = state.http_request(
+        RequestBuilder::get("/app.js")
+            .with_header("Accept-Encoding", "gzip")
+            .build(),
+        &[],
+        streaming_callback.clone(),
+    );
+
+    assert_eq!(response.status_code, 200);
+    assert_eq!(response.body.as_ref(), GZIP_CHUNK_1);
+    assert_eq!(lookup_header(&response, "content-encoding"), Some("gzip"));
+
+    let StreamingStrategy::Callback { callback, token } = response
+        .streaming_strategy
+        .expect("missing streaming strategy");
+    assert_eq!(callback, streaming_callback);
+    assert_eq!(token.encoding, Encoding::Gzip);
+
+    let second = state.http_request_streaming_callback(token).unwrap();
+    assert_eq!(second.body.as_ref(), GZIP_CHUNK_2);
+    assert!(second.token.is_none(), "stream should end after chunk 2");
+}
+
+#[test]
+fn single_chunk_asset_has_no_streaming_strategy() {
+    let mut state = State::default();
+    let system_context = mock_system_context();
+
+    create_assets(
+        &mut state,
+        &system_context,
+        vec![AssetBuilder::new("/small.html", "text/html")
+            .with_encoding("identity", vec![b"<html></html>"])],
+    );
+
+    let response = state.http_request(
+        RequestBuilder::get("/small.html").build(),
+        &[],
+        unused_callback(),
+    );
+
+    assert_eq!(response.status_code, 200);
+    assert!(
+        response.streaming_strategy.is_none(),
+        "a single-chunk asset must not advertise streaming: {response:?}"
+    );
+}
+
+#[test]
+fn streaming_callback_rejects_unknown_key() {
+    let mut state = State::default();
+    let system_context = mock_system_context();
+
+    create_assets(
+        &mut state,
+        &system_context,
+        vec![AssetBuilder::new("/index.html", "text/html")
+            .with_encoding("identity", vec![b"a", b"b"])],
+    );
+
+    let err = state
+        .http_request_streaming_callback(StreamingCallbackToken {
+            key: "/does-not-exist.html".to_string(),
+            encoding: Encoding::Identity,
+            index: Nat::from(1_u8),
+            sha256: ByteBuf::from([0u8; 32].as_slice()),
+        })
+        .unwrap_err();
+    assert_eq!(err, "Invalid token on streaming: key not found.");
+}
+
+#[test]
+fn streaming_callback_rejects_unknown_encoding() {
+    let mut state = State::default();
+    let system_context = mock_system_context();
+
+    // Asset exists with only an identity encoding; a token naming gzip must be
+    // rejected before the sha256 is even consulted.
+    create_assets(
+        &mut state,
+        &system_context,
+        vec![AssetBuilder::new("/index.html", "text/html")
+            .with_encoding("identity", vec![b"a", b"b"])],
+    );
+
+    let err = state
+        .http_request_streaming_callback(StreamingCallbackToken {
+            key: "/index.html".to_string(),
+            encoding: Encoding::Gzip,
+            index: Nat::from(1_u8),
+            sha256: ByteBuf::from([0u8; 32].as_slice()),
+        })
+        .unwrap_err();
+    assert_eq!(err, "Invalid token on streaming: encoding not found.");
+}
+
+#[test]
 fn supports_cache_control_via_headers() {
     let mut state = State::default();
     let system_context = mock_system_context();

--- a/crates/canister/src/lib.rs
+++ b/crates/canister/src/lib.rs
@@ -34,9 +34,7 @@ fn http_request(req: HttpRequest) -> HttpResponse {
 }
 
 #[query]
-fn http_request_streaming_callback(
-    token: StreamingCallbackToken,
-) -> Option<StreamingCallbackHttpResponse> {
+fn http_request_streaming_callback(token: StreamingCallbackToken) -> StreamingCallbackHttpResponse {
     canister_core::http_request_streaming_callback(token)
 }
 

--- a/crates/e2e/tests/streaming.rs
+++ b/crates/e2e/tests/streaming.rs
@@ -1,0 +1,70 @@
+use e2e::{http_fetch_with_headers, icp_cmd, setup_project, LocalNetwork};
+use reqwest::StatusCode;
+use std::fs;
+
+/// Deterministic, incompressible bytes via a xorshift64 PRNG. Incompressibility
+/// matters: it keeps the asset a single `Identity` encoding (the sync plugin
+/// only stores a compressed copy when it is actually smaller), so the encoding
+/// the gateway serves is unambiguous and the served bytes equal what we wrote.
+fn incompressible_bytes(len: usize) -> Vec<u8> {
+    let mut state: u64 = 0x9e3779b97f4a7c15;
+    let mut out = Vec::with_capacity(len + 8);
+    while out.len() < len {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        out.extend_from_slice(&state.to_le_bytes());
+    }
+    out.truncate(len);
+    out
+}
+
+/// A multi-megabyte asset must round-trip byte-for-byte through the HTTP gateway.
+///
+/// This is the one property the `canister-core` unit tests structurally cannot
+/// cover: that an asset larger than a single `http_request` response actually
+/// reassembles correctly via the streaming-callback protocol *and* that the
+/// reassembled body verifies against the certified hash.
+///
+/// - The body is ~5 MB, well over 2 × `MAX_CHUNK_SIZE` (1.9 MB), so the canister
+///   stores it as three chunks. A single query response is capped far below that,
+///   so the full body can only come back intact via streaming callbacks — a
+///   broken stream would truncate to the first chunk.
+/// - `http_fetch_*` goes through the boundary node, which validates the
+///   `IC-Certificate` before returning anything. An exact-match fetch therefore
+///   also proves the streamed reassembly matches the certified content hash.
+#[test]
+fn streams_large_asset_through_gateway() {
+    let tmp = setup_project("tests/fixture/basic");
+    let project = tmp.path();
+
+    let body = incompressible_bytes(5_000_000);
+    fs::write(project.join("dist/large.bin"), &body).expect("write large asset into fixture");
+
+    let _network = LocalNetwork::start(project);
+    icp_cmd(project).arg("deploy").assert().success();
+
+    // `Accept-Encoding: identity` pins the served encoding and stops reqwest /
+    // the gateway from negotiating compression, so the bytes we compare are the
+    // raw asset bytes.
+    let response =
+        http_fetch_with_headers(project, "/large.bin", &[("Accept-Encoding", "identity")]);
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let fetched = response
+        .bytes()
+        .expect("read streamed response body")
+        .to_vec();
+    assert_eq!(
+        fetched.len(),
+        body.len(),
+        "streamed body length mismatch: got {} bytes, expected {} \
+         (a truncated body means streaming did not reassemble all chunks)",
+        fetched.len(),
+        body.len(),
+    );
+    assert!(
+        fetched == body,
+        "streamed body bytes differ from the uploaded asset",
+    );
+}


### PR DESCRIPTION
## What

Serving any **multi-chunk** asset (> `MAX_CHUNK_SIZE`, 1.9 MB) through the HTTP gateway returned **HTTP 503**. The fix: `http_request_streaming_callback` now returns a bare `StreamingCallbackHttpResponse` instead of `opt StreamingCallbackHttpResponse`.

## Root cause

The HTTP gateway follows the streaming callback via `ic-agent`, which decodes the reply into a **non-optional** `(StreamingCallbackHttpResponse,)`. We returned `opt ...`, and candid cannot coerce wire-type `opt T` into the expected `T` (subtype-incomparable), so the gateway failed with `AgentError::CandidError` ("Candid returned an error") and served 503. The first `http_request` response decodes fine, so single-chunk assets worked and no existing test exercised the callback decode path.

This means `opt` was a real bug even though it matches the **written** [HTTP Gateway Protocol spec](https://docs.internetcomputer.org/references/http-gateway-protocol-spec/#canister-http-interface). The spec text is stale: ic-agent and the SDK reference asset canister's *actual wasm* both use non-opt (the SDK's hand-written `.did` says `opt` but its Rust returns non-opt). A separate docs PR will correct the spec.

## Changes

- Drop `Option`/`opt` from the callback return type in three places: the `#[query]` method, `certified-assets.did`, and the `StreamingStrategy` callback func type (`define_function!`).
- **e2e test** (`crates/e2e/tests/streaming.rs`): generates a ~5 MB (3-chunk) incompressible asset on the fly, deploys it, and asserts it round-trips byte-for-byte through the local gateway. A >2 MB body can only return intact via streaming callbacks, and the gateway validates the certificate before responding — so this also proves certified reassembly.
- **canister-core unit tests**: 3-chunk continuation token (the mid-stream case a 2-chunk asset never reaches), non-identity (gzip) multi-chunk streaming, single-chunk assets advertise no streaming strategy, and the callback's unknown-key / unknown-encoding error paths.

## Testing

- `cargo test -p canister-core` — 104 pass
- `cargo test -p canister candid_interface_compatibility` — pass
- `cargo test -p e2e` — full suite pass (streaming round-trips through the gateway; previously 503)
- `cargo fmt --check`, `cargo clippy --workspace --all-targets` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
