### PR TITLE
chore: prepare release 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,9 +37,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -67,15 +67,15 @@ checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ar_archive_writer"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
 dependencies = [
  "object",
 ]
@@ -94,9 +94,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "ascii-canvas"
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "asset-prep"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "brotli",
  "flate2",
@@ -146,9 +146,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -217,9 +217,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -232,18 +232,18 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -262,20 +262,20 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
  "regex-automata",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-unit"
@@ -295,9 +295,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cached"
@@ -335,7 +335,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -369,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.27"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba5b4833b63bf7b785fecdd2cc918ed90d988fd974825d5c48e7b407c39ef38"
+checksum = "b649560badafa98cdf260958393f317c013b5aa819dba26f21cc3e26cae41dae"
 dependencies = [
  "anyhow",
  "binread",
@@ -392,26 +392,26 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.10.27"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b60664b6324832dfb4863f3b19eb4d58819cd38fba6d3941b101213cea0d9ec"
+checksum = "8f94f9df97dd04077b5a30e82dfb5a5f2eae1a6e8c9d6a98fd24351c8a333464"
 dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "candid_parser"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "470a4cf0c110e217e54ab3d21c4a9c290736c4a70ab6263d65155522d4b93fb6"
+checksum = "2e35c12ed409a6c02c6e204db49926c75ceeb622a4a994b828cdd3dea7dfec59"
 dependencies = [
  "anyhow",
  "candid",
  "codespan-reporting",
- "convert_case 0.6.0",
+ "convert_case",
  "handlebars",
  "hex",
  "lalrpop",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "canister"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "candid",
  "candid_parser",
@@ -436,7 +436,7 @@ dependencies = [
 
 [[package]]
 name = "canister-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "asset-prep",
@@ -455,7 +455,7 @@ dependencies = [
  "ic-representation-independent-hash",
  "ic-response-verification",
  "ic-stable-structures",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "num-traits",
  "percent-encoding",
  "serde",
@@ -468,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -484,9 +484,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -533,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "comparable"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "838d2d21a142bc619c262bb2145d1af0a2e3dccfcb1360bbc47ae4c6686e1ec6"
+checksum = "a8582d59b2e3f69e206fc893a30ed094317e922c4d6cda583e26191589ec747e"
 dependencies = [
  "comparable_derive",
  "comparable_helper",
@@ -545,11 +545,11 @@ dependencies = [
 
 [[package]]
 name = "comparable_derive"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fef8fab462495e2956b0666a4fb50c6c5058bdbd2c2bc91c5894a03f916177f"
+checksum = "95d4cd19b75655e4cfb0731d1bca92cecc41b05f40f109d84890c97197379ca6"
 dependencies = [
- "convert_case 0.4.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -557,11 +557,11 @@ dependencies = [
 
 [[package]]
 name = "comparable_helper"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be7a1af3ce1ccc3c9a6edfc769672c5d7512959e292882beca663843a660eb9e"
+checksum = "95c88d7d5400a6f4d64b21bd3e31e817707ce2be337717f370e461657ae2ba8b"
 dependencies = [
- "convert_case 0.6.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -582,12 +582,6 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "convert_case"
@@ -649,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -711,7 +705,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -724,7 +718,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -746,7 +740,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -757,7 +751,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -791,9 +785,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "derive_builder"
@@ -813,7 +804,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -823,7 +814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -854,9 +845,9 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -888,12 +879,12 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "e2e"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "candid",
@@ -908,9 +899,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "ena"
@@ -989,12 +980,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1085,15 +1070,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1126,9 +1109,9 @@ dependencies = [
 
 [[package]]
 name = "handlebars"
-version = "6.4.1"
+version = "6.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43ccdfe15a81ab0a8af639e90254227c9a46afd9c5f5b6ec7efaa345c4b0f00"
+checksum = "f26569a2763497b7bd3fbd19374b774ea6038c5293678771259cd534d49740ff"
 dependencies = [
  "derive_builder",
  "log",
@@ -1152,20 +1135,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -1224,18 +1198,18 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1359,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64dfa64757e7bfdd3bd6048c35e1edd74b69325deeed6bcaafedbc864c645fc"
+checksum = "6a7971f4983db147afbbc4e7f87f60b09fcd60ac707af37ff3d2468dcddbf551"
 dependencies = [
  "candid",
  "ic-cdk-executor",
@@ -1386,15 +1360,15 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.20.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd0794365edf9997b1114b4ea10358c6af1317e39fc6611b4fc67053a44ec8f1"
+checksum = "a7c20c002200c720958f321bb78b4d4987fc2c380bf9ef69ed4404730810f45f"
 dependencies = [
  "candid",
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1537,7 +1511,7 @@ name = "ic-crypto-internal-types"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic.git?rev=724ae4101bfdd8d4443126a6a8b1ec5ca9b68a12#724ae4101bfdd8d4443126a6a8b1ec5ca9b68a12"
 dependencies = [
- "arrayvec 0.7.6",
+ "arrayvec 0.7.8",
  "hex",
  "ic-protobuf",
  "phantom_newtype",
@@ -1632,7 +1606,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1821,7 +1795,7 @@ source = "git+https://github.com/dfinity/ic.git?rev=724ae4101bfdd8d4443126a6a8b1
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1861,9 +1835,9 @@ dependencies = [
 
 [[package]]
 name = "ic_principal"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aea751965eaf92990be8c79c64b4f3174ff22dd3604e6696a06a494afbaba2a"
+checksum = "0c2732829022822ec69021c336d23b32a053e07abdd08553c71407d6e2d1675d"
 dependencies = [
  "arbitrary",
  "crc32fast",
@@ -2043,6 +2017,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2050,13 +2033,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2099,9 +2081,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
+checksum = "c83bff1d572d6b9aeef67ddfc8448e4a3737909cb28e81f97c791b9018703e52"
 
 [[package]]
 name = "leb128fmt"
@@ -2123,9 +2105,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
 ]
@@ -2159,9 +2141,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logos"
@@ -2184,7 +2166,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2204,7 +2186,7 @@ checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2215,9 +2197,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mime"
@@ -2253,9 +2235,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2280,9 +2262,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2291,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2306,9 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "num-modular"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
+checksum = "fc41a1374056e9672221567958a66c16be12d0e2c1b408761e14d901c237d5e0"
 
 [[package]]
 name = "num-order"
@@ -2390,9 +2372,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -2400,9 +2382,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2410,25 +2392,24 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
 dependencies = [
  "pest",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2559,7 +2540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2631,7 +2612,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2652,9 +2633,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -2697,7 +2678,7 @@ dependencies = [
 
 [[package]]
 name = "recipe-gen"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "handlebars",
  "serde",
@@ -2726,9 +2707,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2749,9 +2730,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -2812,9 +2793,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -2907,15 +2888,16 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -2991,9 +2973,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
@@ -3048,15 +3030,15 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3083,7 +3065,7 @@ dependencies = [
 
 [[package]]
 name = "state-hash"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "sha2 0.11.0",
  "wire-types",
@@ -3091,7 +3073,7 @@ dependencies = [
 
 [[package]]
 name = "state-hash-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "asset-prep",
  "hex",
@@ -3140,7 +3122,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3162,9 +3144,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3173,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "sync-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "asset-prep",
  "candid",
@@ -3187,12 +3169,12 @@ dependencies = [
 
 [[package]]
 name = "sync-plugin"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "candid",
  "serde",
  "sync-core",
- "wit-bindgen 0.58.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -3212,7 +3194,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3222,7 +3204,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -3280,7 +3262,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3291,7 +3273,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3302,12 +3284,11 @@ checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -3317,15 +3298,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3475,9 +3456,9 @@ checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -3499,9 +3480,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -3547,9 +3528,9 @@ checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8-width"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+checksum = "159a7cadce548703edd50d24069bc294c5415ecab0a480e0cd1ca06d112dc94a"
 
 [[package]]
 name = "utf8_iter"
@@ -3598,28 +3579,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3640,9 +3603,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3650,9 +3613,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3660,34 +3623,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.244.0",
 ]
 
 [[package]]
@@ -3697,19 +3650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.251.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder 0.244.0",
- "wasmparser 0.244.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3720,20 +3661,8 @@ checksum = "5f998ccc6e012f7b86865eb2a106c8a0422017a1a88977ce01a69f2244be2e57"
 dependencies = [
  "anyhow",
  "indexmap",
- "wasm-encoder 0.251.0",
- "wasmparser 0.251.0",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3750,9 +3679,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3820,7 +3749,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3831,7 +3760,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3951,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "wire-types"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "candid",
  "serde",
@@ -3960,38 +3889,12 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro 0.51.0",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen"
 version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a43552cfa071f246cfd99e5dbb23710dfe7336b3259e09339818483359470749"
 dependencies = [
  "bitflags",
- "wit-bindgen-rust-macro 0.58.0",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser 0.244.0",
+ "wit-bindgen-rust-macro",
 ]
 
 [[package]]
@@ -4002,23 +3905,7 @@ checksum = "4738d1c9a78e97bc7f664bfafd5d8e67d7bb26faa5c41e6d628e8bbdad3ec351"
 dependencies = [
  "anyhow",
  "heck",
- "wit-parser 0.251.0",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata 0.244.0",
- "wit-bindgen-core 0.51.0",
- "wit-component 0.244.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -4031,25 +3918,10 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
- "wasm-metadata 0.251.0",
- "wit-bindgen-core 0.58.0",
- "wit-component 0.251.0",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core 0.51.0",
- "wit-bindgen-rust 0.51.0",
+ "syn 2.0.118",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
 ]
 
 [[package]]
@@ -4063,28 +3935,9 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
- "wit-bindgen-core 0.58.0",
- "wit-bindgen-rust 0.58.0",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.244.0",
- "wasm-metadata 0.244.0",
- "wasmparser 0.244.0",
- "wit-parser 0.244.0",
+ "syn 2.0.118",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
 ]
 
 [[package]]
@@ -4100,28 +3953,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.251.0",
- "wasm-metadata 0.251.0",
- "wasmparser 0.251.0",
- "wit-parser 0.251.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.244.0",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
 ]
 
 [[package]]
@@ -4140,7 +3975,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.251.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -4157,9 +3992,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4174,28 +4009,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4215,28 +4050,28 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4269,7 +4104,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,9 @@ resolver = "2"
 # Single semver for every crate in the workspace; also the release identity the
 # canister and sync plugin share (see crates/wire-types/src/version.rs). Bump it
 # per the breaking/non-breaking rule documented there, then `make tag`.
-version = "0.1.0"
+version = "0.2.0"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/dfinity/certified-assets"
 license = "Apache-2.0"
 publish = false
@@ -21,13 +21,13 @@ ic-response-verification = "3.0.3"
 ic-representation-independent-hash = "3.0.3"
 
 # Others
-anyhow = "1.0.56"
+anyhow = "1.0.103"
 assert_cmd = "2"
 base64 = "0.22.1"
 brotli = "8.0.2"
 canbench-rs = "0.6.0"
 candid = "0.10.18"
-candid_parser = "0.3.0"
+candid_parser = "0.4.0"
 ciborium = "0.2.2"
 flate2 = "1.0"
 # Pinned to the versions icp-cli uses so recipe-gen's tests render recipes the
@@ -38,7 +38,7 @@ http = "1.4.2"
 ic-cdk = "0.20.1"
 ic-cdk-management-canister = "0.1.1"
 ic-stable-structures = "0.7.2"
-itertools = "0.14.0"
+itertools = "0.15.0"
 mime = "0.3"
 mime_guess = "2.0"
 num-traits = "0.2.14"

--- a/crates/asset-prep/src/content.rs
+++ b/crates/asset-prep/src/content.rs
@@ -82,10 +82,10 @@ fn is_compressible(media_type: &Mime) -> bool {
     if ty == mime::FONT {
         return !matches!(subtype.as_str(), "woff" | "woff2");
     }
-    if let Some(suffix) = media_type.suffix() {
-        if suffix == mime::JSON || suffix == mime::XML {
-            return true;
-        }
+    if let Some(suffix) = media_type.suffix()
+        && (suffix == mime::JSON || suffix == mime::XML)
+    {
+        return true;
     }
     subtype == mime::JAVASCRIPT
         || subtype == mime::JSON

--- a/crates/asset-prep/src/html_handling.rs
+++ b/crates/asset-prep/src/html_handling.rs
@@ -267,9 +267,11 @@ mod tests {
         let rules = synthesize(&keys);
         // 5 rules for /foo.html, none for the others.
         assert_eq!(rules.len(), 5);
-        assert!(rules
-            .iter()
-            .all(|r| matches!(&r.from, RulePattern::Exact(p) if p.starts_with("/foo"))));
+        assert!(
+            rules
+                .iter()
+                .all(|r| matches!(&r.from, RulePattern::Exact(p) if p.starts_with("/foo")))
+        );
     }
 
     #[test]

--- a/crates/asset-prep/src/lib.rs
+++ b/crates/asset-prep/src/lib.rs
@@ -26,8 +26,8 @@ pub mod scan;
 
 mod prepare;
 pub use prepare::{
-    manifest, prepare_project, state_hash_for_dir, PreparedAsset, PreparedChunk, PreparedEncoding,
-    PreparedProject, MAX_CHUNK_SIZE,
+    MAX_CHUNK_SIZE, PreparedAsset, PreparedChunk, PreparedEncoding, PreparedProject, manifest,
+    prepare_project, state_hash_for_dir,
 };
 
 /// Strips a Netlify-style trailing comment from a single line of a `_redirects`

--- a/crates/asset-prep/src/prepare.rs
+++ b/crates/asset-prep/src/prepare.rs
@@ -13,8 +13,8 @@ use std::path::Path;
 
 use wire_types::{Encoding, RedirectRule, RulePattern};
 
-use crate::content::{encoders_for, Content};
-use crate::headers::{self, HeaderRule, HEADERS_FILENAME};
+use crate::content::{Content, encoders_for};
+use crate::headers::{self, HEADERS_FILENAME, HeaderRule};
 use crate::redirects::{self, REDIRECTS_FILENAME};
 use crate::scan::{self, AssetSource};
 use crate::{html_handling, not_found};
@@ -351,10 +351,12 @@ mod tests {
         // plus the `/* -> /404.html 404` catch-all (see `not_found`).
         assert_eq!(prepared.assets.len(), 1);
         assert_eq!(prepared.assets[0].key, not_found::ROOT_404_KEY);
-        assert!(prepared
-            .redirect_rules
-            .iter()
-            .any(|r| r.status == 404 && r.to == not_found::ROOT_404_KEY));
+        assert!(
+            prepared
+                .redirect_rules
+                .iter()
+                .any(|r| r.status == 404 && r.to == not_found::ROOT_404_KEY)
+        );
     }
 
     #[test]
@@ -369,10 +371,12 @@ mod tests {
             .filter(|a| a.key == not_found::ROOT_404_KEY)
             .count();
         assert_eq!(count_404, 1);
-        assert!(prepared.assets[0]
-            .encodings
-            .iter()
-            .any(|e| e.encoding == Encoding::Identity));
+        assert!(
+            prepared.assets[0]
+                .encodings
+                .iter()
+                .any(|e| e.encoding == Encoding::Identity)
+        );
     }
 
     #[test]
@@ -387,10 +391,12 @@ mod tests {
             .find(|a| a.key == "/index.html")
             .expect("index.html prepared");
         assert_eq!(index.content_type, "text/html");
-        assert!(index
-            .encodings
-            .iter()
-            .any(|e| e.encoding == Encoding::Identity));
+        assert!(
+            index
+                .encodings
+                .iter()
+                .any(|e| e.encoding == Encoding::Identity)
+        );
         // Each kept encoding is at least one chunk.
         for enc in &index.encodings {
             assert!(!enc.chunks.is_empty());

--- a/crates/asset-prep/src/redirects.rs
+++ b/crates/asset-prep/src/redirects.rs
@@ -61,13 +61,13 @@ fn parse_line(body: &str) -> Result<RedirectRule, String> {
         n if n < 3 => {
             return Err(format!(
                 "expected '<from> <to> <status>' (3 fields), got {n}"
-            ))
+            ));
         }
         n => {
             return Err(format!(
                 "expected '<from> <to> <status>' (3 fields), got {n}; \
                  extra fields are not supported (no headers, conditions, or query-string match)"
-            ))
+            ));
         }
     }
     let from_tok = tokens[0];

--- a/crates/canister-core/src/asset.rs
+++ b/crates/canister-core/src/asset.rs
@@ -12,11 +12,11 @@
 //! [`crate::state::State`], which owns the chunk store.
 
 use crate::cert::{
-    build_ic_certificate_expression_from_headers_and_encoding,
-    build_ic_certificate_expression_header, response_hash, CertificateExpression, ResponseHash,
+    CertificateExpression, ResponseHash, build_ic_certificate_expression_from_headers_and_encoding,
+    build_ic_certificate_expression_header, response_hash,
 };
 use ic_representation_independent_hash::Value;
-use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+use percent_encoding::{NON_ALPHANUMERIC, utf8_percent_encode};
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
 use std::collections::{BTreeMap, HashMap};
@@ -205,9 +205,11 @@ pub fn response_hashes_for(
     response_hashes.insert(200, response_hash_200);
     response_hashes.insert(304, response_hash_304);
 
-    debug_assert!(STATUS_CODES_TO_CERTIFY
-        .iter()
-        .all(|code| response_hashes.contains_key(code)));
+    debug_assert!(
+        STATUS_CODES_TO_CERTIFY
+            .iter()
+            .all(|code| response_hashes.contains_key(code))
+    );
 
     response_hashes
 }

--- a/crates/canister-core/src/benches.rs
+++ b/crates/canister-core/src/benches.rs
@@ -26,7 +26,7 @@ use crate::http::HttpRequest;
 use crate::runtime::SystemContext;
 use crate::state::State;
 use crate::sync::{ComputationStatus, ExecuteOperationsProgress};
-use canbench_rs::{bench, bench_fn, BenchResult};
+use canbench_rs::{BenchResult, bench, bench_fn};
 use candid::Principal;
 use ic_stable_structures::DefaultMemoryImpl;
 use serde_bytes::ByteBuf;

--- a/crates/canister-core/src/cert/certifier.rs
+++ b/crates/canister-core/src/cert/certifier.rs
@@ -32,12 +32,12 @@ use ic_certification::{AsHashTree, Hash};
 use ic_representation_independent_hash::Value;
 
 use super::primitives::{
-    response_hash, AssetKey, AssetPath, CertificateExpression, CertifiedResponses, HashTreePath,
-    NestedTreeKey, RequestHash, ResponseHash,
+    AssetKey, AssetPath, CertificateExpression, CertifiedResponses, HashTreePath, NestedTreeKey,
+    RequestHash, ResponseHash, response_hash,
 };
 use crate::asset::{
-    certificate_expression_for, headers_for, range_certificate_expression_for, range_response_hash,
-    response_hashes_for, AssetMeta, EncodingMeta,
+    AssetMeta, EncodingMeta, certificate_expression_for, headers_for,
+    range_certificate_expression_for, range_response_hash, response_hashes_for,
 };
 use crate::http::{HeaderField, HttpResponse};
 use crate::protection::ProtectionResponse;

--- a/crates/canister-core/src/cert/certifier.rs
+++ b/crates/canister-core/src/cert/certifier.rs
@@ -123,10 +123,10 @@ impl Certifier {
     /// (`protection == None`) are untouched.
     pub fn effective_headers(&self, store: &Store, meta: &AssetMeta) -> Vec<(String, String)> {
         let mut headers = meta.headers.clone();
-        if let Some(cookie) = &self.env_cookie {
-            if crate::asset::is_html_content_type(&meta.content_type) {
-                headers.push(("set-cookie".to_string(), cookie.clone()));
-            }
+        if let Some(cookie) = &self.env_cookie
+            && crate::asset::is_html_content_type(&meta.content_type)
+        {
+            headers.push(("set-cookie".to_string(), cookie.clone()));
         }
         if store.protection_enabled() {
             headers.retain(|(k, _)| !k.eq_ignore_ascii_case("cache-control"));
@@ -430,11 +430,11 @@ impl Certifier {
         store: &Store,
         rule: &RedirectRule,
     ) -> Option<crate::redirect::CertifiedRuleEntry> {
-        if let RulePattern::Exact(src) = &rule.from {
-            if store.contains_asset(src) {
-                // Asset at the source path shadows the rule.
-                return None;
-            }
+        if let RulePattern::Exact(src) = &rule.from
+            && store.contains_asset(src)
+        {
+            // Asset at the source path shadows the rule.
+            return None;
         }
         match rule.status {
             // 200 rewrites and 4xx custom error pages both borrow body + headers

--- a/crates/canister-core/src/cert/mod.rs
+++ b/crates/canister-core/src/cert/mod.rs
@@ -29,8 +29,8 @@ mod primitives;
 
 pub(crate) use certifier::Certifier;
 pub(crate) use primitives::{
+    AssetKey, AssetPath, CertificateExpression, HashTreePath, NestedTreeKey, ResponseHash,
     build_ic_certificate_expression_from_headers,
     build_ic_certificate_expression_from_headers_and_encoding,
-    build_ic_certificate_expression_header, response_hash, AssetKey, AssetPath,
-    CertificateExpression, HashTreePath, NestedTreeKey, ResponseHash,
+    build_ic_certificate_expression_header, response_hash,
 };

--- a/crates/canister-core/src/cert/primitives.rs
+++ b/crates/canister-core/src/cert/primitives.rs
@@ -14,11 +14,11 @@
 //! `cert`.
 
 use super::nested_tree::NestedTree;
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use candid::CandidType;
-use ic_certification::merge_hash_trees;
 pub use ic_certification::HashTree;
-use ic_representation_independent_hash::{representation_independent_hash, Value};
+use ic_certification::merge_hash_trees;
+use ic_representation_independent_hash::{Value, representation_independent_hash};
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
 use std::borrow::Borrow;

--- a/crates/canister-core/src/protection.rs
+++ b/crates/canister-core/src/protection.rs
@@ -19,8 +19,8 @@
 //! submodule (see [`crate::state`]).
 
 use crate::cert::{
-    build_ic_certificate_expression_from_headers, build_ic_certificate_expression_header,
-    response_hash, CertificateExpression, NestedTreeKey,
+    CertificateExpression, NestedTreeKey, build_ic_certificate_expression_from_headers,
+    build_ic_certificate_expression_header, response_hash,
 };
 use crate::http::HttpRequest;
 use candid::CandidType;

--- a/crates/canister-core/src/redirect.rs
+++ b/crates/canister-core/src/redirect.rs
@@ -1,8 +1,9 @@
 //! User-supplied redirect/rewrite/error rules expressed as `_redirects` entries.
 
 use crate::cert::{
+    AssetPath, CertificateExpression, HashTreePath, NestedTreeKey,
     build_ic_certificate_expression_from_headers, build_ic_certificate_expression_header,
-    response_hash, AssetPath, CertificateExpression, HashTreePath, NestedTreeKey,
+    response_hash,
 };
 use http::{HeaderName, HeaderValue, StatusCode};
 use ic_representation_independent_hash::Value;

--- a/crates/canister-core/src/state/assets.rs
+++ b/crates/canister-core/src/state/assets.rs
@@ -6,7 +6,7 @@
 //! [`Store`]: crate::store::Store
 //! [`Certifier`]: crate::cert::Certifier
 
-use super::{State, PAGE_SIZE};
+use super::{PAGE_SIZE, State};
 use crate::asset::{AssetMeta, EncodingMeta};
 use crate::cert::AssetKey;
 use serde_bytes::ByteBuf;

--- a/crates/canister-core/src/state/env.rs
+++ b/crates/canister-core/src/state/env.rs
@@ -40,10 +40,10 @@ impl State {
         self.store_env(env);
         let keys = self.store.asset_keys();
         for key in keys {
-            if let Some(meta) = self.store.get_asset(&key) {
-                if crate::asset::is_html_content_type(&meta.content_type) {
-                    self.certifier.recertify_asset(&self.store, &key, &meta);
-                }
+            if let Some(meta) = self.store.get_asset(&key)
+                && crate::asset::is_html_content_type(&meta.content_type)
+            {
+                self.certifier.recertify_asset(&self.store, &key, &meta);
             }
         }
         // Rebuild rule entries: a 200-rewrite (e.g. the `/` SPA alias) to an HTML

--- a/crates/canister-core/src/state/protection.rs
+++ b/crates/canister-core/src/state/protection.rs
@@ -11,11 +11,11 @@
 //! (`token_index`) lives on `State` and is read here.
 
 use super::State;
-use crate::cert::{build_ic_certificate_expression_header, AssetPath, HashTreePath};
+use crate::cert::{AssetPath, HashTreePath, build_ic_certificate_expression_header};
 use crate::http::{HttpRequest, HttpResponse};
 use crate::protection::{
-    access_cookie_values, parse_form_token, token_id, ProtectionResponse, ProtectionStatus,
-    TokenInfo, TokenMeta,
+    ProtectionResponse, ProtectionStatus, TokenInfo, TokenMeta, access_cookie_values,
+    parse_form_token, token_id,
 };
 use serde_bytes::ByteBuf;
 

--- a/crates/canister-core/src/state/protection.rs
+++ b/crates/canister-core/src/state/protection.rs
@@ -105,15 +105,14 @@ impl State {
         now: u64,
     ) -> HttpResponse {
         let location = AssetPath::from(login_page).asset_hash_path_root();
-        if let Some(value) = parse_form_token(req.body.as_ref()) {
-            if self
+        if let Some(value) = parse_form_token(req.body.as_ref())
+            && self
                 .token_index
                 .get(&token_id(&value))
                 .is_some_and(|&expires_at| expires_at > now)
-            {
-                let resp = ProtectionResponse::redeem_success(&value);
-                return self.serve_protection_response(&resp, login_page, &location, certificate);
-            }
+        {
+            let resp = ProtectionResponse::redeem_success(&value);
+            return self.serve_protection_response(&resp, login_page, &location, certificate);
         }
         let resp = ProtectionResponse::redeem_failure();
         self.serve_protection_response(&resp, login_page, &location, certificate)

--- a/crates/canister-core/src/state/rules.rs
+++ b/crates/canister-core/src/state/rules.rs
@@ -5,7 +5,7 @@
 //!
 //! [`Certifier`]: crate::cert::Certifier
 
-use super::{State, PAGE_SIZE};
+use super::{PAGE_SIZE, State};
 use wire_types::RedirectRule;
 
 impl State {

--- a/crates/canister-core/src/state/serving.rs
+++ b/crates/canister-core/src/state/serving.rs
@@ -8,7 +8,7 @@
 //! built in [`super::protection`].
 
 use super::State;
-use crate::asset::{headers_for, range_headers_for, AssetMeta, EncodingMeta};
+use crate::asset::{AssetMeta, EncodingMeta, headers_for, range_headers_for};
 use crate::http::{HeaderField, HttpRequest, HttpResponse};
 use ic_certification::Hash;
 use percent_encoding::percent_decode_str;
@@ -423,7 +423,7 @@ impl State {
 
 #[cfg(test)]
 mod tests {
-    use super::{url_decode, UrlDecodeError};
+    use super::{UrlDecodeError, url_decode};
 
     #[test]
     fn check_url_decode() {

--- a/crates/canister-core/src/state/sync.rs
+++ b/crates/canister-core/src/state/sync.rs
@@ -11,7 +11,7 @@ use super::State;
 use crate::redirect;
 use crate::runtime::SystemContext;
 use crate::sync::{
-    ComputationStatus, ExecuteOperationsProgress, SyncSession, SYNC_IDLE_TIMEOUT_NANOS,
+    ComputationStatus, ExecuteOperationsProgress, SYNC_IDLE_TIMEOUT_NANOS, SyncSession,
 };
 use candid::Principal;
 use wire_types::{

--- a/crates/canister-core/src/state/tests.rs
+++ b/crates/canister-core/src/state/tests.rs
@@ -1,10 +1,10 @@
+use crate::UploadChunksArguments;
 use crate::http::{HttpRequest, HttpResponse};
 use crate::protection::ProtectionStatus;
 use crate::runtime::SystemContext;
 use crate::state::State;
 use crate::sync::{ComputationStatus, SYNC_IDLE_TIMEOUT_NANOS};
-use crate::UploadChunksArguments;
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use candid::Principal;
 use ic_certification_testing::CertificateBuilder;
 use ic_crypto_tree_hash::Digest;
@@ -403,8 +403,10 @@ mod sync {
         let session_id = create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/contents.html", "text/html")
-                .with_encoding("identity", vec![BODY])],
+            vec![
+                AssetBuilder::new("/contents.html", "text/html")
+                    .with_encoding("identity", vec![BODY]),
+            ],
         );
 
         let response = certified_http_request(
@@ -639,7 +641,7 @@ mod hashing {
 
     #[test]
     fn state_hash_matches_manifest_digest_single_chunk() {
-        use state_hash::{digest, Manifest, ManifestAsset, ManifestEncoding};
+        use state_hash::{Manifest, ManifestAsset, ManifestEncoding, digest};
 
         let mut state = State::default();
         let ctx = mock_system_context();
@@ -648,9 +650,11 @@ mod hashing {
         create_assets(
             &mut state,
             &ctx,
-            vec![AssetBuilder::new("/index.html", "text/html")
-                .with_header("Cache-Control", "max-age=60")
-                .with_encoding("identity", vec![BODY])],
+            vec![
+                AssetBuilder::new("/index.html", "text/html")
+                    .with_header("Cache-Control", "max-age=60")
+                    .with_encoding("identity", vec![BODY]),
+            ],
         );
 
         let cached = state.cached_state_hash();
@@ -681,7 +685,7 @@ mod hashing {
 
     #[test]
     fn state_hash_folds_per_chunk_hashes_for_multi_chunk() {
-        use state_hash::{digest, Manifest, ManifestAsset, ManifestChunk, ManifestEncoding};
+        use state_hash::{Manifest, ManifestAsset, ManifestChunk, ManifestEncoding, digest};
 
         let mut state = State::default();
         let ctx = mock_system_context();
@@ -691,8 +695,10 @@ mod hashing {
         create_assets(
             &mut state,
             &ctx,
-            vec![AssetBuilder::new("/big.bin", "application/octet-stream")
-                .with_encoding("identity", vec![C0, C1])],
+            vec![
+                AssetBuilder::new("/big.bin", "application/octet-stream")
+                    .with_encoding("identity", vec![C0, C1]),
+            ],
         );
 
         let cached = state.cached_state_hash();
@@ -737,8 +743,10 @@ mod hashing {
         create_assets(
             &mut state,
             &ctx,
-            vec![AssetBuilder::new("/a.txt", "text/plain")
-                .with_encoding("identity", vec![b"v2-different"])],
+            vec![
+                AssetBuilder::new("/a.txt", "text/plain")
+                    .with_encoding("identity", vec![b"v2-different"]),
+            ],
         );
         let after = state.cached_state_hash();
 
@@ -757,8 +765,10 @@ mod hashing {
         create_assets(
             &mut state,
             &ctx,
-            vec![AssetBuilder::new("/index.html", "text/html")
-                .with_encoding("identity", vec![b"hi"])],
+            vec![
+                AssetBuilder::new("/index.html", "text/html")
+                    .with_encoding("identity", vec![b"hi"]),
+            ],
         );
         let before = state.cached_state_hash();
         assert_ne!(before, [0u8; 32]);
@@ -961,8 +971,10 @@ mod serving {
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/index.html", "text/html")
-                .with_encoding("identity", vec![INDEX_BODY])],
+            vec![
+                AssetBuilder::new("/index.html", "text/html")
+                    .with_encoding("identity", vec![INDEX_BODY]),
+            ],
         );
 
         let state = upgrade(state, memory.clone());
@@ -1098,8 +1110,10 @@ mod range_serving {
         create_assets(
             &mut state,
             &ctx,
-            vec![AssetBuilder::new("/big.bin", "application/octet-stream")
-                .with_encoding("identity", vec![C0, C1])],
+            vec![
+                AssetBuilder::new("/big.bin", "application/octet-stream")
+                    .with_encoding("identity", vec![C0, C1]),
+            ],
         );
 
         let resp = certified_http_request(
@@ -1127,8 +1141,10 @@ mod range_serving {
         create_assets(
             &mut state,
             &ctx,
-            vec![AssetBuilder::new("/big.bin", "application/octet-stream")
-                .with_encoding("identity", vec![C0, C1, C2])],
+            vec![
+                AssetBuilder::new("/big.bin", "application/octet-stream")
+                    .with_encoding("identity", vec![C0, C1, C2]),
+            ],
         );
         let total = C0.len() + C1.len() + C2.len();
 
@@ -1157,8 +1173,10 @@ mod range_serving {
         create_assets(
             &mut state,
             &ctx,
-            vec![AssetBuilder::new("/big.bin", "application/octet-stream")
-                .with_encoding("identity", vec![C0, C1])],
+            vec![
+                AssetBuilder::new("/big.bin", "application/octet-stream")
+                    .with_encoding("identity", vec![C0, C1]),
+            ],
         );
         let total = C0.len() + C1.len();
 
@@ -1188,8 +1206,10 @@ mod range_serving {
         create_assets(
             &mut state,
             &ctx,
-            vec![AssetBuilder::new("/big.bin", "application/octet-stream")
-                .with_encoding("identity", vec![C0, C1])],
+            vec![
+                AssetBuilder::new("/big.bin", "application/octet-stream")
+                    .with_encoding("identity", vec![C0, C1]),
+            ],
         );
         let total = C0.len() + C1.len();
 
@@ -1219,8 +1239,10 @@ mod range_serving {
         create_assets(
             &mut state,
             &ctx,
-            vec![AssetBuilder::new("/big.bin", "application/octet-stream")
-                .with_encoding("identity", vec![C0, C1])],
+            vec![
+                AssetBuilder::new("/big.bin", "application/octet-stream")
+                    .with_encoding("identity", vec![C0, C1]),
+            ],
         );
         let total = C0.len() + C1.len();
 
@@ -1249,8 +1271,10 @@ mod range_serving {
         create_assets(
             &mut state,
             &ctx,
-            vec![AssetBuilder::new("/big.bin", "application/octet-stream")
-                .with_encoding("identity", vec![C0, C1])],
+            vec![
+                AssetBuilder::new("/big.bin", "application/octet-stream")
+                    .with_encoding("identity", vec![C0, C1]),
+            ],
         );
 
         // First request: read the canister-managed etag off the 206.
@@ -1287,7 +1311,7 @@ mod range_serving {
             &mut state,
             &ctx,
             vec![
-                AssetBuilder::new("/small.txt", "text/plain").with_encoding("identity", vec![BODY])
+                AssetBuilder::new("/small.txt", "text/plain").with_encoding("identity", vec![BODY]),
             ],
         );
 
@@ -1316,7 +1340,7 @@ mod range_serving {
             &mut state,
             &ctx,
             vec![
-                AssetBuilder::new("/app.js", "text/javascript").with_encoding("gzip", vec![G0, G1])
+                AssetBuilder::new("/app.js", "text/javascript").with_encoding("gzip", vec![G0, G1]),
             ],
         );
         let total = G0.len() + G1.len();
@@ -1349,8 +1373,10 @@ mod range_serving {
         create_assets(
             &mut state,
             &ctx,
-            vec![AssetBuilder::new("/big.bin", "application/octet-stream")
-                .with_encoding("identity", vec![C0, C1])],
+            vec![
+                AssetBuilder::new("/big.bin", "application/octet-stream")
+                    .with_encoding("identity", vec![C0, C1]),
+            ],
         );
         let total = C0.len() + C1.len();
 
@@ -1383,8 +1409,10 @@ mod range_serving {
         create_assets(
             &mut state,
             &ctx,
-            vec![AssetBuilder::new("/big.bin", "application/octet-stream")
-                .with_encoding("identity", vec![C0, C1])],
+            vec![
+                AssetBuilder::new("/big.bin", "application/octet-stream")
+                    .with_encoding("identity", vec![C0, C1]),
+            ],
         );
         let total = C0.len() + C1.len();
         let cr = format!("bytes 0-{}/{}", C0.len() - 1, total);
@@ -1421,9 +1449,11 @@ mod range_serving {
         create_assets(
             &mut state,
             &ctx,
-            vec![AssetBuilder::new("/app.js", "text/javascript")
-                .with_encoding("identity", vec![I0, I1])
-                .with_encoding("gzip", vec![GZ])],
+            vec![
+                AssetBuilder::new("/app.js", "text/javascript")
+                    .with_encoding("identity", vec![I0, I1])
+                    .with_encoding("gzip", vec![GZ]),
+            ],
         );
 
         // gzip is single-chunk → Range ignored, full 200.
@@ -1500,24 +1530,28 @@ mod assets {
         );
 
         // A non-empty `headers` replaces the headers map.
-        assert!(state
-            .set_asset_headers(SetAssetHeadersArguments {
-                key: "/props.html".into(),
-                headers: vec![("new-header".into(), "value".into())],
-            })
-            .is_ok());
+        assert!(
+            state
+                .set_asset_headers(SetAssetHeadersArguments {
+                    key: "/props.html".into(),
+                    headers: vec![("new-header".into(), "value".into())],
+                })
+                .is_ok()
+        );
         assert_eq!(
             headers_of(&state, "/props.html"),
             vec![("new-header".to_string(), "value".to_string())],
         );
 
         // An empty `headers` clears the headers map.
-        assert!(state
-            .set_asset_headers(SetAssetHeadersArguments {
-                key: "/props.html".into(),
-                headers: vec![],
-            })
-            .is_ok());
+        assert!(
+            state
+                .set_asset_headers(SetAssetHeadersArguments {
+                    key: "/props.html".into(),
+                    headers: vec![],
+                })
+                .is_ok()
+        );
         assert!(headers_of(&state, "/props.html").is_empty());
     }
 
@@ -1530,8 +1564,10 @@ mod assets {
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/contents.html", "text/html")
-                .with_encoding("identity", vec![FILE_BODY])],
+            vec![
+                AssetBuilder::new("/contents.html", "text/html")
+                    .with_encoding("identity", vec![FILE_BODY]),
+            ],
         );
 
         assert!(
@@ -1893,9 +1929,11 @@ mod certification {
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/contents.html", "text/html")
-                .with_encoding("identity", vec![BODY])
-                .with_header("Access-Control-Allow-Origin", "*")],
+            vec![
+                AssetBuilder::new("/contents.html", "text/html")
+                    .with_encoding("identity", vec![BODY])
+                    .with_header("Access-Control-Allow-Origin", "*"),
+            ],
         );
 
         let response = certified_http_request(
@@ -1922,9 +1960,11 @@ mod certification {
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/contents.html", "text/html")
-                .with_encoding("identity", vec![UPDATED_BODY])
-                .with_header("Access-Control-Allow-Origin", "*")],
+            vec![
+                AssetBuilder::new("/contents.html", "text/html")
+                    .with_encoding("identity", vec![UPDATED_BODY])
+                    .with_header("Access-Control-Allow-Origin", "*"),
+            ],
         );
 
         let response = certified_http_request(
@@ -1952,9 +1992,11 @@ mod certification {
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/contents.html", "text/html")
-                .with_encoding("identity", vec![BODY])
-                .with_header("etag", "my-etag")],
+            vec![
+                AssetBuilder::new("/contents.html", "text/html")
+                    .with_encoding("identity", vec![BODY])
+                    .with_header("etag", "my-etag"),
+            ],
         );
 
         let response = certified_http_request(
@@ -1986,8 +2028,10 @@ mod certification {
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/contents.html", "text/html")
-                .with_encoding("identity", vec![BODY])],
+            vec![
+                AssetBuilder::new("/contents.html", "text/html")
+                    .with_encoding("identity", vec![BODY]),
+            ],
         );
 
         // Matching etag -> certified 304, empty body, no streaming.
@@ -2027,9 +2071,11 @@ mod certification {
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/contents.html", "text/html")
-                .with_encoding("identity", vec![BODY])
-                .with_header("Access-Control-Allow-Origin", "*")],
+            vec![
+                AssetBuilder::new("/contents.html", "text/html")
+                    .with_encoding("identity", vec![BODY])
+                    .with_header("Access-Control-Allow-Origin", "*"),
+            ],
         );
 
         let response = certified_http_request(
@@ -2060,9 +2106,11 @@ mod certification {
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/contents.html", "text/html")
-                .with_encoding("gzip", vec![BODY])
-                .with_header("Access-Control-Allow-Origin", "*")],
+            vec![
+                AssetBuilder::new("/contents.html", "text/html")
+                    .with_encoding("gzip", vec![BODY])
+                    .with_header("Access-Control-Allow-Origin", "*"),
+            ],
         );
 
         let response = certified_http_request(
@@ -2208,10 +2256,12 @@ mod redirect_rules {
             collected.extend(page);
         }
         assert_eq!(collected.len(), total);
-        assert!(collected
-            .iter()
-            .enumerate()
-            .all(|(i, r)| r.to == format!("/to-{i}")));
+        assert!(
+            collected
+                .iter()
+                .enumerate()
+                .all(|(i, r)| r.to == format!("/to-{i}"))
+        );
     }
 
     #[test]
@@ -2423,8 +2473,10 @@ mod redirect_rules {
         create_assets(
             &mut state,
             &mock_system_context(),
-            vec![AssetBuilder::new("/foo.html", "text/html")
-                .with_encoding("identity", vec![BODY_V1])],
+            vec![
+                AssetBuilder::new("/foo.html", "text/html")
+                    .with_encoding("identity", vec![BODY_V1]),
+            ],
         );
         let v1 = certified_http_request(&state, RequestBuilder::get("/foo").build());
         assert_eq!(v1.status_code, 200);
@@ -2435,8 +2487,10 @@ mod redirect_rules {
         create_assets(
             &mut state,
             &mock_system_context(),
-            vec![AssetBuilder::new("/foo.html", "text/html")
-                .with_encoding("identity", vec![BODY_V2])],
+            vec![
+                AssetBuilder::new("/foo.html", "text/html")
+                    .with_encoding("identity", vec![BODY_V2]),
+            ],
         );
         let v2 = certified_http_request(&state, RequestBuilder::get("/foo").build());
         assert_eq!(v2.body.as_ref(), BODY_V2);
@@ -2466,8 +2520,10 @@ mod redirect_rules {
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/bar.html", "text/html")
-                .with_encoding("identity", vec![RULE_TARGET])],
+            vec![
+                AssetBuilder::new("/bar.html", "text/html")
+                    .with_encoding("identity", vec![RULE_TARGET]),
+            ],
         );
         commit(
             &mut state,
@@ -2490,8 +2546,10 @@ mod redirect_rules {
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/foo", "text/html")
-                .with_encoding("identity", vec![SOURCE_ASSET])],
+            vec![
+                AssetBuilder::new("/foo", "text/html")
+                    .with_encoding("identity", vec![SOURCE_ASSET]),
+            ],
         );
         let via_asset = certified_http_request(&state, RequestBuilder::get("/foo").build());
         assert_eq!(via_asset.body.as_ref(), SOURCE_ASSET);
@@ -2511,8 +2569,10 @@ mod redirect_rules {
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/404.html", "text/html")
-                .with_encoding("identity", vec![PAGE_BODY])],
+            vec![
+                AssetBuilder::new("/404.html", "text/html")
+                    .with_encoding("identity", vec![PAGE_BODY]),
+            ],
         );
         commit(
             &mut state,
@@ -2544,8 +2604,10 @@ mod redirect_rules {
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/410.html", "text/html")
-                .with_encoding("identity", vec![PAGE_BODY])],
+            vec![
+                AssetBuilder::new("/410.html", "text/html")
+                    .with_encoding("identity", vec![PAGE_BODY]),
+            ],
         );
         commit(
             &mut state,
@@ -2598,7 +2660,7 @@ mod redirect_rules {
             &mut state,
             &system_context,
             vec![
-                AssetBuilder::new("/index.html", "text/html").with_encoding("identity", vec![BODY])
+                AssetBuilder::new("/index.html", "text/html").with_encoding("identity", vec![BODY]),
             ],
         );
 
@@ -2620,8 +2682,10 @@ mod redirect_rules {
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/index.html", "text/html")
-                .with_encoding("identity", vec![INDEX])],
+            vec![
+                AssetBuilder::new("/index.html", "text/html")
+                    .with_encoding("identity", vec![INDEX]),
+            ],
         );
 
         // No rule → certified built-in 404 on a missing path.
@@ -2695,8 +2759,10 @@ mod redirect_rules {
         create_assets(
             &mut state,
             &ctx,
-            vec![AssetBuilder::new("/404.html", "text/html")
-                .with_encoding("identity", vec![b"chunk-zero", b"chunk-one!"])],
+            vec![
+                AssetBuilder::new("/404.html", "text/html")
+                    .with_encoding("identity", vec![b"chunk-zero", b"chunk-one!"]),
+            ],
         );
         for status in [404u16, 410] {
             let err = commit(
@@ -2724,8 +2790,10 @@ mod redirect_rules {
         create_assets(
             &mut state,
             &ctx,
-            vec![AssetBuilder::new("/large.bin", "application/octet-stream")
-                .with_encoding("identity", vec![b"chunk-zero", b"chunk-one!"])],
+            vec![
+                AssetBuilder::new("/large.bin", "application/octet-stream")
+                    .with_encoding("identity", vec![b"chunk-zero", b"chunk-one!"]),
+            ],
         );
         commit(
             &mut state,
@@ -2753,8 +2821,10 @@ mod redirect_rules {
         create_assets(
             &mut state,
             &ctx,
-            vec![AssetBuilder::new("/large.bin", "application/octet-stream")
-                .with_encoding("identity", vec![C0, C1])],
+            vec![
+                AssetBuilder::new("/large.bin", "application/octet-stream")
+                    .with_encoding("identity", vec![C0, C1]),
+            ],
         );
         commit(
             &mut state,
@@ -2802,8 +2872,10 @@ mod redirect_rules {
         create_assets(
             &mut state,
             &ctx,
-            vec![AssetBuilder::new("/404.html", "text/html")
-                .with_encoding("identity", vec![b"chunk-zero", b"chunk-one!"])],
+            vec![
+                AssetBuilder::new("/404.html", "text/html")
+                    .with_encoding("identity", vec![b"chunk-zero", b"chunk-one!"]),
+            ],
         );
         // Install the rule directly via state (bypassing the op guard) to model
         // the "target grew multi-chunk later" ordering.
@@ -2953,7 +3025,9 @@ mod redirect_rules {
 
         assert_eq!(identity_response.status_code, 200);
         assert_eq!(identity_response.body.as_ref(), INDEX_BODY);
-        assert!(certificate_header.contains("expr_path=:2dn3g2lodHRwX2V4cHJqaW5kZXguaHRtbGM8JD4=:"));
+        assert!(
+            certificate_header.contains("expr_path=:2dn3g2lodHRwX2V4cHJqaW5kZXguaHRtbGM8JD4=:")
+        );
 
         let fallback_response = certified_http_request(
             &state,
@@ -3156,8 +3230,10 @@ mod redirect_rules {
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/contents.html", "text/html")
-                .with_encoding("identity", vec![FILE_BODY])],
+            vec![
+                AssetBuilder::new("/contents.html", "text/html")
+                    .with_encoding("identity", vec![FILE_BODY]),
+            ],
         );
         set_exact_rewrite_rule(&mut state, "/contents", "/contents.html");
 
@@ -3167,8 +3243,10 @@ mod redirect_rules {
         create_assets(
             &mut state,
             &system_context,
-            vec![AssetBuilder::new("/contents", "text/html")
-                .with_encoding("identity", vec![FILE_BODY_2])],
+            vec![
+                AssetBuilder::new("/contents", "text/html")
+                    .with_encoding("identity", vec![FILE_BODY_2]),
+            ],
         );
 
         let asset_wins = certified_http_request(&state, RequestBuilder::get("/contents").build());
@@ -3469,8 +3547,10 @@ mod env_cookie {
         create_assets(
             &mut state,
             &ctx,
-            vec![html_asset("/page.html", b"<html></html>")
-                .with_header("Set-Cookie", "session=xyz; Path=/")],
+            vec![
+                html_asset("/page.html", b"<html></html>")
+                    .with_header("Set-Cookie", "session=xyz; Path=/"),
+            ],
         );
         state.refresh_env(&env_with(&[("PUBLIC_X", "1")]));
 
@@ -3525,10 +3605,12 @@ mod env_cookie {
         state.capture_env_at_sync_start(&env_with(&[("PUBLIC_X", "one")]));
         let r1 = certified_http_request(&state, RequestBuilder::get("/page.html").build());
         let cookie1 = all_headers(&r1, "set-cookie")[0].to_string();
-        assert!(parse_like_client(&cookie1)
-            .1
-            .get("PUBLIC_X")
-            .is_some_and(|v| v == "one"));
+        assert!(
+            parse_like_client(&cookie1)
+                .1
+                .get("PUBLIC_X")
+                .is_some_and(|v| v == "one")
+        );
 
         // Capturing the *same* env again is a no-op: still certified, unchanged.
         state.capture_env_at_sync_start(&env_with(&[("PUBLIC_X", "one")]));
@@ -3541,10 +3623,12 @@ mod env_cookie {
         let r3 = certified_http_request(&state, RequestBuilder::get("/page.html").build());
         let cookie3 = all_headers(&r3, "set-cookie")[0].to_string();
         assert_ne!(cookie1, cookie3);
-        assert!(parse_like_client(&cookie3)
-            .1
-            .get("PUBLIC_X")
-            .is_some_and(|v| v == "two"));
+        assert!(
+            parse_like_client(&cookie3)
+                .1
+                .get("PUBLIC_X")
+                .is_some_and(|v| v == "two")
+        );
 
         let mut stale = r3.clone();
         for (h, v) in stale.headers.iter_mut() {

--- a/crates/canister-core/src/state/upgrade.rs
+++ b/crates/canister-core/src/state/upgrade.rs
@@ -18,11 +18,11 @@ impl State {
         // If protection is on but the login page asset isn't present, the asset
         // loop above didn't re-assert its redeem responses — do it explicitly so
         // the redeem endpoint survives the upgrade even in the degraded state.
-        if let Some(login_page) = self.protection_login_page() {
-            if !self.store.contains_asset(&login_page) {
-                self.certifier
-                    .reassert_login_responses(&self.store, &login_page);
-            }
+        if let Some(login_page) = self.protection_login_page()
+            && !self.store.contains_asset(&login_page)
+        {
+            self.certifier
+                .reassert_login_responses(&self.store, &login_page);
         }
     }
 

--- a/crates/canister-core/src/store/chunks.rs
+++ b/crates/canister-core/src/store/chunks.rs
@@ -276,11 +276,11 @@ impl<M: Memory> ChunkStore<M> {
     /// region, keeping the free list short and `bump` tight. Stable memory can't
     /// shrink, so the physical pages stay; they're reused by the next `alloc`.
     fn trim_bump(&mut self) {
-        if let Some(last) = self.free.last() {
-            if last.offset + last.len == self.bump {
-                self.bump = last.offset;
-                self.free.pop();
-            }
+        if let Some(last) = self.free.last()
+            && last.offset + last.len == self.bump
+        {
+            self.bump = last.offset;
+            self.free.pop();
         }
     }
 

--- a/crates/canister-core/src/store/chunks.rs
+++ b/crates/canister-core/src/store/chunks.rs
@@ -296,8 +296,8 @@ impl<M: Memory> ChunkStore<M> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ic_stable_structures::memory_manager::{MemoryId, MemoryManager};
     use ic_stable_structures::DefaultMemoryImpl;
+    use ic_stable_structures::memory_manager::{MemoryId, MemoryManager};
 
     fn store() -> ChunkStore<ic_stable_structures::memory_manager::VirtualMemory<DefaultMemoryImpl>>
     {

--- a/crates/canister/src/lib.rs
+++ b/crates/canister/src/lib.rs
@@ -1,8 +1,8 @@
 use candid::Principal;
 use canister_core::{
-    guard_can_sync, guard_is_controller, AssetDetails, ByteBuf, ExecuteOperationsArguments,
-    HttpRequest, HttpResponse, IssueTokenArgs, ProtectionStatus, RedirectRule, StartSyncResult,
-    TokenInfo, UploadChunksArguments, Version,
+    AssetDetails, ByteBuf, ExecuteOperationsArguments, HttpRequest, HttpResponse, IssueTokenArgs,
+    ProtectionStatus, RedirectRule, StartSyncResult, TokenInfo, UploadChunksArguments, Version,
+    guard_can_sync, guard_is_controller,
 };
 use ic_cdk::{post_upgrade, query, update};
 
@@ -138,7 +138,7 @@ ic_cdk::export_candid!();
 
 #[test]
 fn candid_interface_compatibility() {
-    use candid_parser::utils::{service_equal, CandidSource};
+    use candid_parser::utils::{CandidSource, service_equal};
     use std::path::PathBuf;
 
     let new_interface = __export_service();

--- a/crates/e2e/tests/env_cookie.rs
+++ b/crates/e2e/tests/env_cookie.rs
@@ -8,7 +8,7 @@
 //! response reaches the test, so a successful fetch that also carries the
 //! cookie is proof the cookie is part of the certified response.
 
-use e2e::{http_fetch, icp_cmd, setup_example, LocalNetwork};
+use e2e::{LocalNetwork, http_fetch, icp_cmd, setup_example};
 use reqwest::StatusCode;
 
 fn set_cookies(headers: &reqwest::header::HeaderMap) -> Vec<String> {

--- a/crates/e2e/tests/etag.rs
+++ b/crates/e2e/tests/etag.rs
@@ -5,7 +5,7 @@
 //! 304 — exactly the property that lets ETag work without any gateway-side
 //! support (BOUN-446 was closed "won't do" for this reason).
 
-use e2e::{http_fetch, http_fetch_with_headers, icp_cmd, setup_example, LocalNetwork};
+use e2e::{LocalNetwork, http_fetch, http_fetch_with_headers, icp_cmd, setup_example};
 use reqwest::StatusCode;
 
 fn etag_of(headers: &reqwest::header::HeaderMap) -> String {

--- a/crates/e2e/tests/headers.rs
+++ b/crates/e2e/tests/headers.rs
@@ -5,7 +5,7 @@
 //! handing it back, so a successful fetch is also proof of certification —
 //! and proof that the headers we set are the same ones the canister certified.
 
-use e2e::{http_fetch, icp_cmd, list_assets, setup_example, LocalNetwork};
+use e2e::{LocalNetwork, http_fetch, icp_cmd, list_assets, setup_example};
 use reqwest::StatusCode;
 use std::fs;
 
@@ -65,9 +65,11 @@ fn header_edit_propagates_via_set_asset_headers() {
         !headers_before.is_empty(),
         "/index.html should carry headers"
     );
-    assert!(headers_before
-        .iter()
-        .any(|(k, v)| k.eq_ignore_ascii_case("x-frame-options") && v == "DENY"));
+    assert!(
+        headers_before
+            .iter()
+            .any(|(k, v)| k.eq_ignore_ascii_case("x-frame-options") && v == "DENY")
+    );
 
     // Bump the global X-Robots-Tag without touching any asset bytes.
     fs::write(

--- a/crates/e2e/tests/headers_content_type.rs
+++ b/crates/e2e/tests/headers_content_type.rs
@@ -7,7 +7,7 @@
 //! content-type the plugin sent to the canister is the one that ended up
 //! in the certified response.
 
-use e2e::{http_fetch, icp_cmd, setup_project, LocalNetwork};
+use e2e::{LocalNetwork, http_fetch, icp_cmd, setup_project};
 use reqwest::StatusCode;
 use std::fs;
 

--- a/crates/e2e/tests/multi_dir.rs
+++ b/crates/e2e/tests/multi_dir.rs
@@ -1,6 +1,6 @@
 //! Rejecting a manifest that syncs more than one source directory.
 
-use e2e::{icp_cmd, setup_project, LocalNetwork};
+use e2e::{LocalNetwork, icp_cmd, setup_project};
 
 /// The assets sync plugin owns the URL space of its canister and only
 /// supports a single source directory. A manifest that lists multiple

--- a/crates/e2e/tests/nested.rs
+++ b/crates/e2e/tests/nested.rs
@@ -1,6 +1,6 @@
 //! Deploying from a nested source directory.
 
-use e2e::{icp_cmd, list_assets, setup_project, LocalNetwork};
+use e2e::{LocalNetwork, icp_cmd, list_assets, setup_project};
 
 /// Deploy a fixture whose `dirs` entry is a *nested* path (`src/frontend/dist`).
 /// The host preopens it under a multi-segment WASI guest name; the plugin's scan

--- a/crates/e2e/tests/protection.rs
+++ b/crates/e2e/tests/protection.rs
@@ -13,8 +13,8 @@
 //! disturbed.
 
 use e2e::{
-    frontend_canister_id, http_fetch, http_fetch_with_headers, http_post_form, icp_cmd,
-    setup_example, LocalNetwork,
+    LocalNetwork, frontend_canister_id, http_fetch, http_fetch_with_headers, http_post_form,
+    icp_cmd, setup_example,
 };
 use reqwest::StatusCode;
 

--- a/crates/e2e/tests/recipe.rs
+++ b/crates/e2e/tests/recipe.rs
@@ -10,7 +10,7 @@
 //! (`recipe_basic`), `build` (`recipe_build_step`), and `metadata`
 //! (`recipe_metadata`).
 
-use e2e::{icp_cmd, list_assets, setup_recipe_project, LocalNetwork};
+use e2e::{LocalNetwork, icp_cmd, list_assets, setup_recipe_project};
 
 /// `dir` only: deploy through the recipe and confirm the asset is served.
 #[test]

--- a/crates/e2e/tests/redirects.rs
+++ b/crates/e2e/tests/redirects.rs
@@ -4,7 +4,7 @@
 //! HTTP gateway. The gateway validates the response's `IC-Certificate` before
 //! handing it back, so a successful fetch is also proof of certification.
 
-use e2e::{http_fetch, http_fetch_subdomain, icp_cmd, setup_example, LocalNetwork};
+use e2e::{LocalNetwork, http_fetch, http_fetch_subdomain, icp_cmd, setup_example};
 use reqwest::StatusCode;
 
 /// Deploy the `redirects` example and exercise every response kind:

--- a/crates/e2e/tests/streaming.rs
+++ b/crates/e2e/tests/streaming.rs
@@ -1,4 +1,4 @@
-use e2e::{http_fetch_with_headers, icp_cmd, setup_example, LocalNetwork};
+use e2e::{LocalNetwork, http_fetch_with_headers, icp_cmd, setup_example};
 use reqwest::StatusCode;
 use std::fs;
 

--- a/crates/e2e/tests/sync.rs
+++ b/crates/e2e/tests/sync.rs
@@ -1,5 +1,5 @@
 use candid::Principal;
-use e2e::{icp_cmd, list_assets, setup_example, AssetDetails, Encoding, LocalNetwork};
+use e2e::{AssetDetails, Encoding, LocalNetwork, icp_cmd, list_assets, setup_example};
 use std::fs;
 
 /// Deploy the `static-site` example to a local replica and verify that

--- a/crates/e2e/tests/upgrade.rs
+++ b/crates/e2e/tests/upgrade.rs
@@ -6,7 +6,7 @@
 //! certified-response tree. This test proves an in-place upgrade preserves the
 //! assets and that they still serve with a valid certificate afterward.
 
-use e2e::{http_fetch, icp_cmd, list_assets, setup_example, AssetDetails, LocalNetwork};
+use e2e::{AssetDetails, LocalNetwork, http_fetch, icp_cmd, list_assets, setup_example};
 use reqwest::StatusCode;
 
 fn sorted_assets(project: &std::path::Path) -> Vec<AssetDetails> {

--- a/crates/recipe-gen/src/lib.rs
+++ b/crates/recipe-gen/src/lib.rs
@@ -267,7 +267,9 @@ mod tests {
         let r = parse(&out);
         assert_eq!(
             r.build.steps[0].get("url").and_then(Value::as_str),
-            Some("https://github.com/dfinity/certified-assets/releases/download/v1.2.3/canister-release.wasm.gz")
+            Some(
+                "https://github.com/dfinity/certified-assets/releases/download/v1.2.3/canister-release.wasm.gz"
+            )
         );
         assert_eq!(
             r.build.steps[0].get("sha256").and_then(Value::as_str),
@@ -276,7 +278,9 @@ mod tests {
         let sync = r.sync.unwrap();
         assert_eq!(
             sync.steps[0].get("url").and_then(Value::as_str),
-            Some("https://github.com/dfinity/certified-assets/releases/download/v1.2.3/plugin-release.wasm")
+            Some(
+                "https://github.com/dfinity/certified-assets/releases/download/v1.2.3/plugin-release.wasm"
+            )
         );
         assert_eq!(
             sync.steps[0].get("sha256").and_then(Value::as_str),

--- a/crates/recipe-gen/src/main.rs
+++ b/crates/recipe-gen/src/main.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::process::exit;
 
-use recipe_gen::{read_sha256_file, render_recipe, WasmSource};
+use recipe_gen::{WasmSource, read_sha256_file, render_recipe};
 
 const USAGE: &str = "\
 usage:

--- a/crates/sync-core/src/canister.rs
+++ b/crates/sync-core/src/canister.rs
@@ -333,9 +333,11 @@ mod tests {
         ]))
         .unwrap();
         assert_eq!(result.len(), 200);
-        assert!(result
-            .iter()
-            .enumerate()
-            .all(|(i, r)| r.to == format!("/to-{i}")));
+        assert!(
+            result
+                .iter()
+                .enumerate()
+                .all(|(i, r)| r.to == format!("/to-{i}"))
+        );
     }
 }

--- a/crates/sync-core/src/canister.rs
+++ b/crates/sync-core/src/canister.rs
@@ -66,10 +66,10 @@ pub fn list_all_assets(c: &impl CanisterCall) -> Result<HashMap<String, AssetDet
         for d in entries {
             all.insert(d.key.clone(), d);
         }
-        if let Some(prev) = prev_page_size {
-            if n < prev {
-                break;
-            }
+        if let Some(prev) = prev_page_size
+            && n < prev
+        {
+            break;
         }
         prev_page_size = Some(n);
     }
@@ -140,10 +140,10 @@ pub fn list_all_redirect_rules(c: &impl CanisterCall) -> Result<Vec<RedirectRule
         }
         start_index += n as u64;
         all.extend(page);
-        if let Some(prev) = prev_page_size {
-            if n < prev {
-                break;
-            }
+        if let Some(prev) = prev_page_size
+            && n < prev
+        {
+            break;
         }
         prev_page_size = Some(n);
     }

--- a/crates/sync-core/src/sync.rs
+++ b/crates/sync-core/src/sync.rs
@@ -9,10 +9,10 @@ use serde_bytes::ByteBuf;
 use std::collections::HashMap;
 
 use crate::canister::{
-    authorize_via_proxy, can_sync, execute_operations, list_all_assets, list_all_redirect_rules,
-    start_sync, upload_chunks, version, CanisterCall,
+    CanisterCall, authorize_via_proxy, can_sync, execute_operations, list_all_assets,
+    list_all_redirect_rules, start_sync, upload_chunks, version,
 };
-use asset_prep::{prepare_project, PreparedAsset, PreparedChunk, PreparedProject, MAX_CHUNK_SIZE};
+use asset_prep::{MAX_CHUNK_SIZE, PreparedAsset, PreparedChunk, PreparedProject, prepare_project};
 use wire_types::{
     AssetDetails, CreateAssetArguments, DeleteAssetArguments, Encoding, ExecuteOperationsArguments,
     Operation, RedirectRule, RulePattern, SetAssetContentArguments, SetAssetHeadersArguments,
@@ -186,7 +186,7 @@ pub fn sync<C: CanisterCall>(
             return Err(format!(
                 "assets sync plugin: expected exactly one input directory, got {}",
                 dirs.len()
-            ))
+            ));
         }
     };
 

--- a/crates/sync-core/tests/bench_sync.rs
+++ b/crates/sync-core/tests/bench_sync.rs
@@ -17,7 +17,7 @@ use candid::{CandidType, Decode, Encode, Principal};
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::path::Path;
-use sync_core::{sync, CallType, CanisterCall};
+use sync_core::{CallType, CanisterCall, sync};
 use wire_types::{AssetDetails, RedirectRule};
 
 // Wire-compatible mirrors of the response types defined privately in

--- a/crates/sync-plugin/src/lib.rs
+++ b/crates/sync-plugin/src/lib.rs
@@ -11,7 +11,7 @@ use crate::icp::sync_plugin::types as ty;
 
 use candid::{CandidType, Decode, Encode};
 use serde::de::DeserializeOwned;
-use sync_core::{sync, CallType, CanisterCall};
+use sync_core::{CallType, CanisterCall, sync};
 
 struct WasiCall;
 

--- a/crates/wire-types/src/lib.rs
+++ b/crates/wire-types/src/lib.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
 
 mod version;
-pub use version::{Version, VERSION};
+pub use version::{VERSION, Version};
 
 /// Identifies an in-progress sync. Sequential and monotonic across the
 /// canister's whole lifetime, so a session id is never reused — calls carrying


### PR DESCRIPTION
- Bumped the edition to 2024
  - Applied fmt and clippy changes
- Updated dependencies to their latest versions