### PR TITLE
feat(recipe): publish as @dfinity/static-site, add presync config field

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,11 @@ jobs:
       - name: Install ic-wasm
         run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/dfinity/ic-wasm/releases/download/0.9.11/ic-wasm-installer.sh | sh
 
-      - name: Build release artifacts
-        run: make release
+      - name: Build release artifacts and recipe
+        # `recipe-release` depends on `release`, so one invocation builds every
+        # wasm/candid/checksum artifact *and* generates dist/recipe.hbs (pinning
+        # this tag's release URLs + the shas just produced).
+        run: make recipe-release
 
       - name: Publish GitHub release
         env:
@@ -67,12 +70,14 @@ jobs:
           # The release title is just the version tag (e.g. v0.1.0).
           title="$GITHUB_REF_NAME"
 
-          # The full set `make release` produced: each artifact plus its
-          # sibling .sha256 (wasm + candid + checksums).
+          # The full set `make recipe-release` produced: each release artifact
+          # plus its sibling .sha256 (wasm + candid + checksums), and the recipe
+          # itself (`recipe.hbs`, no checksum — it pins the wasm shas internally).
           assets=(
             dist/canister-release.wasm.gz dist/canister-release.wasm.gz.sha256
             dist/plugin-release.wasm      dist/plugin-release.wasm.sha256
             dist/certified-assets.did     dist/certified-assets.did.sha256
+            dist/recipe.hbs
           )
 
           # Releases are allowed from any branch. One whose commit is not on main

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ which `icp-cli` expands into a canister build + sync config:
 canisters:
   - name: frontend
     recipe:
-      type: "@dfinity/certified-assets@v1.0.0"
+      type: "@dfinity/static-site@v1.0.0"
       configuration:
         dir: dist           # required: the single asset directory
         build: [npm run build]   # optional: commands run before sync
@@ -118,8 +118,8 @@ scripts/publish-recipe.sh v<version> --push   # also pushes and opens the PR
 
 The script downloads the release's `.sha256` assets to pin the exact published
 wasm, branches off a fresh `origin/main` in your icp-cli-recipes clone, and
-writes `recipes/certified-assets/{recipe.hbs,README.md}`. After the PR merges,
-tag `certified-assets-v<version>` in icp-cli-recipes to cut the recipe release.
+writes `recipes/static-site/{recipe.hbs,README.md}`. After the PR merges,
+tag `static-site-v<version>` in icp-cli-recipes to cut the recipe release.
 
 ## Candid interface
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,11 @@ in two variants that differ only in how the wasm is pinned:
 
 ```sh
 make recipe-local        # pins wasm by local path -> dist/recipe.local.hbs (for manual testing)
-make recipe-release      # pins wasm by release URL + sha256 -> dist/recipe.hbs (for publishing)
+make recipe-release      # pins wasm by release URL + sha256 -> dist/recipe.hbs (what CI attaches to the release)
 ```
+
+The release CI runs `make recipe-release` and attaches the resulting `recipe.hbs`
+to the GitHub release, so the published recipe has a canonical, verifiable origin.
 
 The e2e tests exercise the local variant through the real `icp` CLI
 ([`crates/e2e/tests/recipe.rs`](crates/e2e/tests/recipe.rs)), and `recipe-gen`'s
@@ -112,14 +115,16 @@ unit tests assert every config field renders to valid icp-cli YAML.
 To publish a new recipe version after a `v<version>` release exists:
 
 ```sh
-scripts/publish-recipe.sh v<version>          # generates + commits on a branch in ../icp-cli-recipes; prints the PR command
+scripts/publish-recipe.sh v<version>          # downloads the release recipe + commits on a branch in ../icp-cli-recipes; prints the PR command
 scripts/publish-recipe.sh v<version> --push   # also pushes and opens the PR
 ```
 
-The script downloads the release's `.sha256` assets to pin the exact published
-wasm, branches off a fresh `origin/main` in your icp-cli-recipes clone, and
-writes `recipes/static-site/{recipe.hbs,README.md}`. After the PR merges,
-tag `static-site-v<version>` in icp-cli-recipes to cut the recipe release.
+The script downloads the release's `recipe.hbs` asset (the exact file the release
+CI generated), branches off a fresh `origin/main` in your icp-cli-recipes clone,
+and writes `recipes/static-site/{recipe.hbs,README.md}` — committing the release
+asset verbatim rather than regenerating it. The PR links back to that asset so
+reviewers can verify the two are identical. After the PR merges, tag
+`static-site-v<version>` in icp-cli-recipes to cut the recipe release.
 
 ## Candid interface
 

--- a/crates/e2e/tests/fixture/recipe-presync/dist/index.html
+++ b/crates/e2e/tests/fixture/recipe-presync/dist/index.html
@@ -1,0 +1,1 @@
+<html><body><h1>recipe presync</h1></body></html>

--- a/crates/e2e/tests/fixture/recipe-presync/icp.yaml
+++ b/crates/e2e/tests/fixture/recipe-presync/icp.yaml
@@ -1,0 +1,19 @@
+networks:
+  - name: local
+    mode: managed
+    gateway:
+      port: 0
+
+canisters:
+  - name: frontend
+    recipe:
+      type: "file://recipe.hbs"
+      configuration:
+        dir: dist
+        presync:
+          # Pre-sync steps run at sync time, after the canister exists, so the
+          # deployed canister IDs are in the environment. Capture them into
+          # served files so the test can prove they were really readable — both
+          # the bare `ICP_CLI_CID` and the per-canister `ICP_CLI_CID_<NAME>` form.
+          - sh -c 'printf %s "$ICP_CLI_CID" > dist/cid.txt'
+          - sh -c 'printf %s "$ICP_CLI_CID_FRONTEND" > dist/cid-frontend.txt'

--- a/crates/e2e/tests/recipe.rs
+++ b/crates/e2e/tests/recipe.rs
@@ -1,4 +1,4 @@
-//! End-to-end tests for the `certified-assets` recipe.
+//! End-to-end tests for the `static-site` recipe.
 //!
 //! Each test renders the *local* recipe variant (via `recipe-gen`, pinning the
 //! freshly built wasm by path), drops it next to a fixture `icp.yaml` that

--- a/crates/e2e/tests/recipe.rs
+++ b/crates/e2e/tests/recipe.rs
@@ -7,10 +7,12 @@
 //!
 //! Together with the recipe-gen unit tests (which assert every configuration
 //! renders to valid icp-cli YAML), this covers each config field: `dir`
-//! (`recipe_basic`), `build` (`recipe_build_step`), and `metadata`
-//! (`recipe_metadata`).
+//! (`recipe_basic`), `build` (`recipe_build_step`), `presync`
+//! (`recipe_presync_env`), and `metadata` (`recipe_metadata`).
 
-use e2e::{LocalNetwork, icp_cmd, list_assets, setup_recipe_project};
+use e2e::{
+    LocalNetwork, frontend_canister_id, http_fetch, icp_cmd, list_assets, setup_recipe_project,
+};
 
 /// `dir` only: deploy through the recipe and confirm the asset is served.
 #[test]
@@ -28,7 +30,7 @@ fn recipe_basic() {
     );
 }
 
-/// `build`: a pre-sync command produces an extra asset, which must then sync.
+/// `build`: a build command produces an extra asset, which must then sync.
 #[test]
 fn recipe_build_step() {
     let tmp = setup_recipe_project("recipe-build");
@@ -62,4 +64,35 @@ fn recipe_metadata() {
         assets.iter().any(|a| a.key == "/index.html"),
         "expected /index.html after metadata injection; got: {assets:#?}",
     );
+}
+
+/// `presync`: commands run at sync time — after the canister exists — with the
+/// deployed canister IDs in the environment. This proves those vars are really
+/// readable (not just that a step runs): pre-sync steps write `$ICP_CLI_CID`
+/// and `$ICP_CLI_CID_FRONTEND` into the asset dir, and the served files must
+/// each equal the frontend canister's own principal. That the files are served
+/// at all also proves the pre-sync step runs *before* the plugin uploads.
+#[test]
+fn recipe_presync_env() {
+    let tmp = setup_recipe_project("recipe-presync");
+    let project = tmp.path();
+    let _network = LocalNetwork::start(project);
+
+    icp_cmd(project).arg("deploy").assert().success();
+
+    let cid = frontend_canister_id(project);
+
+    for path in ["/cid.txt", "/cid-frontend.txt"] {
+        let resp = http_fetch(project, path);
+        assert!(
+            resp.status().is_success(),
+            "{path} should be served (written by a pre-sync step); got {}",
+            resp.status(),
+        );
+        let body = resp.text().expect("asset body should be utf-8");
+        assert_eq!(
+            body, cid,
+            "{path} must hold the canister id read from the pre-sync environment",
+        );
+    }
 }

--- a/crates/recipe-gen/assets/README.md
+++ b/crates/recipe-gen/assets/README.md
@@ -1,4 +1,4 @@
-# Certified Assets Recipe
+# Static Site Recipe
 
 Deploy a static frontend to the [`dfinity/certified-assets`](https://github.com/dfinity/certified-assets) canister, with response certification and asset synchronization handled for you.
 
@@ -12,12 +12,12 @@ Reference this recipe in an `icp.yaml` (or `canister.yaml`) file:
 canisters:
   - name: frontend
     recipe:
-      type: "@dfinity/certified-assets@<version>"
+      type: "@dfinity/static-site@<version>"
       configuration:
         dir: dist
 ```
 
-> Replace `<version>` with a release version (e.g. `v1.0.0`). See [available versions](https://github.com/dfinity/icp-cli-recipes/releases?q=certified-assets&expanded=true).
+> Replace `<version>` with a release version (e.g. `v1.0.0`). See [available versions](https://github.com/dfinity/icp-cli-recipes/releases?q=static-site&expanded=true).
 
 ## Configuration Parameters
 
@@ -45,7 +45,7 @@ canisters:
 canisters:
   - name: website
     recipe:
-      type: "@dfinity/certified-assets@<version>"
+      type: "@dfinity/static-site@<version>"
       configuration:
         dir: build
 ```
@@ -56,7 +56,7 @@ canisters:
 canisters:
   - name: spa-frontend
     recipe:
-      type: "@dfinity/certified-assets@<version>"
+      type: "@dfinity/static-site@<version>"
       configuration:
         build:
           - npm ci
@@ -101,4 +101,4 @@ The sync plugin diffs your local directory against the canister and uploads only
 
 ## Release History
 
-See the [release history](https://github.com/dfinity/icp-cli-recipes/releases?q=certified-assets&expanded=true) for changelogs and version updates.
+See the [release history](https://github.com/dfinity/icp-cli-recipes/releases?q=static-site&expanded=true) for changelogs and version updates.

--- a/crates/recipe-gen/assets/README.md
+++ b/crates/recipe-gen/assets/README.md
@@ -25,6 +25,7 @@ canisters:
 |-----------|------|----------|-------------|---------|
 | dir | string | Yes | The single directory of built assets to synchronize to the canister | - |
 | build | array | No | Shell commands run before sync to produce the asset directory (e.g. `npm run build`) | [] |
+| presync | array | No | Shell commands run at sync time (after the canister exists), with the deployed canister IDs in the environment — see [Pre-sync environment](#pre-sync-environment) | [] |
 | metadata | array | No | Name/value pairs injected into the canister wasm via `ic-wasm` | [] |
 
 > The sync plugin owns the canister's full URL space and accepts **exactly one** asset directory, so `dir` is a single string rather than a list.
@@ -67,14 +68,51 @@ canisters:
             value: "react"
 ```
 
+### With a pre-sync build that needs canister IDs
+
+Build in `presync` rather than `build` when the frontend must embed a canister
+ID — those IDs only exist once the canister is created, which is *after* `build`
+runs:
+
+```yaml
+canisters:
+  - name: frontend
+    recipe:
+      type: "@dfinity/static-site@<version>"
+      configuration:
+        dir: dist
+        presync:
+          - npm ci
+          # `$ICP_CLI_CID_BACKEND` is the `backend` canister's principal.
+          - VITE_CANISTER_ID_BACKEND=$ICP_CLI_CID_BACKEND npm run build
+```
+
 ## Build Process
 
 When this recipe runs:
 
-1. (If `build` is set) runs your build commands to produce the asset directory.
+1. (If `build` is set) runs your build commands to produce the asset directory. This runs *before* the canister exists, so no canister IDs are available yet.
 2. Downloads the pinned certified-assets canister wasm (verified against its `sha256`).
 3. (If `metadata` is set) injects each name/value pair into the wasm with `ic-wasm`.
-4. Installs the canister, then runs the pinned sync plugin to upload and certify the assets in `dir`.
+4. Installs the canister.
+5. (If `presync` is set) runs your pre-sync commands — the canister IDs now exist and are exported as environment variables (see [Pre-sync environment](#pre-sync-environment)).
+6. Runs the pinned sync plugin to upload and certify the assets in `dir`.
+
+## Pre-sync environment
+
+`presync` commands run via `sh -c` in your project directory, after the canister
+is created but before its assets upload. Unlike `build` (which runs earlier, when
+only `ICP_WASM_OUTPUT_PATH` is available), `presync` sees the deployed canister IDs:
+
+| Variable | Value |
+|----------|-------|
+| `ICP_CLI_CID` | This (frontend) canister's principal. |
+| `ICP_CLI_CID_<NAME>` | Each project canister's principal, keyed by its upper-cased name with non-alphanumeric characters replaced by `_` (e.g. `backend` → `ICP_CLI_CID_BACKEND`). |
+| `ICP_CLI_NETWORK` | The target network name. |
+| `ICP_CLI_ENVIRONMENT` | The target environment name. |
+
+This is what lets a client-side app (Vite, Next static export, etc.) embed the
+canister IDs it will call, at build time.
 
 ## Asset Synchronization
 

--- a/crates/recipe-gen/src/lib.rs
+++ b/crates/recipe-gen/src/lib.rs
@@ -236,6 +236,30 @@ mod tests {
     }
 
     #[test]
+    fn local_with_presync() {
+        let cfg = serde_yaml::from_str("dir: dist\npresync:\n  - echo $ICP_CLI_CID").unwrap();
+        let out = render_with_config(&local(), cfg).unwrap();
+        let r = parse(&out);
+        // Build section is untouched — presync belongs to sync, not build.
+        assert_eq!(r.build.steps.len(), 1);
+        assert_eq!(step_type(&r.build.steps[0]), "pre-built");
+        // Sync section: the presync script step runs *before* the plugin step.
+        let sync = r.sync.expect("sync section present");
+        assert_eq!(sync.steps.len(), 2);
+        assert_eq!(step_type(&sync.steps[0]), "script");
+        assert_eq!(step_type(&sync.steps[1]), "plugin");
+        let cmds = sync.steps[0]
+            .get("commands")
+            .and_then(Value::as_sequence)
+            .unwrap();
+        assert_eq!(cmds.len(), 1);
+        assert!(
+            cmds[0].as_str().unwrap().contains("ICP_CLI_CID"),
+            "presync command must survive verbatim, got: {cmds:?}"
+        );
+    }
+
+    #[test]
     fn local_with_metadata() {
         let cfg =
             serde_yaml::from_str("dir: dist\nmetadata:\n  - name: app:framework\n    value: react")

--- a/crates/recipe-gen/src/lib.rs
+++ b/crates/recipe-gen/src/lib.rs
@@ -1,4 +1,4 @@
-//! Generator for the `certified-assets` icp-cli recipe.
+//! Generator for the `static-site` icp-cli recipe.
 //!
 //! A recipe is a Handlebars template (`recipe.hbs`) hosted in the
 //! `dfinity/icp-cli-recipes` registry. icp-cli downloads it, renders it against

--- a/crates/recipe-gen/src/main.rs
+++ b/crates/recipe-gen/src/main.rs
@@ -1,4 +1,4 @@
-//! `recipe-gen` — emit the `certified-assets` recipe (`recipe.hbs`) pinning the
+//! `recipe-gen` — emit the `static-site` recipe (`recipe.hbs`) pinning the
 //! canister and sync-plugin wasm either by local path or by release URL + sha256.
 //!
 //! ```text

--- a/crates/recipe-gen/src/recipe.hbs.in
+++ b/crates/recipe-gen/src/recipe.hbs.in
@@ -1,6 +1,7 @@
 {{! Deploy static assets to the dfinity/certified-assets canister. }}
 {{! `dir: string` Required. The single directory of built assets to synchronize. }}
 {{! `build: [string]` Optional. Commands run before sync to produce the asset directory. }}
+{{! `presync: [string]` Optional. Commands run at sync time (after the canister exists), before assets upload, with the deployed canister IDs in the environment: ICP_CLI_CID, ICP_CLI_CID_<NAME>, ICP_CLI_NETWORK, ICP_CLI_ENVIRONMENT. }}
 {{! `metadata: [{name, value}]` Optional. Pairs injected into the canister wasm via ic-wasm. }}
 
 build:
@@ -29,6 +30,13 @@ build:
 
 sync:
   steps:
+    {{#if presync}}
+    - type: script
+      commands:
+        {{#each presync}}
+        - {{ this }}
+        {{/each}}
+    {{/if}}
     - type: plugin
 @@PLUGIN_SOURCE@@
       dirs:

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -47,12 +47,13 @@ That's it — your site is live and certified.
 
 ## Configuration
 
-The recipe takes three configuration fields:
+The recipe takes four configuration fields:
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `dir` | string | **Yes** | The single directory of built files to serve. The canister owns its whole URL space, so this is one directory, not a list. |
-| `build` | array | No | Shell commands run *before* sync to produce `dir` (e.g. `npm run build`). |
+| `build` | array | No | Shell commands run *before* the canister exists to produce `dir` (e.g. `npm run build`). No canister IDs are available yet. |
+| `presync` | array | No | Shell commands run *at sync time*, after the canister exists, with the deployed canister IDs exported as env vars (`ICP_CLI_CID`, `ICP_CLI_CID_<NAME>`, `ICP_CLI_NETWORK`, `ICP_CLI_ENVIRONMENT`). Use it to build a frontend that must bake in a canister ID. |
 | `metadata` | array | No | `name`/`value` pairs baked into the canister wasm via `ic-wasm`. |
 
 A fuller example with a build step and metadata:
@@ -74,6 +75,31 @@ canisters:
 
 > `metadata` is the only field that needs `ic-wasm`. It ships with `icp-cli`, so if
 > you installed the CLI you already have it.
+
+### Building against canister IDs (`presync` vs `build`)
+
+`build` runs before the canister is created, so it can't know any canister IDs.
+When a client-side app needs to embed the ID of a canister it will call, build it
+in `presync` instead — that runs at sync time, once the IDs exist, and exports
+them to your commands:
+
+```yaml
+canisters:
+  - name: frontend
+    recipe:
+      type: "@dfinity/static-site@<version>"
+      configuration:
+        dir: dist
+        presync:
+          - npm ci
+          # $ICP_CLI_CID_BACKEND is the `backend` canister's principal.
+          - VITE_CANISTER_ID_BACKEND=$ICP_CLI_CID_BACKEND npm run build
+```
+
+The variables available to `presync`: `ICP_CLI_CID` (this canister's principal),
+`ICP_CLI_CID_<NAME>` (each project canister's principal — the name upper-cased,
+non-alphanumerics as `_`, e.g. `backend` → `ICP_CLI_CID_BACKEND`), `ICP_CLI_NETWORK`,
+and `ICP_CLI_ENVIRONMENT`.
 
 ## What you get automatically
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -23,13 +23,13 @@ sites need nothing more than this page.
 canisters:
   - name: frontend
     recipe:
-      type: "@dfinity/certified-assets@<version>"
+      type: "@dfinity/static-site@<version>"
       configuration:
         dir: dist          # the directory of files to serve
 ```
 
 Replace `<version>` with a released version (e.g. `v1.0.0`); see the
-[available versions](https://github.com/dfinity/icp-cli-recipes/releases?q=certified-assets&expanded=true).
+[available versions](https://github.com/dfinity/icp-cli-recipes/releases?q=static-site&expanded=true).
 Pick the version here — because the recipe pins a matched canister + plugin pair,
 there is no separate canister version to choose.
 
@@ -61,7 +61,7 @@ A fuller example with a build step and metadata:
 canisters:
   - name: frontend
     recipe:
-      type: "@dfinity/certified-assets@<version>"
+      type: "@dfinity/static-site@<version>"
       configuration:
         build:
           - npm ci

--- a/scripts/publish-recipe.sh
+++ b/scripts/publish-recipe.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Publish the `certified-assets` recipe to the dfinity/icp-cli-recipes registry.
+# Publish the `static-site` recipe to the dfinity/icp-cli-recipes registry.
 #
 # Generates the *release* recipe (pinning this repo's canister/plugin wasm by
 # release URL + the exact published sha256), drops it into a sibling clone of
@@ -27,12 +27,12 @@
 #                      preparing the branch and print the commands)
 #
 # After the PR merges, publish the recipe release by pushing the registry tag:
-#   git -C <recipes-repo> tag certified-assets-<version> && git push origin certified-assets-<version>
+#   git -C <recipes-repo> tag static-site-<version> && git push origin static-site-<version>
 # which triggers icp-cli-recipes' release-recipe.yml.
 
 set -euo pipefail
 
-RECIPE_NAME="certified-assets"
+RECIPE_NAME="static-site"
 THIS_REPO="dfinity/certified-assets"
 
 die() {

--- a/scripts/publish-recipe.sh
+++ b/scripts/publish-recipe.sh
@@ -2,11 +2,14 @@
 #
 # Publish the `static-site` recipe to the dfinity/icp-cli-recipes registry.
 #
-# Generates the *release* recipe (pinning this repo's canister/plugin wasm by
-# release URL + the exact published sha256), drops it into a sibling clone of
-# icp-cli-recipes on a fresh branch, commits, and — by default — stops so you can
-# review the diff before opening the PR. Pass --push to push the branch and open
-# the PR.
+# Downloads the `recipe.hbs` asset attached to this repo's GitHub release — the
+# exact file the release CI generated (pinning the canister/plugin wasm by
+# release URL + sha256) — drops it into a sibling clone of icp-cli-recipes on a
+# fresh branch, commits, and — by default — stops so you can review the diff
+# before opening the PR. Pass --push to push the branch and open the PR.
+#
+# The committed recipe is the release asset verbatim (not regenerated), and the
+# PR links back to that asset so a reviewer can confirm the two are identical.
 #
 # Resumable & idempotent: each phase (prepare the branch / push + open PR) is
 # safe to re-run. A review run (no --push) prepares the branch; re-running with
@@ -21,7 +24,7 @@
 #   scripts/publish-recipe.sh <version-tag> [--recipes-repo <path>] [--push]
 #
 #   <version-tag>      e.g. v1.0.0 — must match a published GitHub release of
-#                      this repo (the .sha256 release assets are downloaded).
+#                      this repo (its recipe.hbs asset is downloaded).
 #   --recipes-repo P   path to your icp-cli-recipes clone (default: ../icp-cli-recipes)
 #   --push             push the branch and open the PR (default: stop after
 #                      preparing the branch and print the commands)
@@ -110,15 +113,10 @@ else
   TMP="$(mktemp -d)"
   trap 'rm -rf "$TMP"' EXIT
 
-  echo "Downloading release checksums for $VERSION from $THIS_REPO ..."
-  gh release download "$VERSION" -R "$THIS_REPO" -p '*.sha256' --dir "$TMP" \
-    || die "could not download .sha256 assets for $VERSION — is the release published?"
-
-  echo "Generating $RECIPE_NAME recipe.hbs ..."
-  cargo run --quiet --manifest-path "$REPO_ROOT/Cargo.toml" -p recipe-gen -- release \
-    --version "$VERSION" \
-    --shas-from "$TMP" \
-    -o "$TMP/recipe.hbs"
+  echo "Downloading recipe.hbs for $VERSION from $THIS_REPO ..."
+  gh release download "$VERSION" -R "$THIS_REPO" -p 'recipe.hbs' --dir "$TMP" \
+    || die "could not download recipe.hbs for $VERSION — is the release published? (the release CI attaches it via 'make recipe-release')"
+  [ -s "$TMP/recipe.hbs" ] || die "downloaded recipe.hbs is empty"
 
   echo "Fetching origin/main in $RECIPES_REPO ..."
   git -C "$RECIPES_REPO" fetch --quiet origin main
@@ -141,7 +139,11 @@ git -C "$RECIPES_REPO" show --stat --oneline "$BRANCH" | sed 's/^/  /'
 # --- push + open PR (idempotent) ---------------------------------------------
 
 PR_TITLE="$COMMIT_MSG"
+RECIPE_ASSET_URL="https://github.com/$THIS_REPO/releases/download/$VERSION/recipe.hbs"
 PR_BODY="Publishes the \`$RECIPE_NAME\` recipe at $VERSION, pinning the canister and sync-plugin wasm from $THIS_REPO's $VERSION release.
+
+The committed \`recipe.hbs\` is the asset attached to that release, verbatim — verify it matches:
+$RECIPE_ASSET_URL
 
 After merge, tag \`$RECIPE_NAME-$VERSION\` in this repo to cut the recipe release."
 


### PR DESCRIPTION
Prepares this repo's recipe for public release in `icp-cli-recipes` and adds a new configuration field.

## Rename to `@dfinity/static-site`

The published recipe is renamed from `@dfinity/certified-assets` to `@dfinity/static-site` across the publish script, recipe README, user docs, and doc comments. The recipe name only appears in a project's `canister.yaml`, so it should name the recipe's *input* (a built static site) — matching the name-by-input pattern of the sibling `@dfinity/rust` / `@dfinity/motoko` recipes — not the canister's role (already `name: frontend`). Repo/canister references (the `dfinity/certified-assets` repo, the `.did`, "the certified-assets canister wasm") are deliberately unchanged.

## New `presync` config field

`presync` is an array of shell commands, analogous to `build`, but expanded into the **sync** section as a script step *before* the sync-plugin step. Sync steps run after the canister exists, so `icp-cli` exposes the deployed canister IDs to them: `ICP_CLI_CID`, `ICP_CLI_CID_<NAME>` (per project canister), `ICP_CLI_NETWORK`, and `ICP_CLI_ENVIRONMENT`. This lets a frontend build bake in the IDs it will call — something `build` cannot do (it runs before creation, with only `ICP_WASM_OUTPUT_PATH`).

## Ship + verify the recipe via the GitHub release

- The release CI now runs `make recipe-release` and attaches the generated `recipe.hbs` (URL + sha256 pinned — the public form, not the local file-path variant) to the GitHub release.
- `publish-recipe.sh` downloads that asset and commits it to the registry PR **verbatim** (instead of regenerating locally), and the PR links back to the release asset so reviewers can verify the two are identical. This drops the `cargo`/`recipe-gen` dependency from the publish path and removes any template-drift risk.

## Tests

- `recipe-gen` unit tests: 6/6, incl. `local_with_presync` (asserts `presync` renders as a sync script step before the plugin step).
- e2e recipe tests: 4/4, incl. `recipe_presync_env` — a live deploy whose pre-sync step reads `$ICP_CLI_CID` / `$ICP_CLI_CID_FRONTEND` into served assets, which are then fetched through the gateway (certified) and asserted to equal the frontend canister's own principal, proving the env vars are genuinely readable.

## Follow-ups (not in this PR)

- After a `v<version>` release cuts, run `scripts/publish-recipe.sh v<version> --push` to open the `@dfinity/static-site` PR against `icp-cli-recipes`, and close the stale `@dfinity/certified-assets` [PR #30](https://github.com/dfinity/icp-cli-recipes/pull/30).
- Switch the `icp new` templates (icp-cli repo) to the new recipe and deprecate `@dfinity/asset-canister`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
