### PR TITLE
feat: default cookies to SameSite=None; Secure; Partitioned for cross-site iframe embedding

### DIFF
--- a/crates/canister-core/src/asset.rs
+++ b/crates/canister-core/src/asset.rs
@@ -26,21 +26,29 @@ pub const STATUS_CODES_TO_CERTIFY: [u16; 2] = [200, 304];
 /// (`@icp-sdk/core/agent/canister-env`) parses:
 ///
 /// ```text
-/// ic_env=<url_encode(payload)>; SameSite=Lax
+/// ic_env=<url_encode(payload)>; Secure; SameSite=None; Partitioned
 /// payload = "ic_root_key=<hex(DER root key)>" + ("&" + "<name>=<value>")*
 /// ```
 ///
 /// The root key always comes first; `public_vars` follow in sorted (BTreeMap)
 /// order. `url_encode` percent-encodes the `&`/`=` separators so the whole
 /// payload rides inside one cookie value; `decodeURIComponent` restores them
-/// client-side. Pure (no system-API access) so it can be unit-tested directly.
+/// client-side. `SameSite=None; Secure; Partitioned` (CHIPS) so page scripts can
+/// still read it when the app is shown inside a **cross-site iframe** — a plain
+/// cross-site cookie would be dropped by the browser before the client lib runs.
+/// (`ic_env` is read-only client state, never sent back to the canister, so
+/// `SameSite=None` only affects whether the browser stores it, not any request.)
+/// Pure (no system-API access) so it can be unit-tested directly.
 pub fn render_env_cookie(root_key: &[u8], public_vars: &BTreeMap<String, String>) -> String {
     let mut entries = vec![format!("ic_root_key={}", hex::encode(root_key))];
     for (name, value) in public_vars {
         entries.push(format!("{name}={value}"));
     }
     let payload = entries.join("&");
-    format!("ic_env={}; SameSite=Lax", url_encode(&payload))
+    format!(
+        "ic_env={}; Secure; SameSite=None; Partitioned",
+        url_encode(&payload)
+    )
 }
 
 /// Whether an asset's content-type denotes HTML — i.e. whether it should carry

--- a/crates/canister-core/src/protection.rs
+++ b/crates/canister-core/src/protection.rs
@@ -75,12 +75,17 @@ pub fn token_id(value: &str) -> [u8; 32] {
 }
 
 /// The `Set-Cookie` value handed back on a successful redeem. Host-only (no
-/// `Domain`), `HttpOnly` (page scripts can't read it), `Secure`, `SameSite=Lax`,
-/// and a session cookie (no `Max-Age` → dies on tab close). Must be byte-identical
-/// between the certify path (`issue_token`) and the serve path (redeem), since it
-/// is part of the certified response hash.
+/// `Domain`), `HttpOnly` (page scripts can't read it), `Secure`, and a session
+/// cookie (no `Max-Age` → dies on tab close). `SameSite=None; Partitioned` (CHIPS)
+/// so the credential is delivered when the app is shown inside a **cross-site
+/// iframe** (e.g. a preview embedded in another site): a plain cross-site cookie is
+/// blocked by Safari and restricted by Chrome/Firefox, whereas a partitioned cookie
+/// is scoped to the embedding top-level site and delivered there. `Partitioned` also
+/// keeps the cookie from riding along to arbitrary *other* embedders. Must be
+/// byte-identical between the certify path (`issue_token`) and the serve path
+/// (redeem), since it is part of the certified response hash.
 pub fn access_cookie(value: &str) -> String {
-    format!("{ACCESS_COOKIE}={value}; HttpOnly; Secure; SameSite=Lax; Path=/")
+    format!("{ACCESS_COOKIE}={value}; HttpOnly; Secure; SameSite=None; Partitioned; Path=/")
 }
 
 /// Every `certified_assets_access=` value present in the request's `Cookie` header(s). The
@@ -277,6 +282,17 @@ mod tests {
             Some("a b c".to_string())
         );
         assert_eq!(parse_form_token(b"password=x"), None);
+    }
+
+    #[test]
+    fn access_cookie_is_embeddable_by_default() {
+        // The default must work inside a cross-site iframe out of the box (the
+        // Caffeine preview use case): `SameSite=None; Secure; Partitioned` (CHIPS).
+        // Host-only (no `Domain`) and a session cookie (no `Max-Age`).
+        assert_eq!(
+            access_cookie("tok"),
+            "certified_assets_access=tok; HttpOnly; Secure; SameSite=None; Partitioned; Path=/"
+        );
     }
 
     #[test]

--- a/crates/canister-core/src/tests.rs
+++ b/crates/canister-core/src/tests.rs
@@ -3326,11 +3326,11 @@ mod env_cookie {
         ]);
         let rendered = render_env_cookie(&[0xab, 0xcd], &vars);
 
-        assert!(rendered.ends_with("; SameSite=Lax"));
+        assert!(rendered.ends_with("; Secure; SameSite=None; Partitioned"));
         let value = rendered
             .strip_prefix("ic_env=")
             .unwrap()
-            .strip_suffix("; SameSite=Lax")
+            .strip_suffix("; Secure; SameSite=None; Partitioned")
             .unwrap();
         // Separators are percent-encoded, so the payload rides in one cookie value.
         assert!(!value.contains('&') && !value.contains('='));
@@ -3395,7 +3395,7 @@ mod env_cookie {
         let cookies = all_headers(&resp, "set-cookie");
         assert_eq!(cookies.len(), 1);
         assert!(cookies[0].starts_with("ic_env="), "got: {}", cookies[0]);
-        assert!(cookies[0].ends_with("; SameSite=Lax"));
+        assert!(cookies[0].ends_with("; Secure; SameSite=None; Partitioned"));
     }
 
     #[test]
@@ -3800,6 +3800,10 @@ mod access_protection {
             "got: {set_cookie}"
         );
         assert!(set_cookie.contains("HttpOnly"), "got: {set_cookie}");
+        // Embedding-friendly by default: the credential must survive a cross-site
+        // iframe (Caffeine-style preview), so it is a partitioned cross-site cookie.
+        assert!(set_cookie.contains("SameSite=None"), "got: {set_cookie}");
+        assert!(set_cookie.contains("Partitioned"), "got: {set_cookie}");
     }
 
     #[test]

--- a/crates/e2e/tests/env_cookie.rs
+++ b/crates/e2e/tests/env_cookie.rs
@@ -40,9 +40,13 @@ fn sync_publishes_certified_ic_env_cookie_on_html() {
         .iter()
         .find(|c| c.starts_with("ic_env="))
         .unwrap_or_else(|| panic!("expected an ic_env cookie on /index.html, got: {cookies:?}"));
+    // Embeddable by default: `SameSite=None; Secure; Partitioned` (CHIPS) so page
+    // scripts can read it inside a cross-site iframe (Caffeine-style preview).
     assert!(
-        ic_env.contains("SameSite=Lax"),
-        "ic_env cookie should carry SameSite=Lax, got: {ic_env}"
+        ic_env.contains("SameSite=None")
+            && ic_env.contains("Secure")
+            && ic_env.contains("Partitioned"),
+        "ic_env cookie should carry SameSite=None; Secure; Partitioned, got: {ic_env}"
     );
 
     // A non-HTML asset carries no env cookie.

--- a/crates/e2e/tests/protection.rs
+++ b/crates/e2e/tests/protection.rs
@@ -99,6 +99,10 @@ fn protected_app_gates_unauthenticated_requests() {
         "got: {set_cookie}"
     );
     assert!(set_cookie.contains("HttpOnly"), "got: {set_cookie}");
+    // Embeddable by default: the credential must survive a cross-site iframe
+    // (Caffeine-style preview), so it is a partitioned cross-site cookie.
+    assert!(set_cookie.contains("SameSite=None"), "got: {set_cookie}");
+    assert!(set_cookie.contains("Partitioned"), "got: {set_cookie}");
 
     // A wrong password re-prompts with a certified 401.
     assert_eq!(

--- a/examples/access-protection/README.md
+++ b/examples/access-protection/README.md
@@ -25,11 +25,13 @@ the real HTTP gateway.
 
 ```
 access-protection
-├── icp.yaml          # the `frontend` asset canister config
-└── dist              # the site that gets synced
-    ├── index.html    # the private content (served only when authenticated)
-    ├── app.js        # a non-HTML asset — gated too (401 when logged out)
-    └── login.html    # the gate-exempt login page (fully self-contained)
+├── icp.yaml            # the `frontend` asset canister config
+├── dist                # the site that gets synced
+│   ├── index.html      # the private content (served only when authenticated)
+│   ├── app.js          # a non-HTML asset — gated too (401 when logged out)
+│   └── login.html      # the gate-exempt login page (fully self-contained)
+└── preview-harness     # optional local iframe check (Chromium only)
+    └── serve.sh
 ```
 
 ## Prerequisites
@@ -79,6 +81,27 @@ Make it public again, then stop the replica when you're done:
 icp canister call frontend disable_protection '()'
 icp network stop
 ```
+
+## Preview it in an embedded iframe (local, Chromium only)
+
+The access cookie is `SameSite=None; Secure; Partitioned`, so a private app also
+works when shown inside a **cross-site iframe** (e.g. an embedded preview). To
+check this locally:
+
+```sh
+cd examples/access-protection
+icp network start -d && icp deploy
+./preview-harness/serve.sh --setup   # enables protection + issues token "secret"
+```
+
+Open <http://harness.localhost:8000/> in a **Chromium-based** browser
+(Chrome/Edge/Brave): the page frames this canister as a cross-site iframe.
+**PASS** = the private content renders in the frame; **FAIL** = you get the
+login page (the cookie was blocked as a third-party cookie).
+
+Only Chromium browsers can be checked this way — they resolve `*.localhost` and
+honour `Secure` cookies over local `http`. Safari and Firefox behave correctly
+only over real HTTPS, so verify those against a deployed `https://<id>.icp0.io`.
 
 ## Managing access
 

--- a/examples/access-protection/preview-harness/serve.sh
+++ b/examples/access-protection/preview-harness/serve.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Local cross-site iframe preview check for access protection.
+#
+# Serves a tiny parent page (on harness.localhost) that embeds this canister
+# (on <canister-id>.localhost) in an iframe. The two are different sites, so the
+# browser treats the canister as a cross-site frame — the "embedded preview"
+# scenario — which exercises the SameSite=None; Secure; Partitioned access cookie.
+#
+# Chromium-based browsers ONLY (Chrome/Edge/Brave): they resolve *.localhost and
+# accept Secure cookies over local http. Safari/Firefox cannot be checked this
+# way; verify those against a real https deployment (see the README).
+#
+# Usage: ./serve.sh [--setup]
+#   --setup  first enable protection + issue the token "secret" on the canister.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PROJECT="$(dirname "$HERE")"
+TOKEN="secret"
+PORT=8000
+
+cid="$(cd "$PROJECT" && icp canister status frontend --id-only | tr -d '[:space:]')"
+gw="$(cd "$PROJECT" && icp network status --json \
+       | python3 -c 'import sys,json; print(json.load(sys.stdin)["gateway_url"])')"
+gwport="$(python3 -c 'import sys; from urllib.parse import urlparse; print(urlparse(sys.argv[1]).port)' "$gw")"
+
+if [ "${1:-}" = "--setup" ]; then
+  ( cd "$PROJECT" && icp canister call frontend enable_protection '("/login.html")' ) || true
+  # Record form (not a positional tuple): the dev wasm carries no candid metadata,
+  # so icp infers arg types from the text and a tuple would be read as 3 args.
+  ( cd "$PROJECT" && icp canister call frontend issue_token \
+      "(record { label = \"preview\"; ttl_secs = 3600 : nat32; value = opt \"$TOKEN\" })" )
+fi
+
+serve="$(mktemp -d)"
+cat > "$serve/index.html" <<HTML
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>iframe preview check</title>
+<p>Cross-site iframe of <code>http://$cid.localhost:$gwport</code> —
+   PASS: app content renders below; FAIL: the login page appears (cookie blocked).</p>
+<iframe src="http://$cid.localhost:$gwport/login.html#t=$TOKEN"
+        style="width:840px;max-width:100%;height:600px;border:1px solid #888"></iframe>
+HTML
+
+echo "Open  http://harness.localhost:$PORT/  in a Chromium-based browser (Ctrl-C to stop)."
+cd "$serve"
+exec python3 -m http.server "$PORT" --bind 127.0.0.1


### PR DESCRIPTION
## What

Default both cookies the canister sets to `SameSite=None; Secure; Partitioned` (CHIPS) so a private app works inside a **cross-site iframe** out of the box — the Caffeine embedded-preview use case — with nothing to opt into.

- **Access cookie** (`certified_assets_access`, the login credential): `SameSite=Lax` → `SameSite=None; Partitioned`.
- **`ic_env` cookie** (canister→frontend metadata): gains `Secure; SameSite=None; Partitioned` so page scripts can still read it inside the iframe. (`ic_env` is read-only client state, never sent back, so `None` only affects whether the browser *stores* it.)

## Why

Caffeine shows the draft preview in a cross-site iframe; `SameSite=Lax` is never sent there, so the gate loops back to login. Plain `SameSite=None` would be blocked by Safari and restricted by Chrome/Firefox. `Partitioned` (CHIPS) is the standards-track way to make a cookie work in a cross-site iframe across browsers, and it scopes the cookie to the embedding top-level site — so it never becomes a blanket cross-site cookie sent to arbitrary embedders.

No per-token / `enable_protection` opt-in: the default is embedding-friendly. Hardening back to `Lax` is deferred until a real user asks.

## Testing

- `cargo test -p canister-core` and `cargo test -p e2e` (protection + env_cookie, through the live gateway) pass; assertions updated and regression guards added pinning the new attributes.
- Manually verified in Chrome via the new local harness (`examples/access-protection/preview-harness/serve.sh`): the private app renders inside a cross-site iframe.

## Follow-up (not blocking)

Safari couldn't be verified locally — a plain-`http` loopback setup trips Safari's `Secure`-cookie / ITP edge cases that don't reflect production HTTPS. Whether Safari honours the `Partitioned` attribute for a cookie **written** inside a third-party iframe is the open question, and it needs one check against a real `https://<id>.icp0.io` deployment before Caffeine relies on it for Safari users. This change is strictly better than the prior `Lax` (broken for iframes in every browser) and has no regression for non-embedding apps, so it ships safely on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)