### PR TITLE
fix(cert): certify the 304 at 200-rewrite alias locations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "asset-prep"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "brotli",
  "flate2",
@@ -557,7 +557,7 @@ dependencies = [
 
 [[package]]
 name = "canister"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "candid",
  "candid_parser",
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "canister-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "asset-prep",
@@ -1166,7 +1166,7 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "e2e"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "assert_cmd",
  "candid",
@@ -3526,7 +3526,7 @@ checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
 name = "recipe-gen"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "handlebars",
  "serde",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "state-hash"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "sha2 0.11.0",
  "wire-types",
@@ -4151,7 +4151,7 @@ dependencies = [
 
 [[package]]
 name = "state-hash-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "asset-prep",
  "hex",
@@ -4251,7 +4251,7 @@ dependencies = [
 
 [[package]]
 name = "sync-agent"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "candid",
@@ -4263,7 +4263,7 @@ dependencies = [
 
 [[package]]
 name = "sync-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "asset-prep",
  "candid",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "sync-plugin"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "candid",
  "serde",
@@ -5064,7 +5064,7 @@ dependencies = [
 
 [[package]]
 name = "wire-types"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "candid",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 # Single semver for every crate in the workspace; also the release identity the
 # canister and sync plugin share (see crates/wire-types/src/version.rs). Bump it
 # per the breaking/non-breaking rule documented there, then `make tag`.
-version = "0.3.0"
+version = "0.3.1"
 authors = ["DFINITY Stiftung <sdk@dfinity.org>"]
 edition = "2024"
 repository = "https://github.com/dfinity/certified-assets"

--- a/crates/canister-core/src/cert/certifier.rs
+++ b/crates/canister-core/src/cert/certifier.rs
@@ -165,7 +165,8 @@ impl Certifier {
     ) -> HashTreePath {
         let cert_expr = resp.cert_expr();
         let resp_hash = resp.response_hash();
-        let tp = crate::redirect::alias_tree_path(location, cert_expr.expression_hash, resp_hash);
+        let tp =
+            crate::redirect::response_leaf_path(location, cert_expr.expression_hash, resp_hash);
         self.asset_hashes.certify_response_precomputed(&tp);
         tp
     }
@@ -293,8 +294,9 @@ impl Certifier {
             &enc.sha256,
         );
 
-        let leaf =
-            |expr_hash, resp_hash| crate::redirect::alias_tree_path(location, expr_hash, resp_hash);
+        let leaf = |expr_hash, resp_hash| {
+            crate::redirect::response_leaf_path(location, expr_hash, resp_hash)
+        };
         let mut leaves = vec![leaf(cert_expr.expression_hash, resp_hashes[&304])];
         if enc.num_chunks == 1 {
             leaves.push(leaf(cert_expr.expression_hash, resp_hashes[&200]));
@@ -531,8 +533,11 @@ impl Certifier {
             .map(|(k, v)| (k, Value::String(v)))
             .collect();
             let resp_hash = response_hash(&base_headers, status, &enc.sha256).0;
-            let tp =
-                crate::redirect::alias_tree_path(&location, cert_expr.expression_hash, resp_hash);
+            let tp = crate::redirect::response_leaf_path(
+                &location,
+                cert_expr.expression_hash,
+                resp_hash,
+            );
             self.asset_hashes.certify_response_precomputed(&tp);
             tree_paths.push(tp);
         }

--- a/crates/canister-core/src/cert/certifier.rs
+++ b/crates/canister-core/src/cert/certifier.rs
@@ -33,7 +33,7 @@ use ic_representation_independent_hash::Value;
 
 use super::primitives::{
     AssetKey, AssetPath, CertificateExpression, CertifiedResponses, HashTreePath, NestedTreeKey,
-    RequestHash, ResponseHash, response_hash,
+    response_hash,
 };
 use crate::asset::{
     AssetMeta, EncodingMeta, certificate_expression_for, headers_for,
@@ -209,60 +209,27 @@ impl Certifier {
     /// access-protection tail there runs even for a content-less asset.
     fn certify_asset_encodings(&mut self, store: &Store, key: &AssetKey, meta: &AssetMeta) {
         let effective_headers = self.effective_headers(store, meta);
-        let path = AssetPath::from(key.as_str());
+        // The asset's own `<$>` slot — the same location a 200-rewrite rule to
+        // this path would mirror (see `redirect::tree_location`).
+        let location = AssetPath::from(key.as_str()).asset_hash_path_root();
         for (&encoding, enc) in &meta.encodings {
-            let cert_expr = certificate_expression_for(&effective_headers, encoding, &enc.sha256);
-            let response_hashes = response_hashes_for(
+            self.certify_ok_leaves(
+                store,
+                &location,
                 &effective_headers,
                 &meta.content_type,
                 encoding,
-                &cert_expr,
-                &enc.sha256,
+                enc,
             );
-            // Always certify the 304 (empty body). Certify the full 200 only for
-            // single-chunk encodings — a multi-chunk asset is served as N×206 (the
-            // gateway reassembles them into a 200), so a full 200 is never served
-            // and certifying it would be dead weight in the tree.
-            let hash_304 = path.hash_tree_path(
-                &cert_expr,
-                &RequestHash::default(),
-                ResponseHash::from(&response_hashes[&304]),
-            );
-            self.asset_hashes.certify_response_precomputed(&hash_304);
-            if enc.num_chunks == 1 {
-                let hash_200 = path.hash_tree_path(
-                    &cert_expr,
-                    &RequestHash::default(),
-                    ResponseHash::from(&response_hashes[&200]),
-                );
-                self.asset_hashes.certify_response_precomputed(&hash_200);
-            } else {
-                // Multi-chunk: certify one 206 per chunk (response-only).
-                let (range_cert_expr, resp_hashes) = self.range_response_certs(
-                    store,
-                    &effective_headers,
-                    &meta.content_type,
-                    encoding,
-                    enc,
-                );
-                for resp_hash in resp_hashes {
-                    let hash_path = path.hash_tree_path(
-                        &range_cert_expr,
-                        &RequestHash::default(),
-                        ResponseHash::from(&resp_hash),
-                    );
-                    self.asset_hashes.certify_response_precomputed(&hash_path);
-                }
-            }
         }
     }
 
     /// Content-free per-chunk 206 certification data for a multi-chunk encoding:
     /// the shared range certificate expression plus one response hash per chunk,
     /// in chunk order. Derived from `chunk_certs` + `content_len`, so it never
-    /// reads chunk bytes. Both the direct-asset path (`certify_asset_encodings`)
-    /// and the alias path (`build_alias_rule_entry`) use it, each placing the
-    /// resulting leaves at its own tree location.
+    /// reads chunk bytes. Used by [`Self::certify_ok_leaves`], which places the
+    /// resulting leaves at whichever tree location its caller passes (an asset's
+    /// own slot or an alias's).
     fn range_response_certs(
         &self,
         store: &Store,
@@ -294,6 +261,56 @@ impl Certifier {
             offset += len;
         }
         (range_cert_expr, resp_hashes)
+    }
+
+    /// Certifies the OK-family response leaves for one encoding at `location`:
+    /// the 304 (empty body) always, plus either the full 200 (single-chunk) or
+    /// the N×206 range leaves (multi-chunk — the 200 is delivered as reassembled
+    /// 206s and never served whole, so certifying it would be dead weight).
+    /// Shared by the direct-asset path ([`Self::certify_asset_encodings`]) and the
+    /// 200-rewrite alias path ([`Self::build_alias_rule_entry`]) so the two always
+    /// certify the *identical* leaf set — only `location` differs (an asset's own
+    /// `<$>` vs the alias's `<$>`/`<*>`). Returns every leaf it certified.
+    ///
+    /// The 304 uses the non-range expression at every location: a conditional
+    /// request short-circuits the 206 path in `build_ok_http_response`, so a
+    /// matching `If-None-Match` yields a 304 regardless of chunk count.
+    fn certify_ok_leaves(
+        &mut self,
+        store: &Store,
+        location: &HashTreePath,
+        effective_headers: &[(String, String)],
+        content_type: &str,
+        encoding: Encoding,
+        enc: &EncodingMeta,
+    ) -> Vec<HashTreePath> {
+        let cert_expr = certificate_expression_for(effective_headers, encoding, &enc.sha256);
+        let resp_hashes = response_hashes_for(
+            effective_headers,
+            content_type,
+            encoding,
+            &cert_expr,
+            &enc.sha256,
+        );
+
+        let leaf =
+            |expr_hash, resp_hash| crate::redirect::alias_tree_path(location, expr_hash, resp_hash);
+        let mut leaves = vec![leaf(cert_expr.expression_hash, resp_hashes[&304])];
+        if enc.num_chunks == 1 {
+            leaves.push(leaf(cert_expr.expression_hash, resp_hashes[&200]));
+        } else {
+            let (range_cert_expr, resp_206) =
+                self.range_response_certs(store, effective_headers, content_type, encoding, enc);
+            leaves.extend(
+                resp_206
+                    .into_iter()
+                    .map(|h| leaf(range_cert_expr.expression_hash, h)),
+            );
+        }
+        for tp in &leaves {
+            self.asset_hashes.certify_response_precomputed(tp);
+        }
+        leaves
     }
 
     // ---- access-protection certify helpers ----
@@ -481,64 +498,21 @@ impl Certifier {
             if status != 200 && enc.num_chunks > 1 {
                 continue;
             }
-            let cert_expr = certificate_expression_for(&effective_headers, encoding, &enc.sha256);
-
             if status == 200 {
-                // Compute the 200/304 response hashes once. A conditional
-                // request (a matching `If-None-Match`) to a 200-rewrite alias is
-                // served as a certified 304 with an empty body by
-                // `build_ok_http_response` — exactly like a direct hit, and
-                // regardless of chunk count, since its 304 branch runs ahead of
-                // the 206 branch. So the 304 leaf must exist at the alias
-                // location too; without it a normal browser refresh of an
-                // aliased path (e.g. `/` → `/index.html`) serves an uncertified
-                // 304 and fails response verification.
-                let resp_hashes = response_hashes_for(
+                // A 200-rewrite serves the target asset unchanged, so it must
+                // certify the very same leaves a direct hit does — the 200/206
+                // *and* the 304. Without the 304 leaf a normal browser refresh of
+                // an aliased path (e.g. `/` → `/index.html`) sends `If-None-Match`,
+                // is served a 304, and fails response verification. Reuse the exact
+                // direct-hit certification, only at the alias location.
+                tree_paths.extend(self.certify_ok_leaves(
+                    store,
+                    &location,
                     &effective_headers,
                     &meta.content_type,
                     encoding,
-                    &cert_expr,
-                    &enc.sha256,
-                );
-                let tp_304 = crate::redirect::alias_tree_path(
-                    &location,
-                    cert_expr.expression_hash,
-                    resp_hashes[&304],
-                );
-                self.asset_hashes.certify_response_precomputed(&tp_304);
-                tree_paths.push(tp_304);
-
-                if enc.num_chunks > 1 {
-                    // Multi-chunk target: the 200 is delivered as N×206 (the
-                    // gateway reassembles them into a 200), exactly like a direct
-                    // hit. Certify those 206 leaves; the full 200 is never served
-                    // for a multi-chunk encoding, so it is not certified.
-                    let (range_cert_expr, resp_206) = self.range_response_certs(
-                        store,
-                        &effective_headers,
-                        &meta.content_type,
-                        encoding,
-                        enc,
-                    );
-                    for resp_hash in resp_206 {
-                        let tp = crate::redirect::alias_tree_path(
-                            &location,
-                            range_cert_expr.expression_hash,
-                            resp_hash,
-                        );
-                        self.asset_hashes.certify_response_precomputed(&tp);
-                        tree_paths.push(tp);
-                    }
-                } else {
-                    // Single-chunk target: certify the encoding's full 200.
-                    let tp = crate::redirect::alias_tree_path(
-                        &location,
-                        cert_expr.expression_hash,
-                        resp_hashes[&200],
-                    );
-                    self.asset_hashes.certify_response_precomputed(&tp);
-                    tree_paths.push(tp);
-                }
+                    enc,
+                ));
                 continue;
             }
 
@@ -546,6 +520,7 @@ impl Certifier {
             // the same headers and body the asset would serve at 200. Only
             // single-chunk encodings reach here (multi-chunk 4xx was skipped
             // above), and an error page never takes the etag/304 path.
+            let cert_expr = certificate_expression_for(&effective_headers, encoding, &enc.sha256);
             let base_headers: Vec<(String, Value)> = headers_for(
                 &effective_headers,
                 &meta.content_type,

--- a/crates/canister-core/src/cert/certifier.rs
+++ b/crates/canister-core/src/cert/certifier.rs
@@ -483,22 +483,58 @@ impl Certifier {
             }
             let cert_expr = certificate_expression_for(&effective_headers, encoding, &enc.sha256);
 
-            // A 200-rewrite to a multi-chunk target serves N×206 (the gateway
-            // reassembles them into a 200), exactly like a direct hit. Certify
-            // those 206 leaves at the alias location and move on.
-            if status == 200 && enc.num_chunks > 1 {
-                let (range_cert_expr, resp_hashes) = self.range_response_certs(
-                    store,
+            if status == 200 {
+                // Compute the 200/304 response hashes once. A conditional
+                // request (a matching `If-None-Match`) to a 200-rewrite alias is
+                // served as a certified 304 with an empty body by
+                // `build_ok_http_response` — exactly like a direct hit, and
+                // regardless of chunk count, since its 304 branch runs ahead of
+                // the 206 branch. So the 304 leaf must exist at the alias
+                // location too; without it a normal browser refresh of an
+                // aliased path (e.g. `/` → `/index.html`) serves an uncertified
+                // 304 and fails response verification.
+                let resp_hashes = response_hashes_for(
                     &effective_headers,
                     &meta.content_type,
                     encoding,
-                    enc,
+                    &cert_expr,
+                    &enc.sha256,
                 );
-                for resp_hash in resp_hashes {
+                let tp_304 = crate::redirect::alias_tree_path(
+                    &location,
+                    cert_expr.expression_hash,
+                    resp_hashes[&304],
+                );
+                self.asset_hashes.certify_response_precomputed(&tp_304);
+                tree_paths.push(tp_304);
+
+                if enc.num_chunks > 1 {
+                    // Multi-chunk target: the 200 is delivered as N×206 (the
+                    // gateway reassembles them into a 200), exactly like a direct
+                    // hit. Certify those 206 leaves; the full 200 is never served
+                    // for a multi-chunk encoding, so it is not certified.
+                    let (range_cert_expr, resp_206) = self.range_response_certs(
+                        store,
+                        &effective_headers,
+                        &meta.content_type,
+                        encoding,
+                        enc,
+                    );
+                    for resp_hash in resp_206 {
+                        let tp = crate::redirect::alias_tree_path(
+                            &location,
+                            range_cert_expr.expression_hash,
+                            resp_hash,
+                        );
+                        self.asset_hashes.certify_response_precomputed(&tp);
+                        tree_paths.push(tp);
+                    }
+                } else {
+                    // Single-chunk target: certify the encoding's full 200.
                     let tp = crate::redirect::alias_tree_path(
                         &location,
-                        range_cert_expr.expression_hash,
-                        resp_hash,
+                        cert_expr.expression_hash,
+                        resp_hashes[&200],
                     );
                     self.asset_hashes.certify_response_precomputed(&tp);
                     tree_paths.push(tp);
@@ -506,29 +542,20 @@ impl Certifier {
                 continue;
             }
 
-            let resp_hash = if status == 200 {
-                // The encoding's already-certified 200 response hash.
-                response_hashes_for(
-                    &effective_headers,
-                    &meta.content_type,
-                    encoding,
-                    &cert_expr,
-                    &enc.sha256,
-                )[&200]
-            } else {
-                // 4xx custom error page: re-certify with the override status
-                // using the same headers and body the asset would serve at 200.
-                let base_headers: Vec<(String, Value)> = headers_for(
-                    &effective_headers,
-                    &meta.content_type,
-                    encoding,
-                    &enc.sha256,
-                )
-                .into_iter()
-                .map(|(k, v)| (k, Value::String(v)))
-                .collect();
-                response_hash(&base_headers, status, &enc.sha256).0
-            };
+            // 4xx custom error page: re-certify with the override status using
+            // the same headers and body the asset would serve at 200. Only
+            // single-chunk encodings reach here (multi-chunk 4xx was skipped
+            // above), and an error page never takes the etag/304 path.
+            let base_headers: Vec<(String, Value)> = headers_for(
+                &effective_headers,
+                &meta.content_type,
+                encoding,
+                &enc.sha256,
+            )
+            .into_iter()
+            .map(|(k, v)| (k, Value::String(v)))
+            .collect();
+            let resp_hash = response_hash(&base_headers, status, &enc.sha256).0;
             let tp =
                 crate::redirect::alias_tree_path(&location, cert_expr.expression_hash, resp_hash);
             self.asset_hashes.certify_response_precomputed(&tp);

--- a/crates/canister-core/src/redirect.rs
+++ b/crates/canister-core/src/redirect.rs
@@ -228,22 +228,21 @@ pub fn build_synthetic_entry(rule: &RedirectRule) -> CertifiedRuleEntry {
     let resp_hash = response_hash(&certified, rule.status, &body_hash);
 
     let location = tree_location(rule);
-    let mut full_segs = location.0.clone();
-    full_segs.push(NestedTreeKey::Hash(expression.expression_hash));
-    full_segs.push(NestedTreeKey::String(String::new())); // empty request hash sentinel
-    full_segs.push(NestedTreeKey::Hash(resp_hash.0));
+    let tree_path = response_leaf_path(&location, expression.expression_hash, resp_hash.0);
 
     CertifiedRuleEntry {
-        tree_paths: vec![HashTreePath::from(full_segs)],
+        tree_paths: vec![tree_path],
         location,
         kind: CertifiedRuleEntryKind::Synthetic { expression },
     }
 }
 
-/// Build a tree path slot for the rule's location with the given expression
-/// hash and response hash. Used by the status-200 path to mirror each
-/// encoding of a target asset.
-pub fn alias_tree_path(
+/// Build a response-only certified leaf at `location`: the location prefix
+/// followed by `[expression_hash, <empty request hash>, response_hash]`. This is
+/// the generic leaf shape every certified response uses (asset, alias, synthetic
+/// redirect, protection sibling), not anything alias-specific — the empty request
+/// hash is the "no request certification" sentinel.
+pub fn response_leaf_path(
     location: &HashTreePath,
     expression_hash: [u8; 32],
     response_hash: [u8; 32],

--- a/crates/canister-core/src/state/tests.rs
+++ b/crates/canister-core/src/state/tests.rs
@@ -2062,6 +2062,86 @@ mod certification {
     }
 
     #[test]
+    fn conditional_request_to_exact_alias_serves_certified_304() {
+        // Regression: a 200-rewrite alias (`/` → `/index.html`) must certify the
+        // 304 at the *alias* location, not only at the target asset's own path. A
+        // normal browser refresh of `/` sends `If-None-Match`, so the alias serves
+        // a 304; before the fix that 304 was uncertified and failed response
+        // verification (a direct `/index.html` hit was fine, masking the bug).
+        // Requesting the alias path through `certified_http_request` reproduces the
+        // browser path and asserts the 304 is cryptographically valid.
+        let mut state = State::default();
+        let system_context = mock_system_context();
+
+        const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
+        let etag = format!("\"{}\"", hex::encode(sha2::Sha256::digest(BODY)));
+
+        create_assets(
+            &mut state,
+            &system_context,
+            vec![
+                AssetBuilder::new("/index.html", "text/html").with_encoding("identity", vec![BODY]),
+            ],
+        );
+        set_exact_rewrite_rule(&mut state, "/", "/index.html");
+
+        // Matching etag against the alias path -> certified 304, empty body.
+        let not_modified = certified_http_request(
+            &state,
+            RequestBuilder::get("/")
+                .with_header("Accept-Encoding", "identity")
+                .with_header("If-None-Match", &etag)
+                .build(),
+        );
+        assert_eq!(not_modified.status_code, 304);
+        assert!(not_modified.body.is_empty());
+        assert_eq!(lookup_header(&not_modified, "etag").unwrap(), etag);
+
+        // A first visit (no `If-None-Match`) still serves the full certified 200.
+        let full = certified_http_request(
+            &state,
+            RequestBuilder::get("/")
+                .with_header("Accept-Encoding", "identity")
+                .build(),
+        );
+        assert_eq!(full.status_code, 200);
+        assert_eq!(full.body.as_ref(), BODY);
+    }
+
+    #[test]
+    fn conditional_request_to_subtree_alias_serves_certified_304() {
+        // The 304 certification must also hold for a subtree (SPA) fallback alias,
+        // whose leaves live at a `<*>` tree location rather than an exact `<$>` one.
+        let mut state = State::default();
+        let system_context = mock_system_context();
+
+        const BODY: &[u8] = b"<!DOCTYPE html><html></html>";
+        let etag = format!("\"{}\"", hex::encode(sha2::Sha256::digest(BODY)));
+
+        create_assets(
+            &mut state,
+            &system_context,
+            vec![
+                AssetBuilder::new("/index.html", "text/html").with_encoding("identity", vec![BODY]),
+            ],
+        );
+        set_root_spa_rule(&mut state, "/index.html");
+
+        // A deep client route with no asset falls through to the SPA alias; a
+        // matching `If-None-Match` there must serve a certified 304.
+        let not_modified = certified_http_request(
+            &state,
+            RequestBuilder::get("/deep/client/route")
+                .with_header("Accept-Encoding", "identity")
+                .with_header("If-None-Match", &etag)
+                .build(),
+        );
+        assert_eq!(not_modified.status_code, 304);
+        assert!(not_modified.body.is_empty());
+        assert_eq!(lookup_header(&not_modified, "etag").unwrap(), etag);
+    }
+
+    #[test]
     fn ic_certificate_expression_present_for_new_assets() {
         let mut state = State::default();
         let system_context = mock_system_context();

--- a/crates/canister-core/src/state/tests.rs
+++ b/crates/canister-core/src/state/tests.rs
@@ -2937,6 +2937,23 @@ mod redirect_rules {
         );
         assert_eq!(ranged.status_code, 206);
         assert_eq!(ranged.body.as_ref(), C1);
+
+        // A conditional request short-circuits the 206 path: a matching
+        // `If-None-Match` (the whole-content ETag the 206 carries) must serve a
+        // certified 304 at the alias location, exactly as for a single-chunk
+        // target. The 304 leaf is certified with the non-range expression, so its
+        // certification is independent of chunk count.
+        let etag = lookup_header(&plain, "etag").unwrap().to_string();
+        let not_modified = certified_http_request(
+            &state,
+            RequestBuilder::get("/landing")
+                .with_header("Accept-Encoding", "identity")
+                .with_header("If-None-Match", &etag)
+                .build(),
+        );
+        assert_eq!(not_modified.status_code, 304);
+        assert!(not_modified.body.is_empty());
+        assert_eq!(lookup_header(&not_modified, "etag").unwrap(), etag);
     }
 
     #[test]

--- a/crates/e2e/tests/etag.rs
+++ b/crates/e2e/tests/etag.rs
@@ -59,4 +59,29 @@ fn conditional_request_yields_certified_304() {
         !modified.bytes().unwrap().is_empty(),
         "stale If-None-Match should serve the full body"
     );
+
+    // Regression: the same round-trip against the `/` alias (the `/ →
+    // /index.html` 200 rewrite a browser actually navigates to), not just the
+    // direct asset path. A normal browser refresh of `/` sends `If-None-Match`,
+    // so the alias serves a 304 — which must be certified at the *alias*
+    // location or the gateway rejects it with a Response Verification Error. The
+    // direct hit above once passed while this failed, masking the bug.
+    let root = http_fetch(project, "/");
+    assert_eq!(root.status(), StatusCode::OK);
+    let root_etag = etag_of(root.headers());
+    assert!(
+        !root.bytes().unwrap().is_empty(),
+        "`/` 200 should carry a body"
+    );
+
+    let root_not_modified = http_fetch_with_headers(project, "/", &[("If-None-Match", &root_etag)]);
+    assert_eq!(
+        root_not_modified.status(),
+        StatusCode::NOT_MODIFIED,
+        "conditional GET of the `/` alias must yield a certified 304"
+    );
+    assert!(
+        root_not_modified.bytes().unwrap().is_empty(),
+        "304 must have an empty body"
+    );
 }


### PR DESCRIPTION
## Problem

A browser navigating to the site requests **`/`**, which the canister serves through a **status-200 rewrite alias** (`/ → /index.html`). On a **normal refresh** the browser revalidates with `If-None-Match`, so the alias serves a **304** (empty body). But [`build_alias_rule_entry`](crates/canister-core/src/cert/certifier.rs) certified only the **200** (and N×206) at the alias location — never the 304. The uncertified 304 failed response verification at the gateway, surfacing to the user as a **503 "Response Verification Error"**.

The fingerprint matched exactly: first load and **hard** refresh (no `If-None-Match` → 200) worked; **normal** refresh (→ 304) failed. A direct `/index.html` hit certifies both 200 and 304, which is why the existing ETag e2e test — hitting `/index.html` — never caught it.

## Fix

Certify the **304 leaf at the alias location** for every status-200 rewrite, single- and multi-chunk alike. The serve path's 304 branch runs ahead of the 206 branch, so a matching conditional request yields a 304 regardless of chunk count. The existing 200 / N×206 leaves and the 4xx error-page path are unchanged; response hashes are computed once.

## Follow-up refactor

The root cause was drift: a 200-rewrite alias must certify the *same* leaf set as a direct asset hit (304 included), and the two had diverged. To make that class of bug structurally impossible, the paths now share one implementation — a pure refactor, verified byte-identical by the crypto-verified suite + golden vectors.

- **`certify_ok_leaves`** — the "304 always + full-200 (single-chunk) / N×206 (multi-chunk)" leaf set was written twice (direct-asset `certify_asset_encodings` and the alias branch). Extracted into one helper that both call with their own tree location, so they can no longer certify different sets. Net −25 lines in the certifier.
- **`alias_tree_path` → `response_leaf_path`** — the shared leaf-path builder was named "alias" though it builds the generic response-leaf shape every certified response uses (asset, alias, synthetic redirect, protection sibling). Renamed, and `build_synthetic_entry` (3xx redirects) — which had hand-inlined the identical construction — now calls it too.

## Testing

- **Unit** (`canister-core`): new tests for the exact (`/`) and subtree (`<*>` SPA) alias locations, verified cryptographically via `certified_http_request` (the real `ic-response-verification` path). They **fail before this change and pass after** (confirmed by reverting the fix). The existing multi-chunk alias test also gains a matching-`If-None-Match` assertion, guarding the multi-chunk 304 leaf.
- **E2E**: extended the ETag test to revalidate the `/` alias through the live gateway — the exact browser path that was failing. Passes end-to-end.
- The refactor's byte-identical output is guarded by the crypto-verified serve/verify tests (incl. the 3xx-redirect path) and the `state-hash` golden vectors.
- Full `canister-core` suite green (160 tests); `clippy` and `fmt` clean.

## Rollout

Non-breaking (no stable-state shape change) → **patch** release, **bumped in this PR (`0.3.0 → 0.3.1`)**. Deployed 0.3.0 canisters upgrade in place; `post_upgrade_rebuild` re-runs the fixed certification and adds the 304 leaves — **no asset re-sync required**.

After merge, cut the release from an up-to-date `main`:

```sh
make tag                    # tags HEAD v0.3.1 (verifies it matches Cargo.toml)
git push origin v0.3.1      # triggers .github/workflows/release.yml
```

Then re-point the `@dfinity/static-site` recipe in `icp-cli-recipes` at the new release's wasm URLs + checksums (it pins them exactly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
