### PR TITLE
feat!: serve large assets as certified HTTP 206 range responses

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,7 +23,7 @@ the wasm build target. All crates live under [`crates/`](crates/):
 
 | Crate | Kind | Role |
 |-------|------|------|
-| [`canister-core`](crates/canister-core/) | library | Asset storage, certification (response verification), streaming, and access control. Can also be embedded in other canisters. |
+| [`canister-core`](crates/canister-core/) | library | Asset storage, certification (response verification), large-asset range serving, and access control. Can also be embedded in other canisters. |
 | [`canister`](crates/canister/) | `cdylib`, `wasm32-unknown-unknown` | Thin wrapper that exposes `canister-core` as the deployable ICP assets canister. |
 | [`sync-core`](crates/sync-core/) | library | Platform-agnostic sync logic: directory scanning, MIME detection, content encoding, `_headers`/`_redirects` parsing, canister diffing, and the `CanisterCall` trait that abstracts the transport layer. |
 | [`sync-plugin`](crates/sync-plugin/) | `cdylib`, `wasm32-wasip2` | Thin `icp-cli` sync plugin that wraps `sync-core`. |
@@ -39,8 +39,8 @@ target — `canister` wraps `canister-core`, `sync-plugin` wraps `sync-core`.
    call to the canister.
 2. The canister picks the best stored encoding for the client's `Accept-Encoding`,
    handles conditional requests (`If-None-Match` → `304`), and returns a response
-   carrying its certificate. Large bodies are returned in chunks via a streaming
-   callback.
+   carrying its certificate. Large bodies are split into chunks, each served as a
+   certified `206` range response that the gateway reassembles into the full `200`.
 3. The gateway verifies the certificate against the canister's certified data before
    forwarding the response, so the browser only ever sees content the canister has
    provably committed to.

--- a/README.md
+++ b/README.md
@@ -126,10 +126,10 @@ in [`crates/canister/src/lib.rs`](crates/canister/src/lib.rs) checks the
 Rust-exported service against this file (via `service_equal`), so the two stay in
 lockstep.
 
-The HTTP types (`HeaderField`, `HttpRequest`, `HttpResponse`, `StreamingToken`,
-`StreamingStrategy`, `StreamingCallbackHttpResponse`) come from the official
-[IC HTTP Gateway specification](https://docs.internetcomputer.org/references/http-gateway-protocol-spec/),
-kept as published except for `StreamingToken`: the spec defines it as an opaque
-placeholder each canister fills in with its own concrete type, and
-`certified-assets.did` fills it in with the assets canister's concrete token. The file is self-contained
-(no `import`) so it can be attached to the canister wasm as Candid metadata.
+The HTTP types (`HeaderField`, `HttpRequest`, `HttpResponse`) come from the official
+[IC HTTP Gateway specification](https://docs.internetcomputer.org/references/http-gateway-protocol-spec/).
+This canister doesn't use the streaming-callback strategy — large assets are served as
+certified `206` range responses the gateway reassembles into a full `200` — so
+`HttpResponse` carries no `streaming_strategy` field and there is no streaming-callback
+token, strategy, or method. The file is self-contained (no `import`) so it can be
+attached to the canister wasm as Candid metadata.

--- a/certified-assets.did
+++ b/certified-assets.did
@@ -2,9 +2,13 @@
 //
 // The IC HTTP Gateway interface types, from the official specification:
 // https://docs.internetcomputer.org/references/http-gateway-protocol-spec/
-// Kept as published except for `StreamingToken`: the spec defines it as an
-// opaque placeholder that each canister fills in with its own concrete type,
-// and the record below is the assets canister's concrete token.
+//
+// This canister does not use the streaming-callback strategy: large assets are
+// served as certified HTTP 206 range responses, which the gateway reassembles
+// into a full 200 (and which also satisfy client `Range` requests). So
+// `HttpResponse` carries no `streaming_strategy` and there is no streaming
+// callback method. The gateway's own `HttpResponse` type keeps `streaming_strategy`
+// as an optional field, which decodes to null when absent.
 
 type HeaderField = record { text; text; };
 
@@ -21,7 +25,6 @@ type HttpResponse = record {
   headers: vec HeaderField;
   body: blob;
   upgrade : opt bool;
-  streaming_strategy: opt StreamingStrategy;
 };
 
 // The content encodings the canister and sync plugin support — a deliberately
@@ -30,30 +33,6 @@ type HttpResponse = record {
 // form; it is a real stored encoding but never emitted as a `Content-Encoding`
 // header. Defined up here so the asset types below can reference it.
 type Encoding = variant { Identity; Gzip; Brotli };
-
-// Each canister that uses the streaming feature gets to choose their concrete
-// type; the HTTP Gateway will treat it as an opaque value that is only fed to
-// the callback method. This is the assets canister's concrete token — fully
-// self-describing, so the callback serves the next chunk straight from the
-// content store (`content_id`) without reloading any per-asset metadata.
-type StreamingToken = record {
-  content_id: nat64;
-  index: nat32;
-  num_chunks: nat32;
-  sha256: blob;
-};
-
-type StreamingCallbackHttpResponse = record {
-  body: blob;
-  token: opt StreamingToken;
-};
-
-type StreamingStrategy = variant {
-  Callback: record {
-    callback: func (StreamingToken) -> (StreamingCallbackHttpResponse) query;
-    token: StreamingToken;
-  };
-};
 
 // ───────── Shared aliases ─────────
 
@@ -208,7 +187,6 @@ service: {
   // https://docs.internetcomputer.org/references/http-gateway-protocol-spec/
 
   http_request: (request: HttpRequest) -> (HttpResponse) query;
-  http_request_streaming_callback: (token: StreamingToken) -> (StreamingCallbackHttpResponse) query;
 
   // ───────── Asset queries ─────────
 

--- a/crates/canister-core/canbench_results.yml
+++ b/crates/canister-core/canbench_results.yml
@@ -2,35 +2,35 @@ benches:
   post_upgrade_rebuild:
     total:
       calls: 1
-      instructions: 126911382
+      instructions: 127425832
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   serve_large_asset:
     total:
       calls: 1
-      instructions: 8596421
+      instructions: 10100927
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   serve_small_asset:
     total:
       calls: 1
-      instructions: 152481
+      instructions: 152789
       heap_increase: 0
       stable_memory_increase: 0
     scopes: {}
   sync_commit:
     total:
       calls: 1
-      instructions: 85398659
+      instructions: 85764712
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}
   sync_commit_large:
     total:
       calls: 1
-      instructions: 660021522
+      instructions: 1312115978
       heap_increase: 0
       stable_memory_increase: 128
     scopes: {}

--- a/crates/canister-core/src/asset.rs
+++ b/crates/canister-core/src/asset.rs
@@ -218,11 +218,16 @@ pub(crate) fn range_response_hash(
     content_range: &str,
     chunk_body_hash: &[u8; 32],
 ) -> [u8; 32] {
-    let base_headers: Vec<(String, Value)> =
-        range_headers_for(effective_headers, content_type, encoding, sha256, content_range)
-            .into_iter()
-            .map(|(k, v)| (k, Value::String(v)))
-            .collect();
+    let base_headers: Vec<(String, Value)> = range_headers_for(
+        effective_headers,
+        content_type,
+        encoding,
+        sha256,
+        content_range,
+    )
+    .into_iter()
+    .map(|(k, v)| (k, Value::String(v)))
+    .collect();
     response_hash(&base_headers, 206, chunk_body_hash).0
 }
 

--- a/crates/canister-core/src/asset.rs
+++ b/crates/canister-core/src/asset.rs
@@ -166,6 +166,66 @@ pub fn response_hashes_for(
     response_hashes
 }
 
+// ---- Phase 0 spike: 206 range-response certification ----
+//
+// A 206's certified header set is the 200's set plus `content-range`. Only the
+// `Content-Range` *value* varies per chunk (it lives in the response hash), so
+// the CEL/expression is the same for every chunk of an encoding. Certification
+// is response-only (`RequestHash::default()`), so an arbitrary client range can
+// be snapped to the containing chunk at serve time. These three helpers are used
+// by both the certify path (`recertify_asset`) and the serve path
+// (`build_range_response`) so the two can never disagree.
+
+/// The certificate expression for a 206 range response: the 200 certified header
+/// set plus `content-range`.
+pub(crate) fn range_certificate_expression_for(
+    effective_headers: &[(String, String)],
+    encoding: Encoding,
+    sha256: &[u8; 32],
+) -> CertificateExpression {
+    let mut headers = effective_headers_with_etag(effective_headers, sha256);
+    // The value is irrelevant to the expression (it lists header *names*).
+    headers.push(("content-range".to_string(), String::new()));
+    build_ic_certificate_expression_from_headers_and_encoding(&headers, encoding.header_name())
+}
+
+/// The full served header list for a 206 range response, including
+/// `content-range` and the `ic-certificateexpression` header.
+pub(crate) fn range_headers_for(
+    effective_headers: &[(String, String)],
+    content_type: &str,
+    encoding: Encoding,
+    sha256: &[u8; 32],
+    content_range: &str,
+) -> Vec<(String, String)> {
+    let cert_expr = range_certificate_expression_for(effective_headers, encoding, sha256);
+    let mut headers = effective_headers_with_etag(effective_headers, sha256);
+    headers.push(("content-range".to_string(), content_range.to_string()));
+    build_headers(
+        headers.iter().map(|(k, v)| (k, v)),
+        content_type,
+        encoding,
+        Some(&cert_expr),
+    )
+}
+
+/// The certified response hash for one 206 range chunk.
+pub(crate) fn range_response_hash(
+    effective_headers: &[(String, String)],
+    content_type: &str,
+    encoding: Encoding,
+    sha256: &[u8; 32],
+    content_range: &str,
+    chunk_body_hash: &[u8; 32],
+) -> [u8; 32] {
+    let base_headers: Vec<(String, Value)> =
+        range_headers_for(effective_headers, content_type, encoding, sha256, content_range)
+            .into_iter()
+            .map(|(k, v)| (k, Value::String(v)))
+            .collect();
+    response_hash(&base_headers, 206, chunk_body_hash).0
+}
+
 fn build_headers(
     effective_headers: impl Iterator<Item = (impl Into<String>, impl Into<String>)>,
     content_type: impl Into<String>,

--- a/crates/canister-core/src/benches.rs
+++ b/crates/canister-core/src/benches.rs
@@ -22,7 +22,7 @@
 //! `#[bench(raw)]` + [`bench_fn`] measures only the closure; the setup before it
 //! (building state, syncing assets) is excluded.
 
-use crate::http::{CallbackFunc, HttpRequest, StreamingStrategy};
+use crate::http::HttpRequest;
 use crate::runtime::SystemContext;
 use crate::state::State;
 use crate::sync::{ComputationStatus, ExecuteOperationsProgress};
@@ -45,8 +45,9 @@ use wire_types::{
 /// A small single-chunk asset (typical HTML page).
 const SMALL_ASSET_BYTES: usize = 10 * 1024;
 
-/// A large multi-chunk asset. 8 × 1 MiB ⇒ 7 streaming callbacks, each of which
-/// re-fetches the asset metadata — this is where Risk A would show up.
+/// A large multi-chunk asset. 8 × 1 MiB ⇒ eight certified 206 responses, one per
+/// chunk, each re-resolving the asset from its URL (metadata read + chunk-cert
+/// scan + chunk read + witness) — this is where the per-chunk serve cost shows up.
 const LARGE_CHUNK_BYTES: usize = 1024 * 1024;
 const LARGE_NUM_CHUNKS: usize = 8;
 
@@ -70,10 +71,6 @@ fn caller() -> Principal {
     Principal::from_text("ryjl3-tyaaa-aaaaa-aaaba-cai").unwrap()
 }
 
-fn callback() -> CallbackFunc {
-    CallbackFunc::new(caller(), "http_request_streaming_callback".to_string())
-}
-
 fn identity() -> Encoding {
     Encoding::from_token("identity").expect("identity is a supported encoding")
 }
@@ -95,6 +92,14 @@ fn get(url: &str) -> HttpRequest {
         body: ByteBuf::new(),
         certificate_version: Some(2),
     }
+}
+
+/// Like [`get`], but with an open-ended `Range` header — what the gateway sends
+/// when fetching a subsequent chunk of a large asset during 206 reassembly.
+fn get_range(url: &str, start: usize) -> HttpRequest {
+    let mut req = get(url);
+    req.headers.push(("Range".to_string(), format!("bytes={start}-")));
+    req
 }
 
 /// Drives `execute_operations` to completion synchronously. Mirrors the
@@ -223,24 +228,19 @@ fn populate_one(key: &str, content_type: &str, num_chunks: usize, chunk_bytes: u
 fn serve_small_asset() -> BenchResult {
     let state = populate_one("/index.html", "text/html", 1, SMALL_ASSET_BYTES);
     // Sanity (not measured): a broken setup would otherwise measure the 404 path.
-    assert_eq!(
-        state
-            .http_request(get("/index.html"), &[], callback())
-            .status_code,
-        200
-    );
+    assert_eq!(state.http_request(get("/index.html"), &[]).status_code, 200);
 
     let req = get("/index.html");
-    let cb = callback();
     bench_fn(|| {
-        std::hint::black_box(state.http_request(req, &[], cb));
+        std::hint::black_box(state.http_request(req, &[]));
     })
 }
 
-/// Serving a large multi-chunk asset end to end: the first `http_request` plus
-/// every streaming callback. Each callback re-fetches and deserializes the asset
-/// metadata, so this is the bench that surfaces Risk A — its cost scales with
-/// `LARGE_NUM_CHUNKS`.
+/// Serving a large multi-chunk asset end to end the way the gateway does it: a
+/// plain GET returns chunk 0 as a 206, then one `Range` request per remaining
+/// chunk. Each call re-resolves the asset from its URL (metadata read +
+/// chunk-cert scan + chunk read + witness), so this is the bench that surfaces
+/// the per-chunk serve cost; it scales with `LARGE_NUM_CHUNKS`.
 #[bench(raw)]
 fn serve_large_asset() -> BenchResult {
     let state = populate_one(
@@ -249,26 +249,20 @@ fn serve_large_asset() -> BenchResult {
         LARGE_NUM_CHUNKS,
         LARGE_CHUNK_BYTES,
     );
-    assert_eq!(
-        state
-            .http_request(get("/big.bin"), &[], callback())
-            .status_code,
-        200
-    );
+    // Sanity (not measured): a plain GET of a multi-chunk asset is a 206 chunk 0.
+    assert_eq!(state.http_request(get("/big.bin"), &[]).status_code, 206);
 
-    let req = get("/big.bin");
-    let cb = callback();
     bench_fn(|| {
-        let resp = state.http_request(req, &[], cb);
-        std::hint::black_box(&resp.body);
-        // Walk the streaming callbacks to the last chunk.
-        let mut token = resp
-            .streaming_strategy
-            .map(|StreamingStrategy::Callback { token, .. }| token);
-        while let Some(t) = token {
-            let next = state.http_request_streaming_callback(t);
-            std::hint::black_box(&next.body);
-            token = next.token;
+        // Chunks are uniform `LARGE_CHUNK_BYTES`, so chunk `i` begins at
+        // `i * LARGE_CHUNK_BYTES`. The gateway sends the first chunk's request
+        // without a Range header and each subsequent one with `bytes={start}-`.
+        for i in 0..LARGE_NUM_CHUNKS {
+            let req = if i == 0 {
+                get("/big.bin")
+            } else {
+                get_range("/big.bin", i * LARGE_CHUNK_BYTES)
+            };
+            std::hint::black_box(state.http_request(req, &[]));
         }
     })
 }

--- a/crates/canister-core/src/benches.rs
+++ b/crates/canister-core/src/benches.rs
@@ -98,7 +98,8 @@ fn get(url: &str) -> HttpRequest {
 /// when fetching a subsequent chunk of a large asset during 206 reassembly.
 fn get_range(url: &str, start: usize) -> HttpRequest {
     let mut req = get(url);
-    req.headers.push(("Range".to_string(), format!("bytes={start}-")));
+    req.headers
+        .push(("Range".to_string(), format!("bytes={start}-")));
     req
 }
 

--- a/crates/canister-core/src/http.rs
+++ b/crates/canister-core/src/http.rs
@@ -1,7 +1,7 @@
 use crate::certification::{
     build_ic_certificate_expression_from_headers, build_ic_certificate_expression_header,
 };
-use candid::{define_function, CandidType, Deserialize};
+use candid::{CandidType, Deserialize};
 use serde_bytes::ByteBuf;
 
 pub type HeaderField = (String, String);
@@ -21,62 +21,6 @@ pub struct HttpResponse {
     pub headers: Vec<HeaderField>,
     pub body: ByteBuf,
     pub upgrade: Option<bool>,
-    pub streaming_strategy: Option<StreamingStrategy>,
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct StreamingCallbackToken {
-    /// Content group to stream from. Carrying it lets the streaming callback
-    /// read chunks straight from the content store, with no `AssetMeta`
-    /// lookup/decode per chunk — the token is fully self-describing.
-    pub content_id: u64,
-    /// Index of the chunk this token requests.
-    pub index: u32,
-    /// Total chunks in the content group; the callback emits a follow-on token
-    /// while `index + 1 < num_chunks`.
-    pub num_chunks: u32,
-    /// Full-asset hash, carried for the HTTP gateway's streamed-response check.
-    pub sha256: ByteBuf,
-}
-
-define_function!(pub CallbackFunc : (StreamingCallbackToken) -> (StreamingCallbackHttpResponse) query);
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub enum StreamingStrategy {
-    Callback {
-        callback: CallbackFunc,
-        token: StreamingCallbackToken,
-    },
-}
-
-#[derive(Clone, Debug, CandidType, Deserialize)]
-pub struct StreamingCallbackHttpResponse {
-    pub body: ByteBuf,
-    pub token: Option<StreamingCallbackToken>,
-}
-
-impl StreamingCallbackToken {
-    /// Builds the token for the chunk *after* `chunk_index`, or `None` when
-    /// `chunk_index` is the last chunk. Self-contained: it carries
-    /// `content_id`/`num_chunks`/`sha256` so the streaming callback can serve
-    /// the next chunk without ever reloading the asset's `AssetMeta`.
-    pub fn create_token(
-        content_id: u64,
-        num_chunks: u32,
-        sha256: ByteBuf,
-        chunk_index: usize,
-    ) -> Option<Self> {
-        let next_index = chunk_index + 1;
-        if next_index >= num_chunks as usize {
-            None
-        } else {
-            Some(StreamingCallbackToken {
-                content_id,
-                index: next_index as u32,
-                num_chunks,
-                sha256,
-            })
-        }
-    }
 }
 
 impl HttpRequest {
@@ -109,7 +53,6 @@ impl HttpResponse {
             headers: vec![("content-type".to_string(), "text/plain".to_string())],
             body: ByteBuf::from("not found"),
             upgrade: None,
-            streaming_strategy: None,
         }
     }
 }

--- a/crates/canister-core/src/lib.rs
+++ b/crates/canister-core/src/lib.rs
@@ -18,16 +18,15 @@ mod tests;
 mod benches;
 
 use crate::{
-    http::CallbackFunc,
     runtime::{CanisterEnv, SystemContext},
     state::State,
     sync::ComputationStatus,
 };
 use candid::Principal;
-use ic_cdk::api::{canister_self, certified_data_set, data_certificate, msg_caller, trap};
+use ic_cdk::api::{certified_data_set, data_certificate, msg_caller, trap};
 use std::cell::RefCell;
 
-pub use http::{HttpRequest, HttpResponse, StreamingCallbackHttpResponse, StreamingCallbackToken};
+pub use http::{HttpRequest, HttpResponse};
 pub use wire_types::{
     AssetDetails, ExecuteOperationsArguments, RedirectRule, StartSyncResult, UploadChunksArguments,
     Version,
@@ -116,22 +115,7 @@ pub fn http_request(req: HttpRequest) -> HttpResponse {
     }
     let certificate = data_certificate().unwrap_or_else(|| trap("no data certificate available"));
 
-    STATE.with_borrow(|s| {
-        s.http_request(
-            req,
-            &certificate,
-            CallbackFunc::new(
-                canister_self(),
-                "http_request_streaming_callback".to_string(),
-            ),
-        )
-    })
-}
-
-pub fn http_request_streaming_callback(
-    token: StreamingCallbackToken,
-) -> StreamingCallbackHttpResponse {
-    STATE.with_borrow(|s| s.http_request_streaming_callback(token))
+    STATE.with_borrow(|s| s.http_request(req, &certificate))
 }
 
 /// Whether the current caller may sync assets: either in the authorized set, or

--- a/crates/canister-core/src/stable_store.rs
+++ b/crates/canister-core/src/stable_store.rs
@@ -60,6 +60,46 @@ pub struct EncodingMeta {
     /// Number of chunks, so streaming tokens can be built without a range scan.
     pub num_chunks: u32,
     pub sha256: [u8; 32],
+    /// Total encoded length, i.e. the sum of all chunk lengths. Used as the
+    /// `/total` in a 206 `Content-Range` and to reject out-of-range requests,
+    /// without re-reading the chunks.
+    pub content_len: u64,
+}
+
+/// Per-chunk certification data, stored in its own region keyed by the same
+/// `(content_id, chunk_index)` as the content blob. Holds exactly what the 206
+/// certify path and serve path need *without* reading chunk bytes: the chunk's
+/// length (for `Content-Range`/offset math) and its SHA-256 (the 206 body hash).
+/// Keeping this out of [`AssetMeta`] keeps the per-request metadata decode small.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ChunkCert {
+    pub len: u32,
+    pub sha256: [u8; 32],
+}
+
+impl Storable for ChunkCert {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
+        let mut buf = [0u8; 36];
+        buf[..4].copy_from_slice(&self.len.to_le_bytes());
+        buf[4..].copy_from_slice(&self.sha256);
+        Cow::Owned(buf.to_vec())
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        self.to_bytes().into_owned()
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        let len = u32::from_le_bytes(bytes[..4].try_into().expect("36-byte ChunkCert"));
+        let mut sha256 = [0u8; 32];
+        sha256.copy_from_slice(&bytes[4..36]);
+        Self { len, sha256 }
+    }
+
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 36,
+        is_fixed_size: true,
+    };
 }
 
 /// Key into the content chunk store, encoded big-endian (`content_id` then

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -23,10 +23,7 @@ use crate::certification::{
     response_hash, AssetKey, AssetPath, CertificateExpression, CertifiedResponses, RequestHash,
     ResponseHash,
 };
-use crate::http::{
-    CallbackFunc, HeaderField, HttpRequest, HttpResponse, StreamingCallbackHttpResponse,
-    StreamingCallbackToken, StreamingStrategy,
-};
+use crate::http::{HeaderField, HttpRequest, HttpResponse};
 use crate::stable_store::{
     AssetMeta, AuthorizedSet, ChunkCert, ContentChunkKey, EncodingMeta, RedirectRules,
 };
@@ -582,14 +579,11 @@ impl State {
 
     // ---- HTTP serving ----
 
-    #[allow(clippy::too_many_arguments)]
     fn build_http_response(
         &self,
         certificate: &[u8],
         path: &str,
         requested_encodings: Vec<Encoding>,
-        chunk_index: usize,
-        callback: CallbackFunc,
         etags: Vec<Hash>,
         range_start: Option<usize>,
     ) -> HttpResponse {
@@ -599,9 +593,7 @@ impl State {
             if let Some(response) = self.build_asset_response(
                 &meta,
                 &requested_encodings,
-                chunk_index,
                 Some(&cert_header),
-                &callback,
                 &etags,
                 None,
                 range_start,
@@ -629,8 +621,6 @@ impl State {
                 path,
                 certificate,
                 &requested_encodings,
-                chunk_index,
-                &callback,
                 &etags,
                 range_start,
             );
@@ -645,37 +635,37 @@ impl State {
     /// encoding present in the metadata is certified, so encoding selection is
     /// just preference order.
     #[allow(clippy::too_many_arguments)]
-    #[allow(clippy::too_many_arguments)]
     fn build_asset_response(
         &self,
         meta: &AssetMeta,
         requested_encodings: &[Encoding],
-        chunk_index: usize,
         certificate_header: Option<&HeaderField>,
-        callback: &CallbackFunc,
         etags: &[Hash],
         status_override: Option<u16>,
         range_start: Option<usize>,
     ) -> Option<HttpResponse> {
+        // A status-overridden response (a 4xx custom error page) is served as a
+        // single inline body with that status — there is no way to deliver a
+        // multi-chunk body under a non-200 status now that callback streaming is
+        // gone and 206 reassembly always yields a 200 (see D6). So restrict those
+        // to single-chunk encodings; the certify side does the same.
+        let acceptable = |e: &Encoding| match status_override {
+            Some(_) => meta.encodings.get(e).is_some_and(|enc| enc.num_chunks == 1),
+            None => meta.encodings.contains_key(e),
+        };
         // Honour the client's listed order first; if it expressed no acceptable
         // encoding, fall back to our preference order (identity-first).
         let encoding = requested_encodings
             .iter()
             .copied()
-            .find(|e| meta.encodings.contains_key(e))
-            .or_else(|| {
-                Encoding::PREFERENCE_ORDER
-                    .into_iter()
-                    .find(|e| meta.encodings.contains_key(e))
-            })?;
+            .find(|e| acceptable(e))
+            .or_else(|| Encoding::PREFERENCE_ORDER.into_iter().find(|e| acceptable(e)))?;
         let enc = meta.encodings.get(&encoding)?;
         Some(self.build_ok_http_response(
             meta,
             encoding,
             enc,
-            chunk_index,
             certificate_header,
-            callback,
             etags,
             status_override,
             range_start,
@@ -688,24 +678,22 @@ impl State {
     /// (etag-based not-modified). When it is `Some(s)` — used by redirect rules
     /// that serve a custom error page — the response always carries the body
     /// with status `s`, and the etag / 304 logic is skipped.
-    #[allow(clippy::too_many_arguments)]
     fn build_ok_http_response(
         &self,
         meta: &AssetMeta,
         encoding: Encoding,
         enc: &EncodingMeta,
-        chunk_index: usize,
         certificate_header: Option<&HeaderField>,
-        callback: &CallbackFunc,
         etags: &[Hash],
         status_override: Option<u16>,
         range_start: Option<usize>,
     ) -> HttpResponse {
-        // Phase 0 spike: serve multi-chunk encodings as certified 206s. A plain
-        // GET (no Range) returns chunk 0 — that is what drives the gateway's Flow B
-        // reassembly into a full 200. A Range request returns the containing chunk
-        // (start snapped down to the chunk boundary). Conditional (304) and
-        // status-override (redirect/error-page) responses keep their normal path.
+        // Serve multi-chunk encodings as certified 206s. A plain GET (no Range)
+        // returns chunk 0 — that is what drives the gateway's Flow B reassembly
+        // into a full 200. A Range request returns the containing chunk (start
+        // snapped down to the chunk boundary). Conditional (304) and
+        // status-override (4xx error-page) responses keep their normal path; the
+        // latter only ever reaches here with a single-chunk encoding.
         if status_override.is_none() && !etags.contains(&enc.sha256) && enc.num_chunks > 1 {
             let start = range_start.unwrap_or(0);
             if let Some(response) =
@@ -725,35 +713,18 @@ impl State {
             headers.push((head.0.clone(), head.1.clone()));
         }
 
-        let streaming_strategy = StreamingCallbackToken::create_token(
-            enc.content_id,
-            enc.num_chunks,
-            ByteBuf::from(enc.sha256),
-            chunk_index,
-        )
-        .map(|token| StreamingStrategy::Callback {
-            callback: callback.clone(),
-            token,
-        });
-
-        // The canister-managed `etag` header is already in `headers` (and in the
-        // certified set), so both the 200 and the 304 carry it.
-        let (status_code, body, streaming_strategy) = if let Some(status) = status_override {
-            (
-                status,
-                self.chunk_bytes(enc.content_id, chunk_index),
-                streaming_strategy,
-            )
+        // Reaching here means a single-chunk body — multi-chunk 200s are served as
+        // 206 above, and multi-chunk 4xx error pages are filtered out in
+        // `build_asset_response` — so the whole body is chunk 0. The
+        // canister-managed `etag` header is already in `headers` (and certified),
+        // so both the 200 and the 304 carry it.
+        let (status_code, body) = if let Some(status) = status_override {
+            (status, self.chunk_bytes(enc.content_id, 0))
         } else if etags.contains(&enc.sha256) {
-            // Conditional request matched: serve the certified 304 — empty body,
-            // no streaming. Its response hash is certified alongside the 200.
-            (304, ByteBuf::new(), None)
+            // Conditional request matched: serve the certified 304 (empty body).
+            (304, ByteBuf::new())
         } else {
-            (
-                200,
-                self.chunk_bytes(enc.content_id, chunk_index),
-                streaming_strategy,
-            )
+            (200, self.chunk_bytes(enc.content_id, 0))
         };
 
         HttpResponse {
@@ -761,7 +732,6 @@ impl State {
             headers,
             body,
             upgrade: None,
-            streaming_strategy,
         }
     }
 
@@ -817,7 +787,6 @@ impl State {
             headers,
             body: ByteBuf::from(chunk),
             upgrade: None,
-            streaming_strategy: None,
         })
     }
 
@@ -829,8 +798,6 @@ impl State {
         path: &str,
         certificate: &[u8],
         requested_encodings: &[Encoding],
-        chunk_index: usize,
-        callback: &CallbackFunc,
         etags: &[Hash],
         range_start: Option<usize>,
     ) -> HttpResponse {
@@ -851,7 +818,6 @@ impl State {
                     headers,
                     body: ByteBuf::new(),
                     upgrade: None,
-                    streaming_strategy: None,
                 }
             }
             crate::redirect::CertifiedRuleEntryKind::AliasOf { target_key, status } => {
@@ -862,9 +828,7 @@ impl State {
                 self.build_asset_response(
                     &meta,
                     requested_encodings,
-                    chunk_index,
                     Some(&cert_header),
-                    callback,
                     etags,
                     status_override,
                     range_start,
@@ -874,12 +838,7 @@ impl State {
         }
     }
 
-    pub fn http_request(
-        &self,
-        req: HttpRequest,
-        certificate: &[u8],
-        callback: CallbackFunc,
-    ) -> HttpResponse {
+    pub fn http_request(&self, req: HttpRequest, certificate: &[u8]) -> HttpResponse {
         let mut encodings: Vec<Encoding> = vec![];
         let mut etags: Vec<Hash> = vec![];
         let mut range_start: Option<usize> = None;
@@ -899,9 +858,7 @@ impl State {
         };
 
         match url_decode(path) {
-            Ok(path) => {
-                self.build_http_response(certificate, &path, encodings, 0, callback, etags, range_start)
-            }
+            Ok(path) => self.build_http_response(certificate, &path, encodings, etags, range_start),
             // Malformed percent-encoding (invalid UTF-8 once decoded). This 400
             // is intentionally uncertified: the body is per-request (it echoes
             // the bad path), so it can't be pinned to a certified hash, and a
@@ -914,35 +871,7 @@ impl State {
                 headers: vec![],
                 body: ByteBuf::from(format!("failed to decode path '{path}': {err}")),
                 upgrade: None,
-                streaming_strategy: None,
             },
-        }
-    }
-
-    pub fn http_request_streaming_callback(
-        &self,
-        StreamingCallbackToken {
-            content_id,
-            index,
-            num_chunks,
-            sha256,
-        }: StreamingCallbackToken,
-    ) -> StreamingCallbackHttpResponse {
-        // The token is self-describing, so the callback needs no `metadata.get`
-        // / `AssetMeta` decode: it reads the requested chunk straight from the
-        // content store and re-derives the next token from the token's own
-        // fields. A forged `content_id`/`index` just misses the content store
-        // and yields an empty body — the gateway's `sha256` check then rejects
-        // the stream, so no uncertified bytes are ever served.
-        let chunk_index = index as usize;
-        StreamingCallbackHttpResponse {
-            body: self.chunk_bytes(content_id, chunk_index),
-            token: StreamingCallbackToken::create_token(
-                content_id,
-                num_chunks,
-                sha256,
-                chunk_index,
-            ),
         }
     }
 

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -335,22 +335,28 @@ impl State {
             self.delete_content(old.content_id);
         }
 
-        // Allocate a fresh content group and write the chunks into it, recording
-        // each chunk's length + hash for the 206 cert/serve paths as we go.
+        // Allocate a fresh content group and write the chunks into it. Per-chunk
+        // cert data (length + hash) is only needed to serve/certify 206 ranges,
+        // which only happen for multi-chunk encodings — so single-chunk assets
+        // (the common case) skip the extra hash and the `chunk_certs` write, and
+        // reuse the already-verified full `sha256` instead of re-hashing.
         use sha2::Digest;
         let content_id = self.alloc_content_id();
         let num_chunks = content_chunks.len() as u32;
+        let multi_chunk = num_chunks > 1;
         let mut content_len = 0u64;
         for (index, chunk) in content_chunks.iter().enumerate() {
             self.content.insert(content_id, index as u32, chunk);
-            let chunk_sha256: [u8; 32] = sha2::Sha256::digest(chunk).into();
-            self.chunk_certs.insert(
-                ContentChunkKey::new(content_id, index as u32),
-                ChunkCert {
-                    len: chunk.len() as u32,
-                    sha256: chunk_sha256,
-                },
-            );
+            if multi_chunk {
+                let chunk_sha256: [u8; 32] = sha2::Sha256::digest(chunk).into();
+                self.chunk_certs.insert(
+                    ContentChunkKey::new(content_id, index as u32),
+                    ChunkCert {
+                        len: chunk.len() as u32,
+                        sha256: chunk_sha256,
+                    },
+                );
+            }
             content_len += chunk.len() as u64;
         }
 
@@ -750,9 +756,14 @@ impl State {
         certificate_header: Option<&HeaderField>,
     ) -> Option<HttpResponse> {
         let total = enc.content_len as usize;
-        if total == 0 || start >= total {
+        if total == 0 {
             return None;
         }
+        // An out-of-range start (no byte to satisfy) is treated as "ignore the
+        // Range": serve chunk 0, which the gateway reassembles into the full 200.
+        // Returning `None` here would instead fall through to a plain 200 carrying
+        // only chunk 0 — a truncated body for a multi-chunk asset.
+        let start = if start >= total { 0 } else { start };
         // Find the chunk whose [offset, offset+len) contains `start`.
         let mut offset = 0usize;
         let mut target: Option<(u32, usize, usize)> = None; // (chunk_index, chunk_start, len)

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -15,7 +15,8 @@
 //! upgrade roundtrip over a shared memory handle).
 
 use crate::asset::{
-    certificate_expression_for, headers_for, response_hashes_for, STATUS_CODES_TO_CERTIFY,
+    certificate_expression_for, headers_for, range_certificate_expression_for, range_headers_for,
+    range_response_hash, response_hashes_for, STATUS_CODES_TO_CERTIFY,
 };
 use crate::blob_store::BlobStore;
 use crate::certification::{
@@ -66,6 +67,19 @@ fn parse_if_none_match(value: &str) -> Vec<Hash> {
             <[u8; 32]>::try_from(bytes.as_slice()).ok()
         })
         .collect()
+}
+
+/// Phase 0 spike: parse the *start* byte of a single `Range: bytes=<start>-[end]`
+/// header. The end is ignored (we serve the containing chunk). Multi-range
+/// (comma) and suffix (`bytes=-N`) forms return `None` → the request is served
+/// as a normal full response.
+fn parse_range_start(value: &str) -> Option<usize> {
+    let spec = value.trim().strip_prefix("bytes=")?;
+    if spec.contains(',') {
+        return None;
+    }
+    let (start, _end) = spec.split_once('-')?;
+    start.trim().parse::<usize>().ok()
 }
 
 type Mem = VirtualMemory<DefaultMemoryImpl>;
@@ -408,6 +422,40 @@ impl State {
                 );
                 self.asset_hashes.certify_response_precomputed(&hash_path);
             }
+
+            // Phase 0 spike: certify N×206 for multi-chunk encodings (response-only).
+            // SHORTCUT: reads chunk bytes to hash them, so this is NOT content-free
+            // (the real Phase 1 stores per-chunk hashes to keep `post_upgrade` cheap).
+            if enc.num_chunks > 1 {
+                use sha2::Digest;
+                let chunks: Vec<Vec<u8>> = (0..enc.num_chunks)
+                    .map(|i| self.content.get(enc.content_id, i).unwrap_or_default())
+                    .collect();
+                let total: usize = chunks.iter().map(|c| c.len()).sum();
+                let range_cert_expr =
+                    range_certificate_expression_for(&effective_headers, encoding, &enc.sha256);
+                let mut offset = 0usize;
+                for chunk in &chunks {
+                    let len = chunk.len();
+                    let content_range = format!("bytes {}-{}/{}", offset, offset + len - 1, total);
+                    let body_hash: [u8; 32] = sha2::Sha256::digest(chunk).into();
+                    let resp_hash = range_response_hash(
+                        &effective_headers,
+                        &meta.content_type,
+                        encoding,
+                        &enc.sha256,
+                        &content_range,
+                        &body_hash,
+                    );
+                    let hash_path = path.hash_tree_path(
+                        &range_cert_expr,
+                        &RequestHash::default(),
+                        ResponseHash::from(&resp_hash),
+                    );
+                    self.asset_hashes.certify_response_precomputed(&hash_path);
+                    offset += len;
+                }
+            }
         }
     }
 
@@ -480,6 +528,7 @@ impl State {
         chunk_index: usize,
         callback: CallbackFunc,
         etags: Vec<Hash>,
+        range_start: Option<usize>,
     ) -> HttpResponse {
         // Asset at the requested path wins.
         if let Some(meta) = self.metadata.get(&path.to_string()) {
@@ -492,6 +541,7 @@ impl State {
                 &callback,
                 &etags,
                 None,
+                range_start,
             ) {
                 return response;
             }
@@ -531,6 +581,7 @@ impl State {
     /// encoding present in the metadata is certified, so encoding selection is
     /// just preference order.
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)]
     fn build_asset_response(
         &self,
         meta: &AssetMeta,
@@ -540,6 +591,7 @@ impl State {
         callback: &CallbackFunc,
         etags: &[Hash],
         status_override: Option<u16>,
+        range_start: Option<usize>,
     ) -> Option<HttpResponse> {
         // Honour the client's listed order first; if it expressed no acceptable
         // encoding, fall back to our preference order (identity-first).
@@ -562,6 +614,7 @@ impl State {
             callback,
             etags,
             status_override,
+            range_start,
         ))
     }
 
@@ -582,7 +635,22 @@ impl State {
         callback: &CallbackFunc,
         etags: &[Hash],
         status_override: Option<u16>,
+        range_start: Option<usize>,
     ) -> HttpResponse {
+        // Phase 0 spike: serve multi-chunk encodings as certified 206s. A plain
+        // GET (no Range) returns chunk 0 — that is what drives the gateway's Flow B
+        // reassembly into a full 200. A Range request returns the containing chunk
+        // (start snapped down to the chunk boundary). Conditional (304) and
+        // status-override (redirect/error-page) responses keep their normal path.
+        if status_override.is_none() && !etags.contains(&enc.sha256) && enc.num_chunks > 1 {
+            let start = range_start.unwrap_or(0);
+            if let Some(response) =
+                self.build_range_response(meta, encoding, enc, start, certificate_header)
+            {
+                return response;
+            }
+        }
+
         let mut headers = headers_for(
             &self.effective_headers(meta),
             &meta.content_type,
@@ -633,6 +701,56 @@ impl State {
         }
     }
 
+    /// Phase 0 spike: build a certified 206 for the chunk containing byte `start`
+    /// (snapped down to the chunk boundary). Returns `None` (caller falls back to
+    /// the normal 200 path) when the encoding is empty or `start` is past the end.
+    ///
+    /// SHORTCUT: reads every chunk to compute the total length and locate the
+    /// target. The real serve path keeps this lean (per-chunk lengths from the
+    /// blob index; no full read).
+    fn build_range_response(
+        &self,
+        meta: &AssetMeta,
+        encoding: Encoding,
+        enc: &EncodingMeta,
+        start: usize,
+        certificate_header: Option<&HeaderField>,
+    ) -> Option<HttpResponse> {
+        let chunks: Vec<Vec<u8>> = (0..enc.num_chunks)
+            .map(|i| self.content.get(enc.content_id, i).unwrap_or_default())
+            .collect();
+        let total: usize = chunks.iter().map(|c| c.len()).sum();
+        if total == 0 || start >= total {
+            return None;
+        }
+        let mut offset = 0usize;
+        for chunk in chunks {
+            let len = chunk.len();
+            if start < offset + len {
+                let content_range = format!("bytes {}-{}/{}", offset, offset + len - 1, total);
+                let mut headers = range_headers_for(
+                    &self.effective_headers(meta),
+                    &meta.content_type,
+                    encoding,
+                    &enc.sha256,
+                    &content_range,
+                );
+                if let Some(head) = certificate_header {
+                    headers.push((head.0.clone(), head.1.clone()));
+                }
+                return Some(HttpResponse {
+                    status_code: 206,
+                    headers,
+                    body: ByteBuf::from(chunk),
+                    upgrade: None,
+                    streaming_strategy: None,
+                });
+            }
+            offset += len;
+        }
+        None
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn build_redirect_rule_response(
         &self,
@@ -678,6 +796,7 @@ impl State {
                     callback,
                     etags,
                     status_override,
+                    None, // spike: range serving through aliases is Phase 2c, not here
                 )
                 .unwrap_or_else(|| HttpResponse::build_404(cert_header))
             }
@@ -692,11 +811,14 @@ impl State {
     ) -> HttpResponse {
         let mut encodings: Vec<Encoding> = vec![];
         let mut etags: Vec<Hash> = vec![];
+        let mut range_start: Option<usize> = None;
         for (name, value) in req.headers.iter() {
             if name.eq_ignore_ascii_case("Accept-Encoding") {
                 encodings.extend(Encoding::parse_accept_encoding(value));
             } else if name.eq_ignore_ascii_case("If-None-Match") {
                 etags.extend(parse_if_none_match(value));
+            } else if name.eq_ignore_ascii_case("Range") {
+                range_start = parse_range_start(value);
             }
         }
 
@@ -706,7 +828,9 @@ impl State {
         };
 
         match url_decode(path) {
-            Ok(path) => self.build_http_response(certificate, &path, encodings, 0, callback, etags),
+            Ok(path) => {
+                self.build_http_response(certificate, &path, encodings, 0, callback, etags, range_start)
+            }
             // Malformed percent-encoding (invalid UTF-8 once decoded). This 400
             // is intentionally uncertified: the body is per-request (it echoes
             // the bad path), so it can't be pinned to a certified hash, and a

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -479,8 +479,12 @@ impl State {
                 self.asset_hashes.certify_response_precomputed(&hash_200);
             } else {
                 // Multi-chunk: certify one 206 per chunk (response-only).
-                let (range_cert_expr, resp_hashes) =
-                    self.range_response_certs(&effective_headers, &meta.content_type, encoding, enc);
+                let (range_cert_expr, resp_hashes) = self.range_response_certs(
+                    &effective_headers,
+                    &meta.content_type,
+                    encoding,
+                    enc,
+                );
                 for resp_hash in resp_hashes {
                     let hash_path = path.hash_tree_path(
                         &range_cert_expr,
@@ -675,7 +679,11 @@ impl State {
             .iter()
             .copied()
             .find(|e| acceptable(e))
-            .or_else(|| Encoding::PREFERENCE_ORDER.into_iter().find(|e| acceptable(e)))?;
+            .or_else(|| {
+                Encoding::PREFERENCE_ORDER
+                    .into_iter()
+                    .find(|e| acceptable(e))
+            })?;
         let enc = meta.encodings.get(&encoding)?;
         Some(self.build_ok_http_response(
             meta,
@@ -778,7 +786,10 @@ impl State {
         // Find the chunk whose [offset, offset+len) contains `start`.
         let mut offset = 0usize;
         let mut target: Option<(u32, usize, usize)> = None; // (chunk_index, chunk_start, len)
-        for entry in self.chunk_certs.range(ContentChunkKey::range(enc.content_id)) {
+        for entry in self
+            .chunk_certs
+            .range(ContentChunkKey::range(enc.content_id))
+        {
             let (key, cc) = entry.into_pair();
             let len = cc.len as usize;
             if start < offset + len {
@@ -1022,8 +1033,12 @@ impl State {
             // reassembles them into a 200), exactly like a direct hit. Certify
             // those 206 leaves at the alias location and move on.
             if status == 200 && enc.num_chunks > 1 {
-                let (range_cert_expr, resp_hashes) =
-                    self.range_response_certs(&effective_headers, &meta.content_type, encoding, enc);
+                let (range_cert_expr, resp_hashes) = self.range_response_certs(
+                    &effective_headers,
+                    &meta.content_type,
+                    encoding,
+                    enc,
+                );
                 for resp_hash in resp_hashes {
                     let tp = crate::redirect::alias_tree_path(
                         &location,

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -208,6 +208,16 @@ impl State {
         self.metadata.contains_key(key)
     }
 
+    /// Whether the asset at `key` exists and stores any encoding as more than one
+    /// chunk. A 4xx custom-error-page rule can only serve a single-chunk target
+    /// (see [`State::build_alias_rule_entry`]), so the sync op guard rejects 4xx
+    /// rules whose target is already multi-chunk.
+    pub fn target_is_multichunk(&self, key: &str) -> bool {
+        self.metadata
+            .get(&key.to_string())
+            .is_some_and(|meta| meta.encodings.values().any(|e| e.num_chunks > 1))
+    }
+
     pub fn authorize(&mut self, principal: Principal) {
         let mut authorized = self.authorized.get().clone();
         authorized.0.insert(principal);
@@ -992,6 +1002,19 @@ impl State {
         let location = crate::redirect::tree_location(rule);
         let mut tree_paths = Vec::new();
         for (&encoding, enc) in &meta.encodings {
+            // A 4xx custom error page is served as a single inline body with the
+            // override status — 206 reassembly always yields a 200, so a
+            // multi-chunk encoding can't carry it. Mirror the serve-side
+            // `acceptable` filter and skip such encodings; certifying them here
+            // would leave an unservable leaf the serve path never reproduces (it
+            // falls back to the built-in 404), so the gateway would reject the
+            // mismatched response. If *every* encoding is multi-chunk the rule
+            // gets no leaves and goes inert (built-in 404 fallthrough). The sync
+            // op guard rejects this combination up front; this keeps the
+            // certified tree sound even if some other caller slips it through.
+            if status != 200 && enc.num_chunks > 1 {
+                continue;
+            }
             let cert_expr = certificate_expression_for(&effective_headers, encoding, &enc.sha256);
 
             // A 200-rewrite to a multi-chunk target serves N×206 (the gateway

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -16,11 +16,12 @@
 
 use crate::asset::{
     certificate_expression_for, headers_for, range_certificate_expression_for, range_headers_for,
-    range_response_hash, response_hashes_for, STATUS_CODES_TO_CERTIFY,
+    range_response_hash, response_hashes_for,
 };
 use crate::blob_store::BlobStore;
 use crate::certification::{
-    response_hash, AssetKey, AssetPath, CertifiedResponses, RequestHash, ResponseHash,
+    response_hash, AssetKey, AssetPath, CertificateExpression, CertifiedResponses, RequestHash,
+    ResponseHash,
 };
 use crate::http::{
     CallbackFunc, HeaderField, HttpRequest, HttpResponse, StreamingCallbackHttpResponse,
@@ -446,55 +447,79 @@ impl State {
                 &cert_expr,
                 &enc.sha256,
             );
-            for status_code in STATUS_CODES_TO_CERTIFY {
-                let response_hash = response_hashes[&status_code];
-                let hash_path = path.hash_tree_path(
+            // Always certify the 304 (empty body). Certify the full 200 only for
+            // single-chunk encodings — a multi-chunk asset is served as N×206 (the
+            // gateway reassembles them into a 200), so a full 200 is never served
+            // and certifying it would be dead weight in the tree.
+            let hash_304 = path.hash_tree_path(
+                &cert_expr,
+                &RequestHash::default(),
+                ResponseHash::from(&response_hashes[&304]),
+            );
+            self.asset_hashes.certify_response_precomputed(&hash_304);
+            if enc.num_chunks == 1 {
+                let hash_200 = path.hash_tree_path(
                     &cert_expr,
                     &RequestHash::default(),
-                    ResponseHash::from(&response_hash),
+                    ResponseHash::from(&response_hashes[&200]),
                 );
-                self.asset_hashes.certify_response_precomputed(&hash_path);
-            }
-
-            // Certify N×206 for multi-chunk encodings (response-only). Content-free:
-            // per-chunk length + hash come from `chunk_certs`, so this stays cheap
-            // even when `post_upgrade` re-certifies every asset.
-            if enc.num_chunks > 1 {
-                let range_cert_expr =
-                    range_certificate_expression_for(&effective_headers, encoding, &enc.sha256);
-                let total = enc.content_len;
-                // Collect first so the `chunk_certs` borrow is released before we
-                // borrow `asset_hashes` mutably below.
-                let chunk_infos: Vec<(u32, [u8; 32])> = self
-                    .chunk_certs
-                    .range(ContentChunkKey::range(enc.content_id))
-                    .map(|e| {
-                        let cc = e.into_pair().1;
-                        (cc.len, cc.sha256)
-                    })
-                    .collect();
-                let mut offset: u64 = 0;
-                for (len, sha256) in chunk_infos {
-                    let len = len as u64;
-                    let content_range = format!("bytes {}-{}/{}", offset, offset + len - 1, total);
-                    let resp_hash = range_response_hash(
-                        &effective_headers,
-                        &meta.content_type,
-                        encoding,
-                        &enc.sha256,
-                        &content_range,
-                        &sha256,
-                    );
+                self.asset_hashes.certify_response_precomputed(&hash_200);
+            } else {
+                // Multi-chunk: certify one 206 per chunk (response-only).
+                let (range_cert_expr, resp_hashes) =
+                    self.range_response_certs(&effective_headers, &meta.content_type, encoding, enc);
+                for resp_hash in resp_hashes {
                     let hash_path = path.hash_tree_path(
                         &range_cert_expr,
                         &RequestHash::default(),
                         ResponseHash::from(&resp_hash),
                     );
                     self.asset_hashes.certify_response_precomputed(&hash_path);
-                    offset += len;
                 }
             }
         }
+    }
+
+    /// Content-free per-chunk 206 certification data for a multi-chunk encoding:
+    /// the shared range certificate expression plus one response hash per chunk,
+    /// in chunk order. Derived from `chunk_certs` + `content_len`, so it never
+    /// reads chunk bytes. Both the direct-asset path (`recertify_asset`) and the
+    /// alias path (`build_alias_rule_entry`) use it, each placing the resulting
+    /// leaves at its own tree location.
+    fn range_response_certs(
+        &self,
+        effective_headers: &[(String, String)],
+        content_type: &str,
+        encoding: Encoding,
+        enc: &EncodingMeta,
+    ) -> (CertificateExpression, Vec<[u8; 32]>) {
+        let range_cert_expr =
+            range_certificate_expression_for(effective_headers, encoding, &enc.sha256);
+        let total = enc.content_len;
+        let chunk_infos: Vec<(u32, [u8; 32])> = self
+            .chunk_certs
+            .range(ContentChunkKey::range(enc.content_id))
+            .map(|e| {
+                let cc = e.into_pair().1;
+                (cc.len, cc.sha256)
+            })
+            .collect();
+        let mut resp_hashes = Vec::with_capacity(chunk_infos.len());
+        let mut offset: u64 = 0;
+        for (len, sha256) in chunk_infos {
+            let len = len as u64;
+            let content_range = format!("bytes {}-{}/{}", offset, offset + len - 1, total);
+            resp_hashes.push(range_response_hash(
+                effective_headers,
+                content_type,
+                encoding,
+                &enc.sha256,
+                &content_range,
+                &sha256,
+            ));
+            offset += len;
+        }
+        (range_cert_expr, resp_hashes)
     }
 
     // ---- queries ----
@@ -607,6 +632,7 @@ impl State {
                 chunk_index,
                 &callback,
                 &etags,
+                range_start,
             );
         }
 
@@ -806,6 +832,7 @@ impl State {
         chunk_index: usize,
         callback: &CallbackFunc,
         etags: &[Hash],
+        range_start: Option<usize>,
     ) -> HttpResponse {
         let cert_header =
             self.asset_hashes
@@ -840,7 +867,7 @@ impl State {
                     callback,
                     etags,
                     status_override,
-                    None, // spike: range serving through aliases is Phase 2c, not here
+                    range_start,
                 )
                 .unwrap_or_else(|| HttpResponse::build_404(cert_header))
             }
@@ -1026,6 +1053,25 @@ impl State {
         let mut tree_paths = Vec::new();
         for (&encoding, enc) in &meta.encodings {
             let cert_expr = certificate_expression_for(&effective_headers, encoding, &enc.sha256);
+
+            // A 200-rewrite to a multi-chunk target serves N×206 (the gateway
+            // reassembles them into a 200), exactly like a direct hit. Certify
+            // those 206 leaves at the alias location and move on.
+            if status == 200 && enc.num_chunks > 1 {
+                let (range_cert_expr, resp_hashes) =
+                    self.range_response_certs(&effective_headers, &meta.content_type, encoding, enc);
+                for resp_hash in resp_hashes {
+                    let tp = crate::redirect::alias_tree_path(
+                        &location,
+                        range_cert_expr.expression_hash,
+                        resp_hash,
+                    );
+                    self.asset_hashes.certify_response_precomputed(&tp);
+                    tree_paths.push(tp);
+                }
+                continue;
+            }
+
             let resp_hash = if status == 200 {
                 // The encoding's already-certified 200 response hash.
                 response_hashes_for(

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -26,7 +26,9 @@ use crate::http::{
     CallbackFunc, HeaderField, HttpRequest, HttpResponse, StreamingCallbackHttpResponse,
     StreamingCallbackToken, StreamingStrategy,
 };
-use crate::stable_store::{AssetMeta, AuthorizedSet, EncodingMeta, RedirectRules};
+use crate::stable_store::{
+    AssetMeta, AuthorizedSet, ChunkCert, ContentChunkKey, EncodingMeta, RedirectRules,
+};
 use crate::sync::{Chunk, SyncSession};
 use crate::url::url_decode;
 use candid::Principal;
@@ -94,6 +96,9 @@ const METADATA_MEMORY: MemoryId = MemoryId::new(4);
 const CONTENT_INDEX_MEMORY: MemoryId = MemoryId::new(5);
 /// Raw contiguous chunk bytes managed by the [`BlobStore`] allocator.
 const CONTENT_DATA_MEMORY: MemoryId = MemoryId::new(6);
+/// Per-chunk certification data (`ContentChunkKey -> ChunkCert`); read by the
+/// 206 certify/serve paths so neither has to re-hash or fully read content.
+const CHUNK_CERT_MEMORY: MemoryId = MemoryId::new(7);
 
 pub struct State {
     // ---- durable (stable memory) ----
@@ -114,6 +119,11 @@ pub struct State {
     /// `stable64_read`/`write` instead of an overflow-page walk. See
     /// [`crate::blob_store`].
     content: BlobStore<Mem>,
+    /// Per-chunk certification data (length + SHA-256), keyed by the same
+    /// `(content_id, chunk_index)` as the content blob. Lets the 206 certify path
+    /// stay content-free (no re-hash in `post_upgrade`) and the serve path avoid
+    /// reading every chunk to locate a range. Freed alongside its content group.
+    chunk_certs: StableBTreeMap<ContentChunkKey, ChunkCert, Mem>,
 
     // ---- transient heap (lost on upgrade) ----
     /// Chunks staged by `upload_chunks` for the current sync, in upload order:
@@ -169,6 +179,7 @@ impl State {
             next_content_id: StableCell::init(mm.get(NEXT_CONTENT_ID_MEMORY), 0),
             metadata: StableBTreeMap::init(mm.get(METADATA_MEMORY)),
             content: BlobStore::init(mm.get(CONTENT_INDEX_MEMORY), mm.get(CONTENT_DATA_MEMORY)),
+            chunk_certs: StableBTreeMap::init(mm.get(CHUNK_CERT_MEMORY)),
             chunks: Vec::new(),
             sync_session: None,
             asset_hashes: CertifiedResponses::default(),
@@ -235,9 +246,18 @@ impl State {
             .unwrap_or_default()
     }
 
-    /// Frees every chunk belonging to a content group.
+    /// Frees every chunk belonging to a content group, including its per-chunk
+    /// certification entries.
     fn delete_content(&mut self, content_id: u64) {
         self.content.delete_group(content_id);
+        let keys: Vec<ContentChunkKey> = self
+            .chunk_certs
+            .range(ContentChunkKey::range(content_id))
+            .map(|e| e.into_pair().0)
+            .collect();
+        for key in keys {
+            self.chunk_certs.remove(&key);
+        }
     }
 
     // ---- asset mutations ----
@@ -317,11 +337,23 @@ impl State {
             self.delete_content(old.content_id);
         }
 
-        // Allocate a fresh content group and write the chunks into it.
+        // Allocate a fresh content group and write the chunks into it, recording
+        // each chunk's length + hash for the 206 cert/serve paths as we go.
+        use sha2::Digest;
         let content_id = self.alloc_content_id();
         let num_chunks = content_chunks.len() as u32;
+        let mut content_len = 0u64;
         for (index, chunk) in content_chunks.iter().enumerate() {
             self.content.insert(content_id, index as u32, chunk);
+            let chunk_sha256: [u8; 32] = sha2::Sha256::digest(chunk).into();
+            self.chunk_certs.insert(
+                ContentChunkKey::new(content_id, index as u32),
+                ChunkCert {
+                    len: chunk.len() as u32,
+                    sha256: chunk_sha256,
+                },
+            );
+            content_len += chunk.len() as u64;
         }
 
         meta.encodings.insert(
@@ -330,6 +362,7 @@ impl State {
                 content_id,
                 num_chunks,
                 sha256,
+                content_len,
             },
         );
         self.recertify_asset(&arg.key, &meta);
@@ -423,29 +456,34 @@ impl State {
                 self.asset_hashes.certify_response_precomputed(&hash_path);
             }
 
-            // Phase 0 spike: certify N×206 for multi-chunk encodings (response-only).
-            // SHORTCUT: reads chunk bytes to hash them, so this is NOT content-free
-            // (the real Phase 1 stores per-chunk hashes to keep `post_upgrade` cheap).
+            // Certify N×206 for multi-chunk encodings (response-only). Content-free:
+            // per-chunk length + hash come from `chunk_certs`, so this stays cheap
+            // even when `post_upgrade` re-certifies every asset.
             if enc.num_chunks > 1 {
-                use sha2::Digest;
-                let chunks: Vec<Vec<u8>> = (0..enc.num_chunks)
-                    .map(|i| self.content.get(enc.content_id, i).unwrap_or_default())
-                    .collect();
-                let total: usize = chunks.iter().map(|c| c.len()).sum();
                 let range_cert_expr =
                     range_certificate_expression_for(&effective_headers, encoding, &enc.sha256);
-                let mut offset = 0usize;
-                for chunk in &chunks {
-                    let len = chunk.len();
+                let total = enc.content_len;
+                // Collect first so the `chunk_certs` borrow is released before we
+                // borrow `asset_hashes` mutably below.
+                let chunk_infos: Vec<(u32, [u8; 32])> = self
+                    .chunk_certs
+                    .range(ContentChunkKey::range(enc.content_id))
+                    .map(|e| {
+                        let cc = e.into_pair().1;
+                        (cc.len, cc.sha256)
+                    })
+                    .collect();
+                let mut offset: u64 = 0;
+                for (len, sha256) in chunk_infos {
+                    let len = len as u64;
                     let content_range = format!("bytes {}-{}/{}", offset, offset + len - 1, total);
-                    let body_hash: [u8; 32] = sha2::Sha256::digest(chunk).into();
                     let resp_hash = range_response_hash(
                         &effective_headers,
                         &meta.content_type,
                         encoding,
                         &enc.sha256,
                         &content_range,
-                        &body_hash,
+                        &sha256,
                     );
                     let hash_path = path.hash_tree_path(
                         &range_cert_expr,
@@ -701,13 +739,12 @@ impl State {
         }
     }
 
-    /// Phase 0 spike: build a certified 206 for the chunk containing byte `start`
-    /// (snapped down to the chunk boundary). Returns `None` (caller falls back to
-    /// the normal 200 path) when the encoding is empty or `start` is past the end.
+    /// Build a certified 206 for the chunk containing byte `start` (snapped down
+    /// to the chunk boundary). Returns `None` (caller falls back to the normal 200
+    /// path) when the encoding is empty or `start` is past the end.
     ///
-    /// SHORTCUT: reads every chunk to compute the total length and locate the
-    /// target. The real serve path keeps this lean (per-chunk lengths from the
-    /// blob index; no full read).
+    /// Lean: locates the target chunk by scanning `chunk_certs` (tiny fixed
+    /// entries, early exit), then reads only that one chunk's bytes.
     fn build_range_response(
         &self,
         meta: &AssetMeta,
@@ -716,39 +753,46 @@ impl State {
         start: usize,
         certificate_header: Option<&HeaderField>,
     ) -> Option<HttpResponse> {
-        let chunks: Vec<Vec<u8>> = (0..enc.num_chunks)
-            .map(|i| self.content.get(enc.content_id, i).unwrap_or_default())
-            .collect();
-        let total: usize = chunks.iter().map(|c| c.len()).sum();
+        let total = enc.content_len as usize;
         if total == 0 || start >= total {
             return None;
         }
+        // Find the chunk whose [offset, offset+len) contains `start`.
         let mut offset = 0usize;
-        for chunk in chunks {
-            let len = chunk.len();
+        let mut target: Option<(u32, usize, usize)> = None; // (chunk_index, chunk_start, len)
+        for entry in self.chunk_certs.range(ContentChunkKey::range(enc.content_id)) {
+            let (key, cc) = entry.into_pair();
+            let len = cc.len as usize;
             if start < offset + len {
-                let content_range = format!("bytes {}-{}/{}", offset, offset + len - 1, total);
-                let mut headers = range_headers_for(
-                    &self.effective_headers(meta),
-                    &meta.content_type,
-                    encoding,
-                    &enc.sha256,
-                    &content_range,
-                );
-                if let Some(head) = certificate_header {
-                    headers.push((head.0.clone(), head.1.clone()));
-                }
-                return Some(HttpResponse {
-                    status_code: 206,
-                    headers,
-                    body: ByteBuf::from(chunk),
-                    upgrade: None,
-                    streaming_strategy: None,
-                });
+                target = Some((key.chunk_index, offset, len));
+                break;
             }
             offset += len;
         }
-        None
+        let (chunk_index, chunk_start, len) = target?;
+
+        let chunk = self
+            .content
+            .get(enc.content_id, chunk_index)
+            .unwrap_or_default();
+        let content_range = format!("bytes {}-{}/{}", chunk_start, chunk_start + len - 1, total);
+        let mut headers = range_headers_for(
+            &self.effective_headers(meta),
+            &meta.content_type,
+            encoding,
+            &enc.sha256,
+            &content_range,
+        );
+        if let Some(head) = certificate_header {
+            headers.push((head.0.clone(), head.1.clone()));
+        }
+        Some(HttpResponse {
+            status_code: 206,
+            headers,
+            body: ByteBuf::from(chunk),
+            upgrade: None,
+            streaming_strategy: None,
+        })
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/canister-core/src/state.rs
+++ b/crates/canister-core/src/state.rs
@@ -694,6 +694,7 @@ impl State {
     /// (etag-based not-modified). When it is `Some(s)` — used by redirect rules
     /// that serve a custom error page — the response always carries the body
     /// with status `s`, and the etag / 304 logic is skipped.
+    #[allow(clippy::too_many_arguments)]
     fn build_ok_http_response(
         &self,
         meta: &AssetMeta,

--- a/crates/canister-core/src/sync.rs
+++ b/crates/canister-core/src/sync.rs
@@ -254,6 +254,25 @@ impl State {
                                 validation = Err(e);
                                 break;
                             }
+                            // A 404/410 custom error page is served as a single
+                            // inline body, so its target must be single-chunk
+                            // (see `State::build_alias_rule_entry`). Reject up
+                            // front when the target already exists and is
+                            // multi-chunk. A target that doesn't exist yet is
+                            // allowed — the rule stays inert until it does. The
+                            // sync-plugin enforces the same cross-check at deploy
+                            // time; this guards against other callers.
+                            if matches!(rule.status, 404 | 410)
+                                && self.target_is_multichunk(&rule.to)
+                            {
+                                validation = Err(format!(
+                                    "redirect rule to '{}' with status {} points to a \
+                                     multi-chunk asset; 404/410 error pages must be small \
+                                     enough to serve as a single chunk (< ~1.9 MB)",
+                                    rule.to, rule.status
+                                ));
+                                break;
+                            }
                         }
                         validation.map(|_| self.set_redirect_rules(arg.rules.clone()))
                     }

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -871,11 +871,11 @@ fn multichunk_plain_get_serves_206_first_chunk() {
             .with_encoding("identity", vec![C0, C1])],
     );
 
-    let resp = state.http_request(
+    let resp = certified_http_request(
+        &state,
         RequestBuilder::get("/big.bin")
             .with_header("Accept-Encoding", "identity")
             .build(),
-        &[],
     );
 
     assert_eq!(resp.status_code, 206);
@@ -901,12 +901,12 @@ fn range_request_returns_containing_chunk() {
     );
     let total = C0.len() + C1.len() + C2.len();
 
-    let resp = state.http_request(
+    let resp = certified_http_request(
+        &state,
         RequestBuilder::get("/big.bin")
             .with_header("Accept-Encoding", "identity")
             .with_header("Range", &format!("bytes={}-", C0.len()))
             .build(),
-        &[],
     );
 
     assert_eq!(resp.status_code, 206);
@@ -932,12 +932,12 @@ fn range_request_mid_chunk_snaps_to_chunk_start() {
     let total = C0.len() + C1.len();
 
     // Ask for a byte 2 into chunk 1; expect the whole of chunk 1 back.
-    let resp = state.http_request(
+    let resp = certified_http_request(
+        &state,
         RequestBuilder::get("/big.bin")
             .with_header("Accept-Encoding", "identity")
             .with_header("Range", &format!("bytes={}-", C0.len() + 2))
             .build(),
-        &[],
     );
 
     assert_eq!(resp.status_code, 206);
@@ -963,12 +963,12 @@ fn range_spanning_chunks_returns_single_chunk() {
     let total = C0.len() + C1.len();
 
     // Closed range covering the whole asset → still just chunk 0.
-    let resp = state.http_request(
+    let resp = certified_http_request(
+        &state,
         RequestBuilder::get("/big.bin")
             .with_header("Accept-Encoding", "identity")
             .with_header("Range", &format!("bytes=0-{}", total - 1))
             .build(),
-        &[],
     );
 
     assert_eq!(resp.status_code, 206);
@@ -993,12 +993,12 @@ fn out_of_range_serves_full_asset_via_206() {
     );
     let total = C0.len() + C1.len();
 
-    let resp = state.http_request(
+    let resp = certified_http_request(
+        &state,
         RequestBuilder::get("/big.bin")
             .with_header("Accept-Encoding", "identity")
             .with_header("Range", &format!("bytes={}-", total + 100))
             .build(),
-        &[],
     );
 
     assert_eq!(resp.status_code, 206);
@@ -1023,23 +1023,23 @@ fn conditional_request_with_range_returns_304() {
     );
 
     // First request: read the canister-managed etag off the 206.
-    let first = state.http_request(
+    let first = certified_http_request(
+        &state,
         RequestBuilder::get("/big.bin")
             .with_header("Accept-Encoding", "identity")
             .build(),
-        &[],
     );
     let etag = lookup_header(&first, "etag")
         .expect("206 carries an etag")
         .to_string();
 
-    let resp = state.http_request(
+    let resp = certified_http_request(
+        &state,
         RequestBuilder::get("/big.bin")
             .with_header("Accept-Encoding", "identity")
             .with_header("If-None-Match", &etag)
             .with_header("Range", "bytes=10-")
             .build(),
-        &[],
     );
 
     assert_eq!(resp.status_code, 304);
@@ -1058,12 +1058,12 @@ fn single_chunk_asset_ignores_range() {
         vec![AssetBuilder::new("/small.txt", "text/plain").with_encoding("identity", vec![BODY])],
     );
 
-    let resp = state.http_request(
+    let resp = certified_http_request(
+        &state,
         RequestBuilder::get("/small.txt")
             .with_header("Accept-Encoding", "identity")
             .with_header("Range", "bytes=5-")
             .build(),
-        &[],
     );
 
     assert_eq!(resp.status_code, 200);
@@ -1087,12 +1087,12 @@ fn range_request_non_identity_encoding() {
     );
     let total = G0.len() + G1.len();
 
-    let resp = state.http_request(
+    let resp = certified_http_request(
+        &state,
         RequestBuilder::get("/app.js")
             .with_header("Accept-Encoding", "gzip")
             .with_header("Range", &format!("bytes={}-", G0.len()))
             .build(),
-        &[],
     );
 
     assert_eq!(resp.status_code, 206);
@@ -1122,18 +1122,103 @@ fn range_serving_survives_upgrade() {
 
     let restored = upgrade(state, memory.clone());
 
-    let resp = restored.http_request(
+    let resp = certified_http_request(
+        &restored,
         RequestBuilder::get("/big.bin")
             .with_header("Accept-Encoding", "identity")
             .with_header("Range", &format!("bytes={}-", C0.len()))
             .build(),
-        &[],
     );
 
     assert_eq!(resp.status_code, 206);
     assert_eq!(resp.body.as_ref(), C1);
     let cr = format!("bytes {}-{}/{}", C0.len(), total - 1, total);
     assert_eq!(lookup_header(&resp, "content-range"), Some(cr.as_str()));
+}
+
+/// Range forms the canister doesn't honour — a suffix range (`bytes=-N`), a
+/// multi-range list, and a syntactically broken spec — all parse to "no range"
+/// and serve the asset as a certified 206 chunk 0 (never a truncated 200), which
+/// the gateway reassembles into the full 200.
+#[test]
+fn unhonoured_range_forms_serve_certified_206_chunk_0() {
+    let mut state = State::default();
+    let ctx = mock_system_context();
+    const C0: &[u8] = b"AAAAAAAAAA";
+    const C1: &[u8] = b"BBBBBBB";
+    create_assets(
+        &mut state,
+        &ctx,
+        vec![AssetBuilder::new("/big.bin", "application/octet-stream")
+            .with_encoding("identity", vec![C0, C1])],
+    );
+    let total = C0.len() + C1.len();
+    let cr = format!("bytes 0-{}/{}", C0.len() - 1, total);
+
+    for range in ["bytes=-500", "bytes=0-1,5-6", "bytes=abc-", "kingdoms=0-"] {
+        let resp = certified_http_request(
+            &state,
+            RequestBuilder::get("/big.bin")
+                .with_header("Accept-Encoding", "identity")
+                .with_header("Range", range)
+                .build(),
+        );
+        assert_eq!(resp.status_code, 206, "range {range:?}");
+        assert_eq!(resp.body.as_ref(), C0, "range {range:?}");
+        assert_eq!(
+            lookup_header(&resp, "content-range"),
+            Some(cr.as_str()),
+            "range {range:?}"
+        );
+    }
+}
+
+/// Range/chunk behaviour follows the *selected* encoding, not the asset. A file
+/// stored as a 2-chunk identity plus a 1-chunk (compressed-below-threshold) gzip
+/// serves a 206 when identity is chosen but a plain 200 when gzip is chosen —
+/// both certified.
+#[test]
+fn range_follows_selected_encoding_chunk_count() {
+    let mut state = State::default();
+    let ctx = mock_system_context();
+    const I0: &[u8] = b"identity-chunk-0--";
+    const I1: &[u8] = b"identity-chunk-1";
+    const GZ: &[u8] = b"\x1f\x8b\x08\x00small-gzip";
+    create_assets(
+        &mut state,
+        &ctx,
+        vec![AssetBuilder::new("/app.js", "text/javascript")
+            .with_encoding("identity", vec![I0, I1])
+            .with_encoding("gzip", vec![GZ])],
+    );
+
+    // gzip is single-chunk → Range ignored, full 200.
+    let gz = certified_http_request(
+        &state,
+        RequestBuilder::get("/app.js")
+            .with_header("Accept-Encoding", "gzip")
+            .with_header("Range", "bytes=4-")
+            .build(),
+    );
+    assert_eq!(gz.status_code, 200);
+    assert_eq!(gz.body.as_ref(), GZ);
+    assert_eq!(lookup_header(&gz, "content-encoding"), Some("gzip"));
+    assert_eq!(lookup_header(&gz, "content-range"), None);
+
+    // identity is two chunks → Range honoured, certified 206.
+    let id = certified_http_request(
+        &state,
+        RequestBuilder::get("/app.js")
+            .with_header("Accept-Encoding", "identity")
+            .with_header("Range", &format!("bytes={}-", I0.len()))
+            .build(),
+    );
+    assert_eq!(id.status_code, 206);
+    assert_eq!(id.body.as_ref(), I1);
+    assert_eq!(lookup_header(&id, "content-encoding"), None);
+    let total = I0.len() + I1.len();
+    let cr = format!("bytes {}-{}/{}", I0.len(), total - 1, total);
+    assert_eq!(lookup_header(&id, "content-range"), Some(cr.as_str()));
 }
 
 #[test]

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -854,6 +854,288 @@ fn authorized_set_survives_stable_roundtrip() {
     assert!(restored.is_authorized(&p));
 }
 
+// ───────── HTTP 206 range serving ─────────
+
+/// A plain GET (no Range) of a multi-chunk asset returns chunk 0 as a 206 — this
+/// is what drives the gateway's reassembly into a full 200.
+#[test]
+fn multichunk_plain_get_serves_206_first_chunk() {
+    let mut state = State::default();
+    let ctx = mock_system_context();
+    const C0: &[u8] = b"first-chunk-bytes--";
+    const C1: &[u8] = b"second-chunk";
+    create_assets(
+        &mut state,
+        &ctx,
+        vec![AssetBuilder::new("/big.bin", "application/octet-stream")
+            .with_encoding("identity", vec![C0, C1])],
+    );
+
+    let resp = state.http_request(
+        RequestBuilder::get("/big.bin")
+            .with_header("Accept-Encoding", "identity")
+            .build(),
+        &[],
+    );
+
+    assert_eq!(resp.status_code, 206);
+    assert_eq!(resp.body.as_ref(), C0);
+    let total = C0.len() + C1.len();
+    let cr = format!("bytes 0-{}/{}", C0.len() - 1, total);
+    assert_eq!(lookup_header(&resp, "content-range"), Some(cr.as_str()));
+}
+
+/// A Range request whose start is a chunk boundary returns exactly that chunk.
+#[test]
+fn range_request_returns_containing_chunk() {
+    let mut state = State::default();
+    let ctx = mock_system_context();
+    const C0: &[u8] = b"AAAAAAAAAA";
+    const C1: &[u8] = b"BBBBBBB";
+    const C2: &[u8] = b"CCC";
+    create_assets(
+        &mut state,
+        &ctx,
+        vec![AssetBuilder::new("/big.bin", "application/octet-stream")
+            .with_encoding("identity", vec![C0, C1, C2])],
+    );
+    let total = C0.len() + C1.len() + C2.len();
+
+    let resp = state.http_request(
+        RequestBuilder::get("/big.bin")
+            .with_header("Accept-Encoding", "identity")
+            .with_header("Range", &format!("bytes={}-", C0.len()))
+            .build(),
+        &[],
+    );
+
+    assert_eq!(resp.status_code, 206);
+    assert_eq!(resp.body.as_ref(), C1);
+    let cr = format!("bytes {}-{}/{}", C0.len(), C0.len() + C1.len() - 1, total);
+    assert_eq!(lookup_header(&resp, "content-range"), Some(cr.as_str()));
+}
+
+/// A Range start in the middle of a chunk snaps down to that chunk's boundary:
+/// the whole containing chunk is returned (sub-chunk slices can't be certified).
+#[test]
+fn range_request_mid_chunk_snaps_to_chunk_start() {
+    let mut state = State::default();
+    let ctx = mock_system_context();
+    const C0: &[u8] = b"AAAAAAAAAA";
+    const C1: &[u8] = b"BBBBBBB";
+    create_assets(
+        &mut state,
+        &ctx,
+        vec![AssetBuilder::new("/big.bin", "application/octet-stream")
+            .with_encoding("identity", vec![C0, C1])],
+    );
+    let total = C0.len() + C1.len();
+
+    // Ask for a byte 2 into chunk 1; expect the whole of chunk 1 back.
+    let resp = state.http_request(
+        RequestBuilder::get("/big.bin")
+            .with_header("Accept-Encoding", "identity")
+            .with_header("Range", &format!("bytes={}-", C0.len() + 2))
+            .build(),
+        &[],
+    );
+
+    assert_eq!(resp.status_code, 206);
+    assert_eq!(resp.body.as_ref(), C1);
+    let cr = format!("bytes {}-{}/{}", C0.len(), total - 1, total);
+    assert_eq!(lookup_header(&resp, "content-range"), Some(cr.as_str()));
+}
+
+/// A range that spans multiple chunks returns only the chunk containing its
+/// start; the client (or gateway) fetches the rest with follow-up requests.
+#[test]
+fn range_spanning_chunks_returns_single_chunk() {
+    let mut state = State::default();
+    let ctx = mock_system_context();
+    const C0: &[u8] = b"AAAAAAAAAA";
+    const C1: &[u8] = b"BBBBBBB";
+    create_assets(
+        &mut state,
+        &ctx,
+        vec![AssetBuilder::new("/big.bin", "application/octet-stream")
+            .with_encoding("identity", vec![C0, C1])],
+    );
+    let total = C0.len() + C1.len();
+
+    // Closed range covering the whole asset → still just chunk 0.
+    let resp = state.http_request(
+        RequestBuilder::get("/big.bin")
+            .with_header("Accept-Encoding", "identity")
+            .with_header("Range", &format!("bytes=0-{}", total - 1))
+            .build(),
+        &[],
+    );
+
+    assert_eq!(resp.status_code, 206);
+    assert_eq!(resp.body.as_ref(), C0);
+    let cr = format!("bytes 0-{}/{}", C0.len() - 1, total);
+    assert_eq!(lookup_header(&resp, "content-range"), Some(cr.as_str()));
+}
+
+/// An unsatisfiable range (start past the end) ignores the Range and serves the
+/// asset as a 206 chunk 0 — never a truncated 200.
+#[test]
+fn out_of_range_serves_full_asset_via_206() {
+    let mut state = State::default();
+    let ctx = mock_system_context();
+    const C0: &[u8] = b"AAAAAAAAAA";
+    const C1: &[u8] = b"BBBBBBB";
+    create_assets(
+        &mut state,
+        &ctx,
+        vec![AssetBuilder::new("/big.bin", "application/octet-stream")
+            .with_encoding("identity", vec![C0, C1])],
+    );
+    let total = C0.len() + C1.len();
+
+    let resp = state.http_request(
+        RequestBuilder::get("/big.bin")
+            .with_header("Accept-Encoding", "identity")
+            .with_header("Range", &format!("bytes={}-", total + 100))
+            .build(),
+        &[],
+    );
+
+    assert_eq!(resp.status_code, 206);
+    assert_eq!(resp.body.as_ref(), C0);
+    let cr = format!("bytes 0-{}/{}", C0.len() - 1, total);
+    assert_eq!(lookup_header(&resp, "content-range"), Some(cr.as_str()));
+}
+
+/// A conditional request takes precedence over Range: a matching `If-None-Match`
+/// yields a 304 even when a `Range` header is present.
+#[test]
+fn conditional_request_with_range_returns_304() {
+    let mut state = State::default();
+    let ctx = mock_system_context();
+    const C0: &[u8] = b"AAAAAAAAAA";
+    const C1: &[u8] = b"BBBBBBB";
+    create_assets(
+        &mut state,
+        &ctx,
+        vec![AssetBuilder::new("/big.bin", "application/octet-stream")
+            .with_encoding("identity", vec![C0, C1])],
+    );
+
+    // First request: read the canister-managed etag off the 206.
+    let first = state.http_request(
+        RequestBuilder::get("/big.bin")
+            .with_header("Accept-Encoding", "identity")
+            .build(),
+        &[],
+    );
+    let etag = lookup_header(&first, "etag")
+        .expect("206 carries an etag")
+        .to_string();
+
+    let resp = state.http_request(
+        RequestBuilder::get("/big.bin")
+            .with_header("Accept-Encoding", "identity")
+            .with_header("If-None-Match", &etag)
+            .with_header("Range", "bytes=10-")
+            .build(),
+        &[],
+    );
+
+    assert_eq!(resp.status_code, 304);
+    assert!(resp.body.as_ref().is_empty());
+}
+
+/// A single-chunk asset ignores Range and serves the full body as a 200.
+#[test]
+fn single_chunk_asset_ignores_range() {
+    let mut state = State::default();
+    let ctx = mock_system_context();
+    const BODY: &[u8] = b"a small body that fits in one chunk";
+    create_assets(
+        &mut state,
+        &ctx,
+        vec![AssetBuilder::new("/small.txt", "text/plain").with_encoding("identity", vec![BODY])],
+    );
+
+    let resp = state.http_request(
+        RequestBuilder::get("/small.txt")
+            .with_header("Accept-Encoding", "identity")
+            .with_header("Range", "bytes=5-")
+            .build(),
+        &[],
+    );
+
+    assert_eq!(resp.status_code, 200);
+    assert_eq!(resp.body.as_ref(), BODY);
+    assert_eq!(lookup_header(&resp, "content-range"), None);
+}
+
+/// Range serving works for a non-identity encoding: the 206 carries
+/// `content-encoding` and ranges over the *encoded* bytes.
+#[test]
+fn range_request_non_identity_encoding() {
+    let mut state = State::default();
+    let ctx = mock_system_context();
+    const G0: &[u8] = b"\x1f\x8b\x08\x00gzip-chunk-0";
+    const G1: &[u8] = b"gzip-chunk-1";
+    create_assets(
+        &mut state,
+        &ctx,
+        vec![AssetBuilder::new("/app.js", "text/javascript")
+            .with_encoding("gzip", vec![G0, G1])],
+    );
+    let total = G0.len() + G1.len();
+
+    let resp = state.http_request(
+        RequestBuilder::get("/app.js")
+            .with_header("Accept-Encoding", "gzip")
+            .with_header("Range", &format!("bytes={}-", G0.len()))
+            .build(),
+        &[],
+    );
+
+    assert_eq!(resp.status_code, 206);
+    assert_eq!(resp.body.as_ref(), G1);
+    assert_eq!(lookup_header(&resp, "content-encoding"), Some("gzip"));
+    let cr = format!("bytes {}-{}/{}", G0.len(), total - 1, total);
+    assert_eq!(lookup_header(&resp, "content-range"), Some(cr.as_str()));
+}
+
+/// After an upgrade, multi-chunk assets still serve 206s with correct
+/// `Content-Range` — proof the per-chunk cert data (`chunk_certs` + `content_len`)
+/// is persisted and `post_upgrade_rebuild` re-certifies the 206s content-free.
+#[test]
+fn range_serving_survives_upgrade() {
+    let memory = DefaultMemoryImpl::default();
+    let mut state = State::new(memory.clone());
+    let ctx = mock_system_context();
+    const C0: &[u8] = b"AAAAAAAAAA";
+    const C1: &[u8] = b"BBBBBBB";
+    create_assets(
+        &mut state,
+        &ctx,
+        vec![AssetBuilder::new("/big.bin", "application/octet-stream")
+            .with_encoding("identity", vec![C0, C1])],
+    );
+    let total = C0.len() + C1.len();
+
+    let restored = upgrade(state, memory.clone());
+
+    let resp = restored.http_request(
+        RequestBuilder::get("/big.bin")
+            .with_header("Accept-Encoding", "identity")
+            .with_header("Range", &format!("bytes={}-", C0.len()))
+            .build(),
+        &[],
+    );
+
+    assert_eq!(resp.status_code, 206);
+    assert_eq!(resp.body.as_ref(), C1);
+    let cr = format!("bytes {}-{}/{}", C0.len(), total - 1, total);
+    assert_eq!(lookup_header(&resp, "content-range"), Some(cr.as_str()));
+}
+
 #[test]
 fn supports_cache_control_via_headers() {
     let mut state = State::default();

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -781,10 +781,7 @@ fn no_implicit_aliasing_without_rules() {
     );
 
     for missing in &["/foo", "/foo/", "/blog", "/blog/"] {
-        let response = state.http_request(
-            RequestBuilder::get(*missing).build(),
-            &[],
-        );
+        let response = state.http_request(RequestBuilder::get(*missing).build(), &[]);
         assert_eq!(
             response.status_code, 404,
             "expected 404 for {missing}, got {}",
@@ -1082,8 +1079,7 @@ fn range_request_non_identity_encoding() {
     create_assets(
         &mut state,
         &ctx,
-        vec![AssetBuilder::new("/app.js", "text/javascript")
-            .with_encoding("gzip", vec![G0, G1])],
+        vec![AssetBuilder::new("/app.js", "text/javascript").with_encoding("gzip", vec![G0, G1])],
     );
     let total = G0.len() + G1.len();
 
@@ -1523,10 +1519,7 @@ fn rule_aliasing_persists_through_upgrade() {
     // "aliasing disabled" path); still install one for the subdirectory.
     set_exact_rewrite_rule(&mut state, "/subdirectory", "/subdirectory/index.html");
 
-    let no_alias = state.http_request(
-        RequestBuilder::get("/contents").build(),
-        &[],
-    );
+    let no_alias = state.http_request(RequestBuilder::get("/contents").build(), &[]);
     assert_eq!(no_alias.status_code, 404);
 
     let other = certified_http_request(&state, RequestBuilder::get("/subdirectory").build());
@@ -1534,10 +1527,7 @@ fn rule_aliasing_persists_through_upgrade() {
 
     let state = upgrade(state, memory.clone());
 
-    let no_alias = state.http_request(
-        RequestBuilder::get("/contents").build(),
-        &[],
-    );
+    let no_alias = state.http_request(RequestBuilder::get("/contents").build(), &[]);
     assert_eq!(no_alias.status_code, 404);
     let other = certified_http_request(&state, RequestBuilder::get("/subdirectory").build());
     assert_eq!(other.body.as_ref(), SUBDIR_INDEX_BODY);
@@ -2535,8 +2525,7 @@ mod redirect_rules {
 
         // Delete the target → rule goes inert again.
         delete_asset_via_batch(&mut state, "/foo.html");
-        let after_delete =
-            state.http_request(RequestBuilder::get("/foo").build(), &[]);
+        let after_delete = state.http_request(RequestBuilder::get("/foo").build(), &[]);
         assert_eq!(after_delete.status_code, 404);
     }
 
@@ -2760,10 +2749,7 @@ mod redirect_rules {
         )
         .unwrap();
         // Target doesn't exist → rule inert → built-in fall-through 404.
-        let inert = state.http_request(
-            RequestBuilder::get("/missing").build(),
-            &[],
-        );
+        let inert = state.http_request(RequestBuilder::get("/missing").build(), &[]);
         assert_eq!(inert.status_code, 404);
         // The body is the built-in "not found", not the (missing) /404.html.
         assert_eq!(inert.body.as_ref(), b"not found");

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -2696,6 +2696,141 @@ mod redirect_rules {
     }
 
     #[test]
+    fn rejects_4xx_rule_to_existing_multichunk_target() {
+        // A 404/410 custom error page is served as a single inline body, so a
+        // multi-chunk target can't carry it. Setting such a rule when the target
+        // already exists and is multi-chunk must fail the whole op (which traps
+        // at the canister boundary).
+        let mut state = State::default();
+        let ctx = mock_system_context();
+        create_assets(
+            &mut state,
+            &ctx,
+            vec![AssetBuilder::new("/404.html", "text/html")
+                .with_encoding("identity", vec![b"chunk-zero", b"chunk-one!"])],
+        );
+        for status in [404u16, 410] {
+            let err = commit(
+                &mut state,
+                vec![Operation::SetRedirectRules(SetRedirectRulesArguments {
+                    rules: vec![RedirectRule {
+                        from: RulePattern::Exact("/missing".into()),
+                        to: "/404.html".into(),
+                        status,
+                        headers: vec![],
+                    }],
+                })],
+            )
+            .unwrap_err();
+            assert!(err.contains("multi-chunk asset"), "status {status}: {err}");
+        }
+    }
+
+    #[test]
+    fn allows_200_rule_to_existing_multichunk_target() {
+        // The 4xx guard must not reject a 200 rewrite to a multi-chunk asset —
+        // that path is served as N×206 and is fully supported.
+        let mut state = State::default();
+        let ctx = mock_system_context();
+        create_assets(
+            &mut state,
+            &ctx,
+            vec![AssetBuilder::new("/large.bin", "application/octet-stream")
+                .with_encoding("identity", vec![b"chunk-zero", b"chunk-one!"])],
+        );
+        commit(
+            &mut state,
+            vec![Operation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: vec![RedirectRule {
+                    from: RulePattern::Exact("/landing".into()),
+                    to: "/large.bin".into(),
+                    status: 200,
+                    headers: vec![],
+                }],
+            })],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn alias_200_to_multichunk_target_serves_certified_206() {
+        // Unit-level coverage of the 200-rewrite → multi-chunk path (otherwise
+        // only exercised by the e2e suite): both a plain GET (chunk 0) and a
+        // Range request must return a *certified* 206 at the alias location.
+        let mut state = State::default();
+        let ctx = mock_system_context();
+        const C0: &[u8] = b"AAAAAAAAAA";
+        const C1: &[u8] = b"BBBBBBB";
+        create_assets(
+            &mut state,
+            &ctx,
+            vec![AssetBuilder::new("/large.bin", "application/octet-stream")
+                .with_encoding("identity", vec![C0, C1])],
+        );
+        commit(
+            &mut state,
+            vec![Operation::SetRedirectRules(SetRedirectRulesArguments {
+                rules: vec![RedirectRule {
+                    from: RulePattern::Exact("/landing".into()),
+                    to: "/large.bin".into(),
+                    status: 200,
+                    headers: vec![],
+                }],
+            })],
+        )
+        .unwrap();
+
+        let plain = certified_http_request(
+            &state,
+            RequestBuilder::get("/landing")
+                .with_header("Accept-Encoding", "identity")
+                .build(),
+        );
+        assert_eq!(plain.status_code, 206);
+        assert_eq!(plain.body.as_ref(), C0);
+
+        let ranged = certified_http_request(
+            &state,
+            RequestBuilder::get("/landing")
+                .with_header("Accept-Encoding", "identity")
+                .with_header("Range", &format!("bytes={}-", C0.len()))
+                .build(),
+        );
+        assert_eq!(ranged.status_code, 206);
+        assert_eq!(ranged.body.as_ref(), C1);
+    }
+
+    #[test]
+    fn alias_4xx_to_multichunk_target_degrades_to_certified_builtin_404() {
+        // Defense in depth: even if a 4xx rule pointing at a multi-chunk target
+        // slips past the op guard (e.g. the target grew multi-chunk after the
+        // rule was set), the rule must go inert rather than emit an
+        // unverifiable response. `build_alias_rule_entry` skips multi-chunk
+        // encodings for non-200 status, so the path falls through to the
+        // built-in certified 404.
+        let mut state = State::default();
+        let ctx = mock_system_context();
+        create_assets(
+            &mut state,
+            &ctx,
+            vec![AssetBuilder::new("/404.html", "text/html")
+                .with_encoding("identity", vec![b"chunk-zero", b"chunk-one!"])],
+        );
+        // Install the rule directly via state (bypassing the op guard) to model
+        // the "target grew multi-chunk later" ordering.
+        state.set_redirect_rules(vec![RedirectRule {
+            from: RulePattern::Subtree("/legacy/".into()),
+            to: "/404.html".into(),
+            status: 404,
+            headers: vec![],
+        }]);
+
+        let resp = certified_http_request(&state, RequestBuilder::get("/legacy/x").build());
+        assert_eq!(resp.status_code, 404);
+        assert_eq!(resp.body.as_ref(), b"not found");
+    }
+
+    #[test]
     fn custom_4xx_target_updates_refresh_the_rule() {
         let mut state = State::default();
         let system_context = mock_system_context();

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -1,6 +1,4 @@
-use crate::http::{
-    CallbackFunc, HttpRequest, HttpResponse, StreamingCallbackToken, StreamingStrategy,
-};
+use crate::http::{HttpRequest, HttpResponse};
 use crate::runtime::SystemContext;
 use crate::state::State;
 use crate::sync::{ComputationStatus, SYNC_IDLE_TIMEOUT_NANOS};
@@ -27,10 +25,6 @@ const MAX_CERT_TIME_OFFSET_NS: u128 = 300_000_000_000;
 
 fn some_principal() -> Principal {
     Principal::from_text("ryjl3-tyaaa-aaaaa-aaaba-cai").unwrap()
-}
-
-fn unused_callback() -> CallbackFunc {
-    CallbackFunc::new(some_principal(), "unused".to_string())
 }
 
 /// Simulates a canister upgrade: drop the live `State` and rebuild a fresh one
@@ -128,7 +122,7 @@ pub fn verify_response(
 }
 
 fn certified_http_request(state: &State, request: HttpRequest) -> HttpResponse {
-    let response = state.http_request(request.clone(), &[], unused_callback());
+    let response = state.http_request(request.clone(), &[]);
     match verify_response(state, &request, &response) {
         Err(err) => {
             panic!("Response verification failed with error {err:?}. Response: {response:#?}")
@@ -790,7 +784,6 @@ fn no_implicit_aliasing_without_rules() {
         let response = state.http_request(
             RequestBuilder::get(*missing).build(),
             &[],
-            unused_callback(),
         );
         assert_eq!(
             response.status_code, 404,
@@ -859,197 +852,6 @@ fn authorized_set_survives_stable_roundtrip() {
     let restored = upgrade(state, memory.clone());
 
     assert!(restored.is_authorized(&p));
-}
-
-#[test]
-#[ignore = "Phase 0 spike: multi-chunk now served as certified 206, not callback streaming; rewritten in Phase 5"]
-fn uses_streaming_for_multichunk_assets() {
-    let mut state = State::default();
-    let system_context = mock_system_context();
-
-    const INDEX_BODY_CHUNK_1: &[u8] = b"<!DOCTYPE html>";
-    const INDEX_BODY_CHUNK_2: &[u8] = b"<html>Index</html>";
-
-    create_assets(
-        &mut state,
-        &system_context,
-        vec![AssetBuilder::new("/index.html", "text/html")
-            .with_encoding("identity", vec![INDEX_BODY_CHUNK_1, INDEX_BODY_CHUNK_2])],
-    );
-
-    let streaming_callback = CallbackFunc::new(some_principal(), "stream".to_string());
-    let response = state.http_request(
-        RequestBuilder::get("/index.html")
-            .with_header("Accept-Encoding", "gzip,identity")
-            .build(),
-        &[],
-        streaming_callback.clone(),
-    );
-
-    assert_eq!(response.status_code, 200);
-    assert_eq!(response.body.as_ref(), INDEX_BODY_CHUNK_1);
-
-    let StreamingStrategy::Callback { callback, token } = response
-        .streaming_strategy
-        .expect("missing streaming strategy");
-    assert_eq!(callback, streaming_callback);
-
-    let streaming_response = state.http_request_streaming_callback(token);
-    assert_eq!(streaming_response.body.as_ref(), INDEX_BODY_CHUNK_2);
-    assert!(
-        streaming_response.token.is_none(),
-        "Unexpected streaming response: {streaming_response:?}"
-    );
-}
-
-#[test]
-#[ignore = "Phase 0 spike: multi-chunk now served as certified 206, not callback streaming; rewritten in Phase 5"]
-fn streams_three_chunks_chaining_continuation_tokens() {
-    let mut state = State::default();
-    let system_context = mock_system_context();
-
-    // Three chunks exercise the mid-stream case a 2-chunk asset never reaches:
-    // the callback must itself return a *continuation* token (not a terminator)
-    // for the middle chunk.
-    const C0: &[u8] = b"chunk-zero-";
-    const C1: &[u8] = b"chunk-one--";
-    const C2: &[u8] = b"chunk-two";
-
-    create_assets(
-        &mut state,
-        &system_context,
-        vec![
-            AssetBuilder::new("/big.html", "text/html").with_encoding("identity", vec![C0, C1, C2])
-        ],
-    );
-
-    let streaming_callback = CallbackFunc::new(some_principal(), "stream".to_string());
-    let response = state.http_request(
-        RequestBuilder::get("/big.html").build(),
-        &[],
-        streaming_callback.clone(),
-    );
-
-    // First response: 200 with chunk 0 inline and a strategy pointing at chunk 1.
-    assert_eq!(response.status_code, 200);
-    assert_eq!(response.body.as_ref(), C0);
-    let StreamingStrategy::Callback { callback, token } = response
-        .streaming_strategy
-        .expect("missing streaming strategy");
-    assert_eq!(callback, streaming_callback);
-    assert_eq!(token.index, 1);
-
-    // Middle chunk: the callback returns chunk 1 *and* a continuation token for
-    // chunk 2 — the branch that never fires with only two chunks.
-    let second = state.http_request_streaming_callback(token);
-    assert_eq!(second.body.as_ref(), C1);
-    let next = second
-        .token
-        .expect("expected a continuation token for the final chunk");
-    assert_eq!(next.index, 2);
-
-    // Final chunk: body served, token is None to end the stream.
-    let third = state.http_request_streaming_callback(next);
-    assert_eq!(third.body.as_ref(), C2);
-    assert!(
-        third.token.is_none(),
-        "stream must terminate after the last chunk: {third:?}"
-    );
-}
-
-#[test]
-#[ignore = "Phase 0 spike: multi-chunk now served as certified 206, not callback streaming; rewritten in Phase 5"]
-fn streams_multichunk_non_identity_encoding() {
-    let mut state = State::default();
-    let system_context = mock_system_context();
-
-    // A gzip encoding split across two chunks: streaming must work for an
-    // encoding that also emits a `content-encoding` header, not just identity.
-    const GZIP_CHUNK_1: &[u8] = b"\x1f\x8b\x08\x00fake-gzip-bytes-1";
-    const GZIP_CHUNK_2: &[u8] = b"fake-gzip-bytes-2";
-
-    create_assets(
-        &mut state,
-        &system_context,
-        vec![AssetBuilder::new("/app.js", "text/javascript")
-            .with_encoding("gzip", vec![GZIP_CHUNK_1, GZIP_CHUNK_2])],
-    );
-
-    let streaming_callback = CallbackFunc::new(some_principal(), "stream".to_string());
-    let response = state.http_request(
-        RequestBuilder::get("/app.js")
-            .with_header("Accept-Encoding", "gzip")
-            .build(),
-        &[],
-        streaming_callback.clone(),
-    );
-
-    assert_eq!(response.status_code, 200);
-    assert_eq!(response.body.as_ref(), GZIP_CHUNK_1);
-    assert_eq!(lookup_header(&response, "content-encoding"), Some("gzip"));
-
-    let StreamingStrategy::Callback { callback, token } = response
-        .streaming_strategy
-        .expect("missing streaming strategy");
-    assert_eq!(callback, streaming_callback);
-
-    let second = state.http_request_streaming_callback(token);
-    assert_eq!(second.body.as_ref(), GZIP_CHUNK_2);
-    assert!(second.token.is_none(), "stream should end after chunk 2");
-}
-
-#[test]
-fn single_chunk_asset_has_no_streaming_strategy() {
-    let mut state = State::default();
-    let system_context = mock_system_context();
-
-    create_assets(
-        &mut state,
-        &system_context,
-        vec![AssetBuilder::new("/small.html", "text/html")
-            .with_encoding("identity", vec![b"<html></html>"])],
-    );
-
-    let response = state.http_request(
-        RequestBuilder::get("/small.html").build(),
-        &[],
-        unused_callback(),
-    );
-
-    assert_eq!(response.status_code, 200);
-    assert!(
-        response.streaming_strategy.is_none(),
-        "a single-chunk asset must not advertise streaming: {response:?}"
-    );
-}
-
-#[test]
-fn streaming_callback_with_bogus_content_id_serves_empty_body() {
-    // The self-describing token is no longer validated against `AssetMeta`: a
-    // forged `content_id` simply misses the content store and yields an empty
-    // body (rather than trapping). The HTTP gateway's `sha256` check on the
-    // accumulated stream is what rejects such a response, so no uncertified
-    // bytes are served.
-    let mut state = State::default();
-    let system_context = mock_system_context();
-
-    create_assets(
-        &mut state,
-        &system_context,
-        vec![AssetBuilder::new("/index.html", "text/html")
-            .with_encoding("identity", vec![b"a", b"b"])],
-    );
-
-    let response = state.http_request_streaming_callback(StreamingCallbackToken {
-        content_id: u64::MAX,
-        index: 1,
-        num_chunks: 2,
-        sha256: ByteBuf::from([0u8; 32].as_slice()),
-    });
-    assert!(
-        response.body.as_ref().is_empty(),
-        "a token pointing at a nonexistent content group must serve no bytes"
-    );
 }
 
 #[test]
@@ -1357,7 +1159,6 @@ fn rule_aliasing_persists_through_upgrade() {
     let no_alias = state.http_request(
         RequestBuilder::get("/contents").build(),
         &[],
-        unused_callback(),
     );
     assert_eq!(no_alias.status_code, 404);
 
@@ -1369,7 +1170,6 @@ fn rule_aliasing_persists_through_upgrade() {
     let no_alias = state.http_request(
         RequestBuilder::get("/contents").build(),
         &[],
-        unused_callback(),
     );
     assert_eq!(no_alias.status_code, 404);
     let other = certified_http_request(&state, RequestBuilder::get("/subdirectory").build());
@@ -1729,7 +1529,6 @@ mod certification {
         );
         assert_eq!(not_modified.status_code, 304);
         assert!(not_modified.body.is_empty());
-        assert!(not_modified.streaming_strategy.is_none());
         assert_eq!(lookup_header(&not_modified, "etag").unwrap(), etag);
 
         // A stale etag still serves the full, certified 200.
@@ -2341,7 +2140,7 @@ mod redirect_rules {
             })],
         )
         .unwrap();
-        let inert = state.http_request(RequestBuilder::get("/foo").build(), &[], unused_callback());
+        let inert = state.http_request(RequestBuilder::get("/foo").build(), &[]);
         assert_eq!(inert.status_code, 404);
 
         // Add the asset → rule fires.
@@ -2370,7 +2169,7 @@ mod redirect_rules {
         // Delete the target → rule goes inert again.
         delete_asset_via_batch(&mut state, "/foo.html");
         let after_delete =
-            state.http_request(RequestBuilder::get("/foo").build(), &[], unused_callback());
+            state.http_request(RequestBuilder::get("/foo").build(), &[]);
         assert_eq!(after_delete.status_code, 404);
     }
 
@@ -2597,7 +2396,6 @@ mod redirect_rules {
         let inert = state.http_request(
             RequestBuilder::get("/missing").build(),
             &[],
-            unused_callback(),
         );
         assert_eq!(inert.status_code, 404);
         // The body is the built-in "not found", not the (missing) /404.html.

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -862,6 +862,7 @@ fn authorized_set_survives_stable_roundtrip() {
 }
 
 #[test]
+#[ignore = "Phase 0 spike: multi-chunk now served as certified 206, not callback streaming; rewritten in Phase 5"]
 fn uses_streaming_for_multichunk_assets() {
     let mut state = State::default();
     let system_context = mock_system_context();
@@ -902,6 +903,7 @@ fn uses_streaming_for_multichunk_assets() {
 }
 
 #[test]
+#[ignore = "Phase 0 spike: multi-chunk now served as certified 206, not callback streaming; rewritten in Phase 5"]
 fn streams_three_chunks_chaining_continuation_tokens() {
     let mut state = State::default();
     let system_context = mock_system_context();
@@ -956,6 +958,7 @@ fn streams_three_chunks_chaining_continuation_tokens() {
 }
 
 #[test]
+#[ignore = "Phase 0 spike: multi-chunk now served as certified 206, not callback streaming; rewritten in Phase 5"]
 fn streams_multichunk_non_identity_encoding() {
     let mut state = State::default();
     let system_context = mock_system_context();

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -905,7 +905,7 @@ fn range_request_returns_containing_chunk() {
         &state,
         RequestBuilder::get("/big.bin")
             .with_header("Accept-Encoding", "identity")
-            .with_header("Range", &format!("bytes={}-", C0.len()))
+            .with_header("Range", format!("bytes={}-", C0.len()))
             .build(),
     );
 
@@ -936,7 +936,7 @@ fn range_request_mid_chunk_snaps_to_chunk_start() {
         &state,
         RequestBuilder::get("/big.bin")
             .with_header("Accept-Encoding", "identity")
-            .with_header("Range", &format!("bytes={}-", C0.len() + 2))
+            .with_header("Range", format!("bytes={}-", C0.len() + 2))
             .build(),
     );
 
@@ -967,7 +967,7 @@ fn range_spanning_chunks_returns_single_chunk() {
         &state,
         RequestBuilder::get("/big.bin")
             .with_header("Accept-Encoding", "identity")
-            .with_header("Range", &format!("bytes=0-{}", total - 1))
+            .with_header("Range", format!("bytes=0-{}", total - 1))
             .build(),
     );
 
@@ -997,7 +997,7 @@ fn out_of_range_serves_full_asset_via_206() {
         &state,
         RequestBuilder::get("/big.bin")
             .with_header("Accept-Encoding", "identity")
-            .with_header("Range", &format!("bytes={}-", total + 100))
+            .with_header("Range", format!("bytes={}-", total + 100))
             .build(),
     );
 
@@ -1091,7 +1091,7 @@ fn range_request_non_identity_encoding() {
         &state,
         RequestBuilder::get("/app.js")
             .with_header("Accept-Encoding", "gzip")
-            .with_header("Range", &format!("bytes={}-", G0.len()))
+            .with_header("Range", format!("bytes={}-", G0.len()))
             .build(),
     );
 
@@ -1126,7 +1126,7 @@ fn range_serving_survives_upgrade() {
         &restored,
         RequestBuilder::get("/big.bin")
             .with_header("Accept-Encoding", "identity")
-            .with_header("Range", &format!("bytes={}-", C0.len()))
+            .with_header("Range", format!("bytes={}-", C0.len()))
             .build(),
     );
 
@@ -1210,7 +1210,7 @@ fn range_follows_selected_encoding_chunk_count() {
         &state,
         RequestBuilder::get("/app.js")
             .with_header("Accept-Encoding", "identity")
-            .with_header("Range", &format!("bytes={}-", I0.len()))
+            .with_header("Range", format!("bytes={}-", I0.len()))
             .build(),
     );
     assert_eq!(id.status_code, 206);
@@ -2878,7 +2878,7 @@ mod redirect_rules {
             &state,
             RequestBuilder::get("/landing")
                 .with_header("Accept-Encoding", "identity")
-                .with_header("Range", &format!("bytes={}-", C0.len()))
+                .with_header("Range", format!("bytes={}-", C0.len()))
                 .build(),
         );
         assert_eq!(ranged.status_code, 206);

--- a/crates/canister/src/lib.rs
+++ b/crates/canister/src/lib.rs
@@ -1,8 +1,7 @@
 use candid::Principal;
 use canister_core::{
-    guard_can_sync, guard_is_controller, AssetDetails, ExecuteOperationsArguments, RedirectRule,
-    StartSyncResult, UploadChunksArguments, Version,
-    {HttpRequest, HttpResponse, StreamingCallbackHttpResponse, StreamingCallbackToken},
+    guard_can_sync, guard_is_controller, AssetDetails, ExecuteOperationsArguments, HttpRequest,
+    HttpResponse, RedirectRule, StartSyncResult, UploadChunksArguments, Version,
 };
 use ic_cdk::{post_upgrade, query, update};
 
@@ -31,11 +30,6 @@ fn get_asset_details(start_after: Option<String>) -> Vec<AssetDetails> {
 #[query]
 fn http_request(req: HttpRequest) -> HttpResponse {
     canister_core::http_request(req)
-}
-
-#[query]
-fn http_request_streaming_callback(token: StreamingCallbackToken) -> StreamingCallbackHttpResponse {
-    canister_core::http_request_streaming_callback(token)
 }
 
 #[query]

--- a/crates/e2e/tests/streaming.rs
+++ b/crates/e2e/tests/streaming.rs
@@ -133,8 +133,11 @@ fn range_requests_work_through_a_200_rewrite_alias() {
 
     let body = incompressible_bytes(5_000_000);
     fs::write(project.join("dist/large.bin"), &body).expect("write large asset into fixture");
-    fs::write(project.join("dist/_redirects"), "/landing  /large.bin  200\n")
-        .expect("write _redirects into fixture");
+    fs::write(
+        project.join("dist/_redirects"),
+        "/landing  /large.bin  200\n",
+    )
+    .expect("write _redirects into fixture");
 
     let _network = LocalNetwork::start(project);
     icp_cmd(project).arg("deploy").assert().success();

--- a/crates/e2e/tests/streaming.rs
+++ b/crates/e2e/tests/streaming.rs
@@ -119,3 +119,53 @@ fn range_request_returns_certified_206() {
         "206 body must equal the containing chunk's bytes",
     );
 }
+
+/// A 200-rewrite alias (`_redirects`) to a multi-chunk asset serves ranges too.
+///
+/// `/landing` rewrites to a ~5 MB (3-chunk) asset. The alias must certify the
+/// per-chunk 206s at its own tree location: a plain GET reassembles to a
+/// byte-exact 200 (Flow B), and a `Range` request returns a verified 206
+/// (Flow A) — both through the verifying gateway.
+#[test]
+fn range_requests_work_through_a_200_rewrite_alias() {
+    let tmp = setup_project("tests/fixture/basic");
+    let project = tmp.path();
+
+    let body = incompressible_bytes(5_000_000);
+    fs::write(project.join("dist/large.bin"), &body).expect("write large asset into fixture");
+    fs::write(project.join("dist/_redirects"), "/landing  /large.bin  200\n")
+        .expect("write _redirects into fixture");
+
+    let _network = LocalNetwork::start(project);
+    icp_cmd(project).arg("deploy").assert().success();
+
+    // Plain GET of the alias → gateway reassembles the chunk 206s into a full 200.
+    let full = http_fetch_with_headers(project, "/landing", &[("Accept-Encoding", "identity")]);
+    assert_eq!(full.status(), StatusCode::OK);
+    let fetched = full.bytes().expect("read reassembled body").to_vec();
+    assert_eq!(
+        fetched, body,
+        "alias plain GET must reassemble to the exact asset bytes",
+    );
+
+    // Range GET of the alias → certified 206 for the containing chunk.
+    let partial = http_fetch_with_headers(
+        project,
+        "/landing",
+        &[("Accept-Encoding", "identity"), ("Range", "bytes=2500000-")],
+    );
+    assert_eq!(
+        partial.status(),
+        StatusCode::PARTIAL_CONTENT,
+        "alias range request must return a certified 206",
+    );
+    assert_eq!(
+        partial
+            .headers()
+            .get("content-range")
+            .and_then(|v| v.to_str().ok()),
+        Some("bytes 1900000-3799999/5000000"),
+    );
+    let partial_body = partial.bytes().expect("read alias 206 body").to_vec();
+    assert_eq!(partial_body, body[1_900_000..3_800_000]);
+}

--- a/crates/e2e/tests/streaming.rs
+++ b/crates/e2e/tests/streaming.rs
@@ -68,3 +68,54 @@ fn streams_large_asset_through_gateway() {
         "streamed body bytes differ from the uploaded asset",
     );
 }
+
+/// Phase 0 spike (Flow A): a client `Range` request returns a **certified** `206`.
+///
+/// The asset is ~5 MB → three 1.9 MB chunks. Byte 2_500_000 falls inside chunk 1
+/// (`[1_900_000, 3_800_000)`). The canister snaps the range start down to that
+/// chunk and returns it as a `206` with `Content-Range: bytes 1900000-3799999/5000000`.
+///
+/// Crucially, `http_fetch_*` goes through the boundary node, which validates the
+/// `IC-Certificate` before returning anything. A `206` with the right bytes
+/// therefore proves the **response-only** certification of the chunk verifies
+/// end-to-end — the central unknown this spike exists to settle.
+#[test]
+fn range_request_returns_certified_206() {
+    let tmp = setup_project("tests/fixture/basic");
+    let project = tmp.path();
+
+    let body = incompressible_bytes(5_000_000);
+    fs::write(project.join("dist/large.bin"), &body).expect("write large asset into fixture");
+
+    let _network = LocalNetwork::start(project);
+    icp_cmd(project).arg("deploy").assert().success();
+
+    let response = http_fetch_with_headers(
+        project,
+        "/large.bin",
+        &[("Accept-Encoding", "identity"), ("Range", "bytes=2500000-")],
+    );
+
+    assert_eq!(
+        response.status(),
+        StatusCode::PARTIAL_CONTENT,
+        "expected 206; a non-206 (esp. 500) means the response-only certified \
+         range response failed gateway verification",
+    );
+
+    let content_range = response
+        .headers()
+        .get("content-range")
+        .expect("206 must carry Content-Range")
+        .to_str()
+        .expect("Content-Range is ascii")
+        .to_string();
+    assert_eq!(content_range, "bytes 1900000-3799999/5000000");
+
+    let fetched = response.bytes().expect("read 206 body").to_vec();
+    assert_eq!(
+        fetched,
+        body[1_900_000..3_800_000],
+        "206 body must equal the containing chunk's bytes",
+    );
+}

--- a/crates/sync-core/src/headers.rs
+++ b/crates/sync-core/src/headers.rs
@@ -302,11 +302,11 @@ fn reserved_header_reason(name: &str) -> Option<&'static str> {
         ),
         (
             "accept-ranges",
-            "the canister does not serve range (206 Partial Content) responses",
+            "range handling for large assets is managed by the canister",
         ),
         (
             "content-range",
-            "the canister does not serve range (206 Partial Content) responses",
+            "the canister sets it on the certified 206 range responses it serves for large assets",
         ),
         (
             "ic-certificate",

--- a/crates/sync-core/src/sync.rs
+++ b/crates/sync-core/src/sync.rs
@@ -43,6 +43,52 @@ struct ProjectAsset {
     encodings: HashMap<Encoding, ProjectAssetEncoding>,
 }
 
+impl ProjectAsset {
+    /// Whether any encoding will be stored as more than one chunk. Only
+    /// encodings staged for upload carry their bytes here; an encoding already
+    /// in place on the canister has its `data` cleared, so this under-reports
+    /// for unchanged assets — the canister's `SetRedirectRules` guard backstops
+    /// that case. Used to reject 4xx error-page rules whose target is too large
+    /// to serve as a single inline body (see [`validate_error_page_targets`]).
+    fn is_multichunk(&self) -> bool {
+        self.encodings
+            .values()
+            .any(|e| e.data.len() > MAX_CHUNK_SIZE)
+    }
+}
+
+/// Rejects 404/410 rules whose target asset will be multi-chunk. A custom error
+/// page is served as a single inline body with the override status (the gateway
+/// only reassembles 206 chunks into a *200*), so a target larger than one chunk
+/// can't carry it — the canister would fall back to its built-in 404 and the
+/// response would fail certification. Catching it here points the user at the
+/// offending `_redirects` rule before any sync starts.
+fn validate_error_page_targets(
+    rules: &[RedirectRule],
+    project_assets: &HashMap<String, ProjectAsset>,
+) -> Result<(), String> {
+    for rule in rules {
+        if !matches!(rule.status, 404 | 410) {
+            continue;
+        }
+        if project_assets
+            .get(&rule.to)
+            .is_some_and(ProjectAsset::is_multichunk)
+        {
+            let from = match &rule.from {
+                RulePattern::Exact(p) | RulePattern::Subtree(p) => p,
+            };
+            return Err(format!(
+                "_redirects: rule `{} {} {}` points to a multi-chunk asset; \
+                 404/410 error pages must be small enough to serve as a single \
+                 chunk (< {} bytes). Shrink `{}`, or use a 3xx redirect instead.",
+                from, rule.to, rule.status, MAX_CHUNK_SIZE, rule.to
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Ensures the signing identity can sync assets, before any expensive scanning
 /// or diffing work happens — so an unauthorized run fails fast instead of after
 /// reading and encoding the whole project.
@@ -217,6 +263,9 @@ pub fn sync<C: CanisterCall>(
         let asset = prepare_branded_404(&canister_assets)?;
         project_assets.insert(asset.source.key.clone(), asset);
     }
+
+    // Reject oversized 4xx error-page targets before starting a sync.
+    validate_error_page_targets(&project_rules, &project_assets)?;
 
     if build_operations(
         &project_assets,
@@ -929,6 +978,62 @@ mod tests {
                 encodings: enc_map,
             },
         )
+    }
+
+    fn err_page_rule(from: &str, to: &str, status: u16) -> RedirectRule {
+        RedirectRule {
+            from: RulePattern::Exact(from.to_string()),
+            to: to.to_string(),
+            status,
+            headers: vec![],
+        }
+    }
+
+    #[test]
+    fn validate_rejects_4xx_rule_to_multichunk_target() {
+        let assets = HashMap::from([mk_pending_asset(
+            "/404.html",
+            "identity",
+            vec![0u8; MAX_CHUNK_SIZE + 1], // 2 chunks
+        )]);
+        for status in [404, 410] {
+            let rules = vec![err_page_rule("/missing", "/404.html", status)];
+            let err = validate_error_page_targets(&rules, &assets).unwrap_err();
+            assert!(err.contains("multi-chunk asset"), "got: {err}");
+            assert!(err.contains("/404.html"), "got: {err}");
+        }
+    }
+
+    #[test]
+    fn validate_accepts_4xx_rule_to_single_chunk_target() {
+        let assets = HashMap::from([mk_pending_asset(
+            "/404.html",
+            "identity",
+            vec![0u8; MAX_CHUNK_SIZE], // exactly 1 chunk
+        )]);
+        let rules = vec![err_page_rule("/missing", "/404.html", 404)];
+        validate_error_page_targets(&rules, &assets).unwrap();
+    }
+
+    #[test]
+    fn validate_ignores_non_4xx_rules_to_multichunk_target() {
+        // A 200 rewrite to a multi-chunk target is fine (served as N×206).
+        let assets = HashMap::from([mk_pending_asset(
+            "/large.bin",
+            "identity",
+            vec![0u8; MAX_CHUNK_SIZE + 1],
+        )]);
+        let rules = vec![err_page_rule("/landing", "/large.bin", 200)];
+        validate_error_page_targets(&rules, &assets).unwrap();
+    }
+
+    #[test]
+    fn validate_ignores_4xx_rule_to_absent_target() {
+        // Target not in the project (doesn't exist yet) → the plugin can't size
+        // it; the canister guard backstops it. No error here.
+        let assets: HashMap<String, ProjectAsset> = HashMap::new();
+        let rules = vec![err_page_rule("/missing", "/404.html", 404)];
+        validate_error_page_targets(&rules, &assets).unwrap();
     }
 
     #[test]

--- a/docs/headers.md
+++ b/docs/headers.md
@@ -60,8 +60,9 @@ Unlike other headers, `Content-Type` is single-valued and first-match-wins.
 The canister applies **no default headers** — no `Cache-Control`, no security headers,
 no CSP. If you want them, declare them in `_headers`. The only response headers the
 canister manages on its own are the ones tied to how it serves and certifies content:
-`Content-Type`, `Content-Encoding`, `ETag`, the certification headers, and (on HTML
-responses) its own `ic_env` cookie.
+`Content-Type`, `Content-Encoding`, `ETag`, `Content-Range` (on large-asset
+[range responses](how-it-works.md#serving-large-assets)), the certification headers,
+and (on HTML responses) its own `ic_env` cookie.
 
 A useful baseline to copy and adapt:
 
@@ -100,7 +101,7 @@ immediately.
 | `Content-Encoding` | The canister negotiates gzip/Brotli/identity per request and sets it itself. |
 | `ETag` | Derived from the content hash, so there is exactly one trustworthy validator. |
 | `Transfer-Encoding` | Body framing is handled by the HTTP gateway, not the canister. |
-| `Accept-Ranges`, `Content-Range` | The canister doesn't serve range (`206 Partial Content`) responses. |
+| `Accept-Ranges`, `Content-Range` | Range handling is canister-managed: large assets are served as certified `206 Partial Content` responses with a canister-set `Content-Range`. |
 | `IC-Certificate`, `IC-CertificateExpression` | These carry the response certificate and are canister-managed. |
 | `Location` | A `Location` here wouldn't redirect (the status stays `200`). Use [`_redirects`](redirects.md) instead. |
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -24,14 +24,16 @@ This is also why [redirects](redirects.md#what-isnt-supported-dynamic-rules) and
 [headers](headers.md#reserved-headers) are constrained to what can be enumerated and
 certified ahead of time.
 
-## Streaming large assets
+## Serving large assets
 
-A single canister response has a bounded message size, so large files can't be
-returned in one shot. The canister instead returns the first chunk plus a
-**streaming token**; the gateway calls back repeatedly to fetch the remaining chunks
-and reassembles them into the full response for the browser. Each chunk is certified,
-so streaming a large file is as tamper-proof as a small one — and it's all transparent
-to the client.
+A single canister response has a bounded message size, so a large file can't be
+returned in one shot. The canister splits it into chunks and serves each chunk as a
+certified **`206 Partial Content`** response carrying a `Content-Range`. For an
+ordinary request the **[HTTP gateway](https://docs.internetcomputer.org/references/http-gateway-protocol-spec/)**
+fetches the chunks and reassembles them into the full `200` the browser sees; a client
+that sends a `Range` header gets back the chunk covering the bytes it asked for. Either
+way every chunk is certified, so a large file is exactly as tamper-proof as a small one
+— and it's all transparent to the client.
 
 ## The sync plugin and its sandbox
 

--- a/docs/redirects.md
+++ b/docs/redirects.md
@@ -39,6 +39,12 @@ lines and lines starting with `#` are ignored.
 | `404` | Serve the `to` file as a not-found page. |
 | `410` | Serve the `to` file, signalling the resource is permanently gone. |
 
+A `404` or `410` error page must be a **small, single-chunk file** (under ~1.9 MB).
+Large files are served as [`206` range responses](how-it-works.md#serving-large-assets)
+that the gateway reassembles into a `200`, which can't carry a 4xx status — so the sync
+plugin rejects a 4xx rule pointing at a multi-chunk asset at deploy time, naming the
+offending rule. (A `200` rewrite to a large file is fine.)
+
 ## Examples
 
 ```


### PR DESCRIPTION
## Summary

Replaces the streaming-callback strategy for large (multi-chunk) assets with **certified HTTP `206 Partial Content` range responses**. The canister certifies one `206` per chunk; the IC HTTP gateway reassembles a plain `GET` into a full `200`, and client `Range` requests are satisfied directly. Every chunk is verified — the old callback path stopped certifying past ~4 chunks.

## What changed

- **206 range serving** — per-chunk `206` responses with a certified `Content-Range`; out-of-range and single-chunk edges handled. Per-chunk cert data (length + hash) is persisted so recertify is content-free.
- **Callback streaming removed** (breaking) — drops `StreamingStrategy`, `CallbackFunc`, `StreamingCallbackToken`, `StreamingCallbackHttpResponse`, the `streaming_strategy` field of `HttpResponse`, and the `http_request_streaming_callback` endpoint. The gateway keeps `streaming_strategy` optional, so it decodes to null when absent (confirmed through the real gateway by the e2e suite).
- **4xx error pages must be single-chunk** — a non-200 response can't ride 206 reassembly (which always yields a 200). Enforced in three layers: canister build skips multi-chunk encodings under a status override, the `SetRedirectRules` op guard rejects 4xx rules targeting a multi-chunk asset, and the sync plugin rejects oversized 4xx targets at deploy time.
- **Tests** — 206 range unit tests (parse + encoding edges), certification tests, op-guard accept/reject, 4xx degrade-to-certified-404, and 200-alias-to-multi-chunk; canbench `serve_large_asset` reworked to drive the 206 path.
- **Docs** — refreshed how-it-works, headers, redirects, ARCHITECTURE, README, and the `.did` for the new model.

## Breaking change

Drops the `streaming_strategy` response field and the `http_request_streaming_callback` method. No backward-compat concern — pre-launch, no production instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)