### PR TITLE
perf: self-describing streaming token (drop per-callback metadata.get)

### DIFF
--- a/certified-assets.did
+++ b/certified-assets.did
@@ -28,18 +28,18 @@ type HttpResponse = record {
 // small, closed set (see `wire-types::Encoding`). Carried as a variant
 // (one byte on the wire) rather than a string. `Identity` is the uncompressed
 // form; it is a real stored encoding but never emitted as a `Content-Encoding`
-// header. Defined up here so both the streaming token and the asset types below
-// can reference it.
+// header. Defined up here so the asset types below can reference it.
 type Encoding = variant { Identity; Gzip; Brotli };
 
 // Each canister that uses the streaming feature gets to choose their concrete
 // type; the HTTP Gateway will treat it as an opaque value that is only fed to
-// the callback method. This is the assets canister's concrete token.
-
+// the callback method. This is the assets canister's concrete token — fully
+// self-describing, so the callback serves the next chunk straight from the
+// content store (`content_id`) without reloading any per-asset metadata.
 type StreamingToken = record {
-  key: text;
-  encoding: Encoding;
-  index: nat;
+  content_id: nat64;
+  index: nat32;
+  num_chunks: nat32;
   sha256: blob;
 };
 

--- a/crates/canister-core/canbench_results.yml
+++ b/crates/canister-core/canbench_results.yml
@@ -2,28 +2,28 @@ benches:
   post_upgrade_rebuild:
     total:
       calls: 1
-      instructions: 126827488
+      instructions: 126812761
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   serve_large_asset:
     total:
       calls: 1
-      instructions: 21606853
+      instructions: 21381421
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   serve_small_asset:
     total:
       calls: 1
-      instructions: 156574
+      instructions: 156840
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   sync_commit:
     total:
       calls: 1
-      instructions: 91502274
+      instructions: 91492482
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}

--- a/crates/canister-core/src/benches.rs
+++ b/crates/canister-core/src/benches.rs
@@ -266,9 +266,7 @@ fn serve_large_asset() -> BenchResult {
             .streaming_strategy
             .map(|StreamingStrategy::Callback { token, .. }| token);
         while let Some(t) = token {
-            let next = state
-                .http_request_streaming_callback(t)
-                .expect("streaming callback");
+            let next = state.http_request_streaming_callback(t);
             std::hint::black_box(&next.body);
             token = next.token;
         }

--- a/crates/canister-core/src/http.rs
+++ b/crates/canister-core/src/http.rs
@@ -2,9 +2,8 @@ use crate::certification::{
     build_ic_certificate_expression_from_headers, build_ic_certificate_expression_header,
 };
 use crate::rc_bytes::RcBytes;
-use candid::{define_function, CandidType, Deserialize, Nat};
+use candid::{define_function, CandidType, Deserialize};
 use serde_bytes::ByteBuf;
-use wire_types::Encoding;
 
 pub type HeaderField = (String, String);
 
@@ -28,9 +27,16 @@ pub struct HttpResponse {
 
 #[derive(Clone, Debug, CandidType, Deserialize)]
 pub struct StreamingCallbackToken {
-    pub key: String,
-    pub encoding: Encoding,
-    pub index: Nat,
+    /// Content group to stream from. Carrying it lets the streaming callback
+    /// read chunks straight from the content store, with no `AssetMeta`
+    /// lookup/decode per chunk — the token is fully self-describing.
+    pub content_id: u64,
+    /// Index of the chunk this token requests.
+    pub index: u32,
+    /// Total chunks in the content group; the callback emits a follow-on token
+    /// while `index + 1 < num_chunks`.
+    pub num_chunks: u32,
+    /// Full-asset hash, carried for the HTTP gateway's streamed-response check.
     pub sha256: ByteBuf,
 }
 
@@ -50,21 +56,25 @@ pub struct StreamingCallbackHttpResponse {
 }
 
 impl StreamingCallbackToken {
+    /// Builds the token for the chunk *after* `chunk_index`, or `None` when
+    /// `chunk_index` is the last chunk. Self-contained: it carries
+    /// `content_id`/`num_chunks`/`sha256` so the streaming callback can serve
+    /// the next chunk without ever reloading the asset's `AssetMeta`.
     pub fn create_token(
-        encoding: Encoding,
-        content_chunks_count: usize,
-        content_sha256: [u8; 32],
-        key: &str,
+        content_id: u64,
+        num_chunks: u32,
+        sha256: ByteBuf,
         chunk_index: usize,
     ) -> Option<Self> {
-        if chunk_index + 1 >= content_chunks_count {
+        let next_index = chunk_index + 1;
+        if next_index >= num_chunks as usize {
             None
         } else {
             Some(StreamingCallbackToken {
-                key: key.to_string(),
-                encoding,
-                index: Nat::from(chunk_index + 1),
-                sha256: ByteBuf::from(content_sha256),
+                content_id,
+                index: next_index as u32,
+                num_chunks,
+                sha256,
             })
         }
     }

--- a/crates/canister-core/src/lib.rs
+++ b/crates/canister-core/src/lib.rs
@@ -131,10 +131,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
 pub fn http_request_streaming_callback(
     token: StreamingCallbackToken,
 ) -> StreamingCallbackHttpResponse {
-    STATE.with_borrow(|s| {
-        s.http_request_streaming_callback(token)
-            .unwrap_or_else(|msg| trap(&msg))
-    })
+    STATE.with_borrow(|s| s.http_request_streaming_callback(token))
 }
 
 /// Whether the current caller may sync assets: either in the authorized set, or

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -33,7 +33,6 @@ use ic_certification::{AsHashTree, Hash};
 use ic_representation_independent_hash::Value;
 use ic_stable_structures::memory_manager::{MemoryId, MemoryManager, VirtualMemory};
 use ic_stable_structures::{DefaultMemoryImpl, StableBTreeMap, StableCell};
-use num_traits::ToPrimitive;
 use serde_bytes::ByteBuf;
 use std::collections::BTreeMap;
 use std::convert::TryInto;
@@ -490,7 +489,6 @@ impl State {
             if let Some(response) = self.build_asset_response(
                 &meta,
                 &requested_encodings,
-                path,
                 chunk_index,
                 Some(&cert_header),
                 &callback,
@@ -539,7 +537,6 @@ impl State {
         &self,
         meta: &AssetMeta,
         requested_encodings: &[Encoding],
-        key: &str,
         chunk_index: usize,
         certificate_header: Option<&HeaderField>,
         callback: &CallbackFunc,
@@ -562,7 +559,6 @@ impl State {
             meta,
             encoding,
             enc,
-            key,
             chunk_index,
             certificate_header,
             callback,
@@ -583,7 +579,6 @@ impl State {
         meta: &AssetMeta,
         encoding: Encoding,
         enc: &EncodingMeta,
-        key: &str,
         chunk_index: usize,
         certificate_header: Option<&HeaderField>,
         callback: &CallbackFunc,
@@ -601,10 +596,9 @@ impl State {
         }
 
         let streaming_strategy = StreamingCallbackToken::create_token(
-            encoding,
-            enc.num_chunks as usize,
-            enc.sha256,
-            key,
+            enc.content_id,
+            enc.num_chunks,
+            ByteBuf::from(enc.sha256),
             chunk_index,
         )
         .map(|token| StreamingStrategy::Callback {
@@ -681,7 +675,6 @@ impl State {
                 self.build_asset_response(
                     &meta,
                     requested_encodings,
-                    path,
                     chunk_index,
                     Some(&cert_header),
                     callback,
@@ -738,38 +731,28 @@ impl State {
     pub fn http_request_streaming_callback(
         &self,
         StreamingCallbackToken {
-            key,
-            encoding,
+            content_id,
             index,
+            num_chunks,
             sha256,
         }: StreamingCallbackToken,
-    ) -> Result<StreamingCallbackHttpResponse, String> {
-        let meta = self
-            .metadata
-            .get(&key)
-            .ok_or_else(|| "Invalid token on streaming: key not found.".to_string())?;
-        let enc = meta
-            .encodings
-            .get(&encoding)
-            .ok_or_else(|| "Invalid token on streaming: encoding not found.".to_string())?;
-
-        if sha256 != ByteBuf::from(enc.sha256) {
-            return Err("sha256 mismatch".to_string());
-        }
-
-        // MAX is good enough. This means a chunk would be above 64-bits, which is impossible...
-        let chunk_index = index.0.to_usize().unwrap_or(usize::MAX);
-
-        Ok(StreamingCallbackHttpResponse {
-            body: self.chunk_bytes(enc.content_id, chunk_index),
+    ) -> StreamingCallbackHttpResponse {
+        // The token is self-describing, so the callback needs no `metadata.get`
+        // / `AssetMeta` decode: it reads the requested chunk straight from the
+        // content store and re-derives the next token from the token's own
+        // fields. A forged `content_id`/`index` just misses the content store
+        // and yields an empty body — the gateway's `sha256` check then rejects
+        // the stream, so no uncertified bytes are ever served.
+        let chunk_index = index as usize;
+        StreamingCallbackHttpResponse {
+            body: self.chunk_bytes(content_id, chunk_index),
             token: StreamingCallbackToken::create_token(
-                encoding,
-                enc.num_chunks as usize,
-                enc.sha256,
-                &key,
+                content_id,
+                num_chunks,
+                sha256,
                 chunk_index,
             ),
-        })
+        }
     }
 
     // ---- redirect rules ----

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -7,7 +7,7 @@ use crate::sync::{ComputationStatus, SYNC_IDLE_TIMEOUT_NANOS};
 use crate::url::{url_decode, UrlDecodeError};
 use crate::UploadChunksArguments;
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-use candid::{Nat, Principal};
+use candid::Principal;
 use ic_certification_testing::CertificateBuilder;
 use ic_crypto_tree_hash::Digest;
 use ic_http_certification::{Method, StatusCode};
@@ -893,20 +893,7 @@ fn uses_streaming_for_multichunk_assets() {
         .expect("missing streaming strategy");
     assert_eq!(callback, streaming_callback);
 
-    // A token carrying the wrong hash is rejected.
-    assert_eq!(
-        state
-            .http_request_streaming_callback(StreamingCallbackToken {
-                key: "/index.html".to_string(),
-                encoding: Encoding::Identity,
-                index: Nat::from(1_u8),
-                sha256: ByteBuf::from([0u8; 32].as_slice()),
-            })
-            .unwrap_err(),
-        "sha256 mismatch"
-    );
-
-    let streaming_response = state.http_request_streaming_callback(token).unwrap();
+    let streaming_response = state.http_request_streaming_callback(token);
     assert_eq!(streaming_response.body.as_ref(), INDEX_BODY_CHUNK_2);
     assert!(
         streaming_response.token.is_none(),
@@ -948,19 +935,19 @@ fn streams_three_chunks_chaining_continuation_tokens() {
         .streaming_strategy
         .expect("missing streaming strategy");
     assert_eq!(callback, streaming_callback);
-    assert_eq!(token.index, Nat::from(1_u8));
+    assert_eq!(token.index, 1);
 
     // Middle chunk: the callback returns chunk 1 *and* a continuation token for
     // chunk 2 — the branch that never fires with only two chunks.
-    let second = state.http_request_streaming_callback(token).unwrap();
+    let second = state.http_request_streaming_callback(token);
     assert_eq!(second.body.as_ref(), C1);
     let next = second
         .token
         .expect("expected a continuation token for the final chunk");
-    assert_eq!(next.index, Nat::from(2_u8));
+    assert_eq!(next.index, 2);
 
     // Final chunk: body served, token is None to end the stream.
-    let third = state.http_request_streaming_callback(next).unwrap();
+    let third = state.http_request_streaming_callback(next);
     assert_eq!(third.body.as_ref(), C2);
     assert!(
         third.token.is_none(),
@@ -1002,9 +989,8 @@ fn streams_multichunk_non_identity_encoding() {
         .streaming_strategy
         .expect("missing streaming strategy");
     assert_eq!(callback, streaming_callback);
-    assert_eq!(token.encoding, Encoding::Gzip);
 
-    let second = state.http_request_streaming_callback(token).unwrap();
+    let second = state.http_request_streaming_callback(token);
     assert_eq!(second.body.as_ref(), GZIP_CHUNK_2);
     assert!(second.token.is_none(), "stream should end after chunk 2");
 }
@@ -1035,7 +1021,12 @@ fn single_chunk_asset_has_no_streaming_strategy() {
 }
 
 #[test]
-fn streaming_callback_rejects_unknown_key() {
+fn streaming_callback_with_bogus_content_id_serves_empty_body() {
+    // The self-describing token is no longer validated against `AssetMeta`: a
+    // forged `content_id` simply misses the content store and yields an empty
+    // body (rather than trapping). The HTTP gateway's `sha256` check on the
+    // accumulated stream is what rejects such a response, so no uncertified
+    // bytes are served.
     let mut state = State::default();
     let system_context = mock_system_context();
 
@@ -1046,40 +1037,16 @@ fn streaming_callback_rejects_unknown_key() {
             .with_encoding("identity", vec![b"a", b"b"])],
     );
 
-    let err = state
-        .http_request_streaming_callback(StreamingCallbackToken {
-            key: "/does-not-exist.html".to_string(),
-            encoding: Encoding::Identity,
-            index: Nat::from(1_u8),
-            sha256: ByteBuf::from([0u8; 32].as_slice()),
-        })
-        .unwrap_err();
-    assert_eq!(err, "Invalid token on streaming: key not found.");
-}
-
-#[test]
-fn streaming_callback_rejects_unknown_encoding() {
-    let mut state = State::default();
-    let system_context = mock_system_context();
-
-    // Asset exists with only an identity encoding; a token naming gzip must be
-    // rejected before the sha256 is even consulted.
-    create_assets(
-        &mut state,
-        &system_context,
-        vec![AssetBuilder::new("/index.html", "text/html")
-            .with_encoding("identity", vec![b"a", b"b"])],
+    let response = state.http_request_streaming_callback(StreamingCallbackToken {
+        content_id: u64::MAX,
+        index: 1,
+        num_chunks: 2,
+        sha256: ByteBuf::from([0u8; 32].as_slice()),
+    });
+    assert!(
+        response.body.as_ref().is_empty(),
+        "a token pointing at a nonexistent content group must serve no bytes"
     );
-
-    let err = state
-        .http_request_streaming_callback(StreamingCallbackToken {
-            key: "/index.html".to_string(),
-            encoding: Encoding::Gzip,
-            index: Nat::from(1_u8),
-            sha256: ByteBuf::from([0u8; 32].as_slice()),
-        })
-        .unwrap_err();
-    assert_eq!(err, "Invalid token on streaming: encoding not found.");
 }
 
 #[test]


### PR DESCRIPTION
## What

Make `StreamingCallbackToken` **self-describing** so the streaming callback can serve a chunk straight from the content store, without re-fetching and CBOR-decoding the asset's `AssetMeta` on every chunk. This is **Risk A** from `BENCHMARKING.md` §6.

The token now carries `content_id` + `num_chunks` directly, and per the fixed-width-integer preference, `index` moves from candid `Nat` to `u32`:

```rust
pub struct StreamingCallbackToken {
    pub content_id: u64,   // read chunks directly — no metadata.get
    pub index: u32,        // was Nat
    pub num_chunks: u32,
    pub sha256: ByteBuf,
}
```

The dead `key`/`encoding` fields are dropped. The callback is now **infallible**: a stale or forged token simply misses the content store and serves an empty body, which the HTTP gateway's `sha256` check on the accumulated stream rejects — so no validation (and no `trap`) is needed. The token is uncertified and opaque to the gateway, so reshaping it is safe; per the project's pre-launch stance there are no backward-compat constraints.

## Knock-on cleanups

- Removed the now-dead `key` parameter threaded through `build_asset_response` / `build_ok_http_response`.
- Dropped unused `Nat` / `Encoding` / `ToPrimitive` imports.
- Updated `certified-assets.did` (`content_id: nat64; index: nat32; num_chunks: nat32; sha256: blob`); candid compat test passes.
- Fixed a latent bug: streaming a **200-aliased** multi-chunk asset used to put the *alias* path in the token's `key` and then `metadata.get(alias_path)` in the callback (which doesn't exist) — now keyed by the target's `content_id`.

## Numbers

`serve_large_asset`: **21.61 M → 21.38 M** instructions (−1.0%, ~225 K over 7 callbacks ≈ **32 K saved per callback** — the eliminated `metadata.get` + `AssetMeta` decode). Real but small, as predicted: the per-chunk `stable64_read` byte copy (~2.6 M/chunk) dominates and is irreducible. canbench baseline re-persisted in `canbench_results.yml`.

## Tests

- `cargo test -p canister-core` → 103 pass (replaced the two obsolete `rejects_unknown_key`/`unknown_encoding` error tests with one documenting the new empty-body-on-bogus-token contract).
- `cargo test -p canister` → candid compat passes; `cargo check --workspace --all-targets`, clippy, and fmt all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)