### PR TITLE
docs: document SPA configuration, add spa example + e2e coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ An ICP assets canister and `icp-cli` sync plugin for serving certified static as
 
 - **Using it** — to deploy a site, see the [user documentation](docs/overview.md):
   [getting started](docs/overview.md), [routing & clean URLs](docs/routing.md),
+  [single-page apps](docs/routing.md#single-page-apps-spa),
   [redirects](docs/redirects.md), [custom headers](docs/headers.md),
   [site files](docs/site-files.md), and [how it works](docs/how-it-works.md).
 - **Examples** — runnable projects in [`examples/`](examples/): a minimal static
-  site, custom headers, redirects, clean URLs, a catch-all 404, and access
-  protection. Each deploys with `icp deploy` and doubles as an e2e test.
+  site, custom headers, redirects, clean URLs, a catch-all 404, a single-page app,
+  and access protection. Each deploys with `icp deploy` and doubles as an e2e test.
 - **Hacking on it** — see [`ARCHITECTURE.md`](ARCHITECTURE.md) for the crate layout
   and how the canister and plugin fit together.
 

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -241,6 +241,17 @@ pub fn http_fetch_with_headers(
 /// (notably around path normalisation), so tests that mirror real browser
 /// behaviour should prefer this helper.
 pub fn http_fetch_subdomain(project: &Path, path: &str) -> reqwest::blocking::Response {
+    http_fetch_subdomain_with_headers(project, path, &[])
+}
+
+/// Like [`http_fetch_subdomain`], but attaches arbitrary request headers — e.g.
+/// an `If-None-Match` to exercise a 304 through the browser-style URL, which is
+/// the form that forces the gateway's full v2 verification.
+pub fn http_fetch_subdomain_with_headers(
+    project: &Path,
+    path: &str,
+    headers: &[(&str, &str)],
+) -> reqwest::blocking::Response {
     let cid = frontend_canister_id(project);
     let base = gateway_url(project);
     // base looks like `http://127.0.0.1:PORT` or `http://localhost:PORT`. We
@@ -262,13 +273,16 @@ pub fn http_fetch_subdomain(project: &Path, path: &str) -> reqwest::blocking::Re
         .expect("subdomain URL has port");
     let addr: std::net::SocketAddr = ([127, 0, 0, 1], port).into();
 
-    reqwest::blocking::Client::builder()
+    let mut req = reqwest::blocking::Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .resolve(&host, addr)
         .build()
         .expect("build reqwest client")
-        .get(&url)
-        .send()
+        .get(&url);
+    for (name, value) in headers {
+        req = req.header(*name, *value);
+    }
+    req.send()
         .unwrap_or_else(|e| panic!("GET {url} failed: {e}"))
 }
 

--- a/crates/e2e/tests/spa.rs
+++ b/crates/e2e/tests/spa.rs
@@ -1,0 +1,271 @@
+//! End-to-end tests for the single-page-app fallback (`/* /index.html 200`).
+//!
+//! A SPA is the shape most exposed to the certification edge cases around
+//! rewrite rules: nearly every request is answered from a *wildcard* tree
+//! location that borrows another asset's body, rather than from the asset's own
+//! exact location. The gateway validates the `IC-Certificate` before handing a
+//! response back, so each successful fetch here is also proof the canister
+//! certified that alias response — and a regression would surface as a 503
+//! "Response Verification Error" rather than a wrong body.
+//!
+//! Deploys the `spa` example, whose committed `icp.yaml` is used unchanged (see
+//! `setup_example`).
+
+use e2e::{
+    LocalNetwork, http_fetch_subdomain, http_fetch_subdomain_with_headers, icp_cmd, setup_example,
+};
+use reqwest::StatusCode;
+
+const SHELL_MARKER: &str = "SPA demo";
+
+fn header_value<'a>(headers: &'a reqwest::header::HeaderMap, name: &str) -> Option<&'a str> {
+    headers.get(name).and_then(|v| v.to_str().ok())
+}
+
+/// Assert `path` serves the app shell with a 200 through the browser-style
+/// subdomain URL, and return the response headers for further assertions.
+fn expect_shell(project: &std::path::Path, path: &str) -> reqwest::header::HeaderMap {
+    let r = http_fetch_subdomain(project, path);
+    assert_eq!(
+        r.status(),
+        StatusCode::OK,
+        "SPA fallback: GET {path} expected 200, got {}",
+        r.status()
+    );
+    let headers = r.headers().clone();
+    assert!(
+        header_value(&headers, "content-type").is_some_and(|ct| ct.starts_with("text/html")),
+        "SPA fallback: GET {path} should serve the HTML shell, got content-type {:?}",
+        header_value(&headers, "content-type")
+    );
+    let body = r.text().expect("read body");
+    assert!(
+        body.contains(SHELL_MARKER),
+        "SPA fallback: GET {path} expected the shell body, got: {body}"
+    );
+    headers
+}
+
+/// The headline behaviour: paths with no asset behind them serve the shell with
+/// a certified 200, at any depth, while real files still win.
+#[test]
+fn spa_fallback_serves_shell_and_files_still_win() {
+    let tmp = setup_example("spa");
+    let project = tmp.path();
+    let _network = LocalNetwork::start(project);
+
+    icp_cmd(project).arg("deploy").assert().success();
+
+    // The root, served by the synthesised `/ -> /index.html` rewrite.
+    expect_shell(project, "/");
+
+    // Client routes: no asset, no synthesised rule — only `/*` can answer these.
+    // A full reload of a nested route is the case that breaks on hosts without a
+    // SPA fallback.
+    expect_shell(project, "/dashboard");
+    expect_shell(project, "/dashboard/settings/deep");
+    // Not a route the app knows either — the canister still serves the shell and
+    // lets the client decide it's a 404.
+    expect_shell(project, "/no-such-route");
+
+    // A real file wins over the `/*` rule, via its clean URL.
+    let r = http_fetch_subdomain(project, "/legal");
+    assert_eq!(
+        r.status(),
+        StatusCode::OK,
+        "/legal expected 200 from the static file, got {}",
+        r.status()
+    );
+    let body = r.text().expect("read body");
+    assert!(
+        body.contains("Legal (static page)"),
+        "/legal should serve legal.html, not the shell; got: {body}"
+    );
+
+    // Clean-URL rules are matched before `_redirects`, so aliases of real files
+    // still redirect instead of falling through to `/*`.
+    let r = http_fetch_subdomain(project, "/index");
+    assert_eq!(
+        r.status(),
+        StatusCode::TEMPORARY_REDIRECT,
+        "/index expected 307, got {}",
+        r.status()
+    );
+    assert_eq!(header_value(r.headers(), "location"), Some("/"));
+
+    let r = http_fetch_subdomain(project, "/legal/");
+    assert_eq!(
+        r.status(),
+        StatusCode::TEMPORARY_REDIRECT,
+        "/legal/ expected 307, got {}",
+        r.status()
+    );
+    assert_eq!(header_value(r.headers(), "location"), Some("/legal"));
+}
+
+/// Declaring a root `/*` suppresses the site-wide 404 convention entirely: the
+/// plugin neither injects its branded page nor appends the catch-all rule, so an
+/// unknown path is a client route rather than a 404 — even though this project
+/// ships a `404.html` of its own (wired only to `/assets/*`, below).
+#[test]
+fn root_catchall_suppresses_site_wide_404() {
+    let tmp = setup_example("spa");
+    let project = tmp.path();
+    let _network = LocalNetwork::start(project);
+
+    icp_cmd(project).arg("deploy").assert().success();
+
+    // The observable: nothing routes an unknown page path to a 404 page.
+    expect_shell(project, "/no-such-route");
+    expect_shell(project, "/deeply/nested/unknown");
+
+    // The project's own 404.html is untouched — not overwritten by the branded
+    // default the plugin injects when there is no root catch-all.
+    let r = http_fetch_subdomain(project, "/404.html");
+    assert_eq!(r.status(), StatusCode::OK);
+    let body = r.text().expect("read body");
+    assert!(
+        body.contains("404 — asset not found"),
+        "/404.html should be the project's own page, got: {body}"
+    );
+    assert!(
+        !body.contains("default page served by the assets canister"),
+        "the branded default must not be injected when a root `/*` rule exists"
+    );
+
+    // Being a real file, it also gets a clean URL — and a *200*, since nothing
+    // routes it as an error page site-wide. The example README says so.
+    let r = http_fetch_subdomain(project, "/404");
+    assert_eq!(
+        r.status(),
+        StatusCode::OK,
+        "/404 is the clean URL of a real file, so it 200s; got {}",
+        r.status()
+    );
+    assert!(
+        r.text()
+            .expect("read body")
+            .contains("404 — asset not found"),
+        "/404 should serve 404.html's contents"
+    );
+}
+
+/// A 4xx rule scoped above the catch-all gives build output an honest 404 instead
+/// of the HTML shell, without disturbing real files under the same subtree. This
+/// is the snippet `docs/routing.md` recommends for the "missing asset returns
+/// HTML" caveat.
+#[test]
+fn scoped_4xx_rule_shields_asset_subtree_from_the_catchall() {
+    let tmp = setup_example("spa");
+    let project = tmp.path();
+    let _network = LocalNetwork::start(project);
+
+    icp_cmd(project).arg("deploy").assert().success();
+
+    // A stale or typo'd bundle URL: a real, certified 404 — not the shell.
+    for path in [
+        "/assets/app-old.js",
+        "/assets/typo.js",
+        "/assets/nested/x.json",
+    ] {
+        let r = http_fetch_subdomain(project, path);
+        assert_eq!(
+            r.status(),
+            StatusCode::NOT_FOUND,
+            "{path} expected 404 from the scoped rule, got {}",
+            r.status()
+        );
+        let body = r.text().expect("read body");
+        assert!(
+            body.contains("404 — asset not found"),
+            "{path} should serve /404.html, got: {body}"
+        );
+    }
+
+    // The real file under the same subtree still wins over both rules.
+    let r = http_fetch_subdomain(project, "/assets/app.js");
+    assert_eq!(r.status(), StatusCode::OK);
+    assert!(
+        r.text().expect("read body").contains("client-side router"),
+        "/assets/app.js must still serve the script itself"
+    );
+
+    // And the scoped rule doesn't leak: page routes outside /assets/ still get
+    // the shell, because the catch-all is matched after it.
+    expect_shell(project, "/dashboard");
+}
+
+/// `_headers` patterns match the asset key, and a 200 rewrite reuses its
+/// target's certified headers — so the shell carries the `Cache-Control`
+/// declared for `/*.html` at every client route, not just at `/index.html`.
+#[test]
+fn shell_headers_reach_client_routes() {
+    let tmp = setup_example("spa");
+    let project = tmp.path();
+    let _network = LocalNetwork::start(project);
+
+    icp_cmd(project).arg("deploy").assert().success();
+
+    const SHELL_CACHE: &str = "public, max-age=0, must-revalidate";
+    for path in ["/", "/dashboard", "/dashboard/settings/deep"] {
+        let headers = expect_shell(project, path);
+        assert_eq!(
+            header_value(&headers, "cache-control"),
+            Some(SHELL_CACHE),
+            "{path} should inherit /index.html's Cache-Control through the rewrite"
+        );
+    }
+
+    // The bundle is a direct asset hit and keeps its own long-lived policy.
+    let r = http_fetch_subdomain(project, "/assets/app.js");
+    assert_eq!(r.status(), StatusCode::OK);
+    assert_eq!(
+        header_value(r.headers(), "cache-control"),
+        Some("public, max-age=31536000, immutable"),
+    );
+    // Served as a script, not as the HTML shell — the `/*` rule never sees it.
+    assert!(
+        header_value(r.headers(), "content-type").is_some_and(|ct| ct.contains("javascript")),
+        "/assets/app.js should be served as a script, got content-type {:?}",
+        header_value(r.headers(), "content-type")
+    );
+}
+
+/// A browser reload of a client route sends `If-None-Match`. The 304 must be
+/// certified *at the wildcard alias location*, not only at `/index.html` — the
+/// gateway rejects an uncertified 304, which showed up in the wild as a 503 on
+/// refresh of any aliased path.
+#[test]
+fn conditional_request_on_client_route_yields_certified_304() {
+    let tmp = setup_example("spa");
+    let project = tmp.path();
+    let _network = LocalNetwork::start(project);
+
+    icp_cmd(project).arg("deploy").assert().success();
+
+    for path in ["/", "/dashboard", "/dashboard/settings/deep"] {
+        let headers = expect_shell(project, path);
+        let etag = header_value(&headers, "etag")
+            .unwrap_or_else(|| panic!("{path} must carry an ETag"))
+            .to_string();
+
+        let r = http_fetch_subdomain_with_headers(project, path, &[("If-None-Match", &etag)]);
+        assert_eq!(
+            r.status(),
+            StatusCode::NOT_MODIFIED,
+            "revalidating {path} expected a certified 304, got {} \
+             (a 503 here means the 304 wasn't certified at the alias location)",
+            r.status()
+        );
+        assert!(
+            r.bytes().expect("read body").is_empty(),
+            "304 for {path} must have an empty body"
+        );
+    }
+
+    // A stale validator still serves the full shell.
+    let stale = "\"0000000000000000000000000000000000000000000000000000000000000000\"";
+    let r = http_fetch_subdomain_with_headers(project, "/dashboard", &[("If-None-Match", stale)]);
+    assert_eq!(r.status(), StatusCode::OK);
+    assert!(!r.bytes().expect("read body").is_empty());
+}

--- a/docs/headers.md
+++ b/docs/headers.md
@@ -1,7 +1,7 @@
 # Custom headers
 
 Add a file named `_headers` to the root of your asset directory to attach response
-headers — cache-control, a Content Security Policy, other security headers — to paths
+headers — cache-control, a Content Security Policy, other security headers — to files
 on your site. The syntax follows [Netlify's `_headers`](https://docs.netlify.com/manage/routing/headers/):
 a path pattern on its own line, followed by indented `Name: value` lines.
 
@@ -20,18 +20,37 @@ A blank line or a `#` comment ends a block.
 
 A pattern is an absolute path (leading `/`) with an optional `*` wildcard:
 
-- `/` — the home page only.
-- `/about` — one exact path.
+- `/index.html` — one exact file (the home page).
+- `/about.html` — likewise, one exact file.
 - `/assets/*` — everything under `/assets/`.
-- `/*.css` — every path ending in `.css`.
-- `/*` — every path.
+- `/*.css` — every file ending in `.css`.
+- `/*` — every file.
 
 The single `*` matches any run of characters, including `/`. There is no `**`, no
 `?`, and no `:placeholder` capture (see [why dynamic rules aren't supported](redirects.md#what-isnt-supported-dynamic-rules)).
 
+### Patterns match files, not URLs
+
+A pattern is matched against the **path of the file inside your directory** — its
+asset key — not against the URL a visitor typed. For most sites the two are the same
+string and the distinction never comes up, but it matters wherever a URL and a file
+differ:
+
+- **Clean URLs.** Write `/about.html`, not `/about`, and `/index.html` for the home
+  page. There is no file at `/`, so a `/` pattern matches nothing at all.
+- **Rewrites.** A `200` [rewrite](redirects.md) serves its target file's contents,
+  and reuses that file's headers. So the headers for `/article` come from the pattern
+  matching `/content/article.html`. For a [SPA](routing.md#single-page-apps-spa) — where
+  a single `/*` rewrite serves the shell at every client route — this means a
+  `Cache-Control` declared for `/index.html` reaches all of them, and a block written
+  against a route like `/dashboard/*` matches no file and does nothing.
+- **Redirects.** A `3xx` rule is the one exception: it synthesizes its own response
+  rather than serving a file, so its headers come from patterns matching the rule's
+  `from` path.
+
 ## How rules combine
 
-A path can match several blocks at once, and **all matching blocks contribute** their
+A file can match several blocks at once, and **all matching blocks contribute** their
 headers — patterns don't override each other wholesale. For a single header name:
 
 - Values from different matching blocks are combined into one header, comma-separated

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -122,6 +122,8 @@ When you need finer control, each topic has its own page:
 
 - **[Routing & clean URLs](routing.md)** — how request paths map to files, trailing
   slashes, and 404 handling.
+- **[Single-page apps](routing.md#single-page-apps-spa)** — the one `_redirects` rule a
+  client-side-routed app needs, so every URL loads (and reloads) your shell.
 - **[Redirects & rewrites](redirects.md)** — the `_redirects` file: send `/old` to
   `/new`, serve one file at another path, set custom error pages.
 - **[Custom headers](headers.md)** — the `_headers` file: cache-control, a Content

--- a/docs/redirects.md
+++ b/docs/redirects.md
@@ -82,7 +82,8 @@ overall order:
 4. **The 404 fallback.** Finally the [not-found page](routing.md#not-found-handling).
 
 So a `/*` rule at the end of your file only catches paths that nothing earlier
-claimed — which is exactly what makes the SPA fallback above safe.
+claimed — which is exactly what makes the
+[SPA fallback](routing.md#single-page-apps-spa) above safe.
 
 ## What isn't supported: dynamic rules
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -51,16 +51,71 @@ Every request must resolve to a certified response, so there is always a `404` p
   `404` page for any unmatched path.
 - **Custom.** Add a file at the root of your directory named `404.html`. It's
   automatically wired up as the site-wide not-found page (served with a `404` status).
-- **Single-page apps (SPA).** If your app does client-side routing, send every
-  unmatched path to your shell instead of a 404, by adding this to
-  [`_redirects`](redirects.md):
+- **Client-side routing.** A [single-page app](#single-page-apps-spa) sends unmatched
+  paths to its shell instead of to a 404 page.
+
+## Single-page apps (SPA)
+
+If your app does client-side routing — React Router, Vue Router, SvelteKit in SPA
+mode, or a hand-rolled `history.pushState` router — the server has to answer *every*
+URL with the app shell so the router can take over. Add one rule to
+[`_redirects`](redirects.md):
+
+```
+/*  /index.html  200
+```
+
+That's the whole SPA configuration. `200` makes it a **rewrite**: the shell's
+contents are served at the requested URL with no visible redirect, so
+`/dashboard/settings` works on a fresh load and on a browser reload, not just on
+in-app navigation. Every one of those responses is certified, including the ones at
+paths that have no file behind them.
+
+See the [`spa` example](../examples/spa/) for a complete, runnable project.
+
+### What the `/*` rule changes
+
+- **The default 404 page is not added.** Your root catch-all takes over the whole
+  path space, so unknown paths serve the shell and the app decides what a bad route
+  looks like.
+- **A missing asset returns HTML.** A typo'd or stale `/assets/app-old.js` matches
+  `/*` too, so it serves the shell with `Content-Type: text/html` and a `200`. This
+  mirrors Netlify and Cloudflare Pages, and it's the one behavior worth overriding: a
+  `fetch()` for missing JSON gets HTML it can't parse, and a missing script fails with
+  a confusing MIME-type error instead of a plain 404.
+
+  Give your build output an honest 404 by scoping a rule to it *above* the catch-all
+  — rules are matched in file order:
 
   ```
-  /*  /index.html  200
+  /assets/*  /404.html  404
+  /*         /index.html  200
   ```
 
-  When you declare your own root catch-all (`/*`) like this, it takes over the whole
-  path space and the default 404 page is not added — your rule wins, as a SPA needs.
+  Real files still win over both rules, so this only affects URLs under `/assets/`
+  that don't exist. It needs a `404.html` in your directory: declaring `/*` means the
+  built-in default is never added, and a 4xx rule whose target is missing goes
+  inert.
+
+### What it doesn't change
+
+- **Real files still win.** Files are matched before any rule, so you can mix
+  server-rendered pages into a SPA at no cost: ship `legal.html` and `/legal` serves
+  it, while `/*` only catches what nothing else claimed.
+- **Clean URLs still apply.** The [synthesized rules](#clean-urls) are matched before
+  your `_redirects`, so `/index` still `307`s to `/` and `/legal/` to `/legal`.
+
+### Two things to get right in the app
+
+- **Link assets with absolute paths.** Use `/assets/app.js`, not `assets/app.js`. A
+  relative URL resolves against the *client route*, so at `/dashboard/settings` the
+  browser would request `/dashboard/settings/assets/app.js` — which the `/*` rule
+  answers with the HTML shell.
+- **Put shell headers on the file, not the route.** [`_headers`](headers.md) patterns
+  match the file, and a rewrite reuses its target's headers, so a
+  `Cache-Control` declared for `/index.html` (or `/*.html`) is what every client
+  route gets. A block written against `/dashboard/*` matches no file and does
+  nothing. See [patterns match files, not URLs](headers.md#patterns-match-files-not-urls).
 
 ## See also
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,7 @@ the HTTP gateway (see [`crates/e2e/`](../crates/e2e/)), so these stay working.
 | [redirects](redirects/) | Redirects, custom error pages, and rewrites via a `_redirects` file. |
 | [clean-urls](clean-urls/) | Extensionless routing (`/foo` → `foo.html`), auto-synthesised with no config. |
 | [catch-all-404](catch-all-404/) | A `/*` catch-all serving a custom 404 page for every unknown URL. |
+| [spa](spa/) | A client-side-routed single-page app: one `/* /index.html 200` rule, so every URL loads the shell. |
 | [access-protection](access-protection/) | Turning a public site into a private one gated behind an access token. |
 
 ## Running any example

--- a/examples/spa/README.md
+++ b/examples/spa/README.md
@@ -1,0 +1,107 @@
+# Single-page app (SPA)
+
+Serve a client-side-routed app — React, Vue, Svelte, or the 30 lines of vanilla
+JS in this example — from a certified canister. The whole server-side contract is
+one `_redirects` rule:
+
+```
+/*  /index.html  200
+```
+
+Any path no real asset (and no auto-synthesised [clean-URL](../clean-urls/) rule)
+already claims serves the app shell with a **200**, so the router in the page can
+read `location.pathname` and render. Every one of those responses is certified,
+including the ones served at paths that have no file behind them.
+
+Declaring a root `/*` also **replaces the default 404 page**: unknown paths get
+the shell instead of an error, which is what a SPA wants — the app decides what a
+bad route looks like.
+
+## What it demonstrates
+
+- **The `/*` fallback.** `/dashboard` and `/dashboard/settings/deep` have no
+  files, yet both serve the shell with a 200 — on first load *and* on a full
+  browser reload.
+- **Static pages coexist.** `legal.html` is a real file, and files win over
+  rules, so `/legal` serves it and the `/*` fallback never sees the request.
+- **Headers reach client routes.** `_headers` patterns match the *file*, and a
+  `200` rewrite reuses its target's headers — so the `Cache-Control` declared for
+  `/*.html` is on the shell at every client route.
+- **Absolute asset URLs.** The shell links `/assets/app.js`, not
+  `assets/app.js`: at `/dashboard/settings` a relative path would request
+  `/dashboard/settings/assets/app.js`, which the `/*` rule happily answers with
+  the HTML shell.
+- **An honest 404 for build output.** `/assets/* /404.html 404`, placed above the
+  catch-all, keeps a missing bundle from being answered with the HTML shell and a
+  200 — the failure mode that turns a stale script URL into a MIME-type error and
+  a `fetch()` for missing JSON into unparseable HTML.
+
+It is exercised in CI by [`crates/e2e/tests/spa.rs`](../../crates/e2e/tests/spa.rs).
+
+## Project structure
+
+```
+spa
+├── icp.yaml
+└── dist
+    ├── _redirects        # /assets/* → 404, then /*  /index.html  200
+    ├── _headers          # cache the shell short, the bundle forever
+    ├── index.html        # the app shell
+    ├── legal.html        # a genuinely static page, alongside the app
+    ├── 404.html          # for missing files under /assets/ only
+    └── assets
+        └── app.js        # the client-side router
+```
+
+A real project replaces `dist/` with a bundler's output directory and adds a
+`build` step; see [the configuration reference](../../docs/overview.md#configuration).
+If the app needs a backend canister's ID baked in, build it in
+[`presync`](../../docs/overview.md#building-against-canister-ids-presync-vs-build)
+instead.
+
+## Prerequisites
+
+- [icp-cli](https://cli.icp.build)
+- A Rust toolchain with the `wasm32-unknown-unknown` and `wasm32-wasip2` targets,
+  plus `make`.
+
+## Run it
+
+```sh
+make wasm                 # from the repo root; builds the wasms into ../../dist
+cd examples/spa
+icp network start -d
+icp deploy
+```
+
+Open the `frontend` URL that `icp deploy` prints and click through the nav — then
+reload the page while on a nested route, which is the case that fails on hosts
+without a SPA fallback. From the terminal:
+
+```sh
+BASE="http://<canister-id>.localhost:<port>"
+curl -i "$BASE/dashboard/settings/deep"  # 200 + the shell, not a 404
+curl -i "$BASE/legal"                    # 200 + legal.html — the file wins
+curl -i "$BASE/assets/app.js"            # 200 + immutable Cache-Control
+curl -i "$BASE/assets/app-old.js"        # 404 — a stale bundle URL, not the shell
+```
+
+Stop the replica when you're done:
+
+```sh
+icp network stop
+```
+
+## Caveats worth knowing
+
+- **Outside `/assets/`, a missing file returns HTML, not a 404.** `/typo.js`
+  matches `/*`, so it serves the shell with `Content-Type: text/html` and a 200 —
+  the behaviour the scoped `/assets/*` rule exists to override. Widen that rule to
+  cover wherever your bundler writes.
+- **`404.html` is not the site-wide not-found page here.** The `/*` catch-all owns
+  every other path, so this file is reached only through the `/assets/*` rule.
+  Being a real file, it is also served directly at `/404.html` (and at `/404`, via
+  its clean URL) with a 200.
+- **Clean-URL aliases of real files still redirect.** `/index` 307s to `/` and
+  `/legal/` 307s to `/legal`, because the synthesised rules are matched before
+  your `_redirects`. Only unclaimed paths reach the `/*` fallback.

--- a/examples/spa/dist/404.html
+++ b/examples/spa/dist/404.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>404 — asset not found</title>
+  </head>
+  <body>
+    <main>
+      <h1>404 — asset not found</h1>
+      <p>Nothing under <code>/assets/</code> matched this URL, so the
+        <code>/assets/* /404.html 404</code> rule served this page with a real
+        404 status instead of handing back the app shell.</p>
+      <p>Note that this is <em>not</em> the site-wide not-found page: the
+        <code>/*</code> catch-all owns every other path, and serves the app so
+        its router can decide what an unknown route looks like.</p>
+      <p><a href="/">Back to the app</a></p>
+    </main>
+  </body>
+</html>

--- a/examples/spa/dist/_headers
+++ b/examples/spa/dist/_headers
@@ -1,0 +1,11 @@
+# Patterns match the *file* (its asset key), not the URL a visitor typed. The
+# shell is served at every client route through the `/*` rewrite, and a rewrite
+# reuses the target file's headers — so this block covers /dashboard,
+# /dashboard/settings/deep, and every other client route too.
+/*.html
+  Cache-Control: public, max-age=0, must-revalidate
+
+# Fingerprinted build output never changes, so cache it hard. A real bundler
+# emits hashed names (app-a1b2c3.js); this example keeps the name readable.
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable

--- a/examples/spa/dist/_redirects
+++ b/examples/spa/dist/_redirects
@@ -1,0 +1,18 @@
+# Build output should 404, not fall through to the app. Without this line a
+# typo'd or stale bundle URL would match the `/*` rule below and be answered with
+# the HTML shell and a 200 — so a `fetch()` for missing JSON gets HTML it can't
+# parse, and a missing script fails with a confusing MIME-type error. Scoping a
+# 404 to this subtree keeps real files working (an asset always wins over a rule)
+# and gives everything else under /assets/ an honest 404.
+#
+# It must come *before* the catch-all: rules are matched in file order.
+/assets/*  /404.html  404
+
+# Single-page-app fallback: any path that no real asset — and no
+# auto-synthesised clean-URL rule — already claims is served the app shell with
+# a 200, so the client-side router can take over. This is the one rule a SPA
+# needs.
+#
+# Declaring a root `/*` also means no default 404 page is added: every unknown
+# path serves the shell, which is exactly what a SPA wants.
+/*  /index.html  200

--- a/examples/spa/dist/assets/app.js
+++ b/examples/spa/dist/assets/app.js
@@ -1,0 +1,36 @@
+// A deliberately tiny client-side router — no framework, no build step.
+//
+// The point of the example is the *server* contract: because `_redirects` maps
+// `/*` to `/index.html` with a 200, this script runs no matter which URL the
+// visitor loads or reloads, and can read `location.pathname` to decide what to
+// render.
+
+const routes = {
+  "/": "Home — you loaded the shell at the root.",
+  "/dashboard": "Dashboard — a client route with no file behind it.",
+  "/dashboard/settings/deep":
+    "Deeply nested client route — still the same shell, still a 200.",
+};
+
+function render() {
+  const path = location.pathname;
+  const known = routes[path];
+  document.getElementById("app").innerHTML = `
+    <p><strong>Route:</strong> <code>${path}</code></p>
+    <p>${known ?? "Unknown client route — the app decides this is a 404, not the canister."}</p>
+  `;
+}
+
+// Intercept in-app navigation so it never round-trips to the canister.
+document.addEventListener("click", (event) => {
+  const link = event.target.closest("a[data-link]");
+  if (!link) return;
+  event.preventDefault();
+  history.pushState({}, "", link.getAttribute("href"));
+  render();
+});
+
+// Back/forward buttons.
+addEventListener("popstate", render);
+
+render();

--- a/examples/spa/dist/index.html
+++ b/examples/spa/dist/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>SPA demo</title>
+    <!-- Absolute src (leading `/`). A relative `assets/app.js` would resolve
+         against the *client route* — at /dashboard/settings it would request
+         /dashboard/assets/app.js, which the `/*` rewrite answers with this HTML
+         page instead of the script. -->
+    <script defer src="/assets/app.js"></script>
+  </head>
+  <body>
+    <main>
+      <h1>SPA demo</h1>
+      <p>Every path below is handled by the client-side router in
+        <code>/assets/app.js</code>. The canister serves this same shell for all
+        of them, via one <code>/* /index.html 200</code> rule.</p>
+
+      <nav>
+        <a href="/" data-link>Home</a>
+        <a href="/dashboard" data-link>Dashboard</a>
+        <a href="/dashboard/settings/deep" data-link>Deeply nested route</a>
+        <!-- No data-link: a full page load, proving the server returns the
+             shell for this path too (not a 404). -->
+        <a href="/dashboard/settings/deep">Same route, full reload</a>
+        <!-- A genuinely static page, served from its own file. -->
+        <a href="/legal">Legal (static page)</a>
+      </nav>
+
+      <section id="app">
+        <!-- Rendered by the router; this text only shows if JS is disabled. -->
+        <p>Loading…</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/examples/spa/dist/legal.html
+++ b/examples/spa/dist/legal.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Legal — static page</title>
+  </head>
+  <body>
+    <main>
+      <h1>Legal (static page)</h1>
+      <p>This page is its own file, <code>legal.html</code>. Files and their
+        auto-synthesised clean-URL rules are matched <em>before</em> your
+        <code>_redirects</code>, so <code>/legal</code> serves this page and the
+        <code>/*</code> SPA fallback never sees the request.</p>
+      <p>Mixing server-rendered pages into a SPA needs no extra configuration.</p>
+      <p><a href="/">Back to the app</a></p>
+    </main>
+  </body>
+</html>

--- a/examples/spa/icp.yaml
+++ b/examples/spa/icp.yaml
@@ -1,0 +1,21 @@
+networks:
+  - name: local
+    mode: managed
+    gateway:
+      port: 0
+
+canisters:
+  - name: frontend
+    build:
+      steps:
+        # The canister + sync-plugin wasms are built from this repo by `make wasm`,
+        # which writes them to the repo-root `dist/` directory.
+        - type: pre-built
+          path: ../../dist/canister.wasm
+
+    sync:
+      steps:
+        - type: plugin
+          path: ../../dist/plugin.wasm
+          dirs:
+            - dist # the site to serve (this example's own dist/)


### PR DESCRIPTION
## Why

"What's the necessary config for a SPA?" was answerable from the docs, but only barely: the one rule a client-side-routed app needs was a sub-bullet under **Not-found handling** in `routing.md`, reachable only by someone already thinking about 404s. Nothing in `overview.md`'s topic list or the README pointed at it, and there was no `examples/` project — so the SPA rewrite path had unit coverage but never ran end-to-end through the gateway, despite being the shape most exposed to the cert-tree interactions behind #114 and the earlier `/*`-vs-synth-rules 503.

## What

**`docs/routing.md`** — a real `## Single-page apps (SPA)` section: the `/* /index.html 200` rule, what declaring a root `/*` changes, what it doesn't, and the two app-side requirements. Linked from `overview.md`, `redirects.md`, and the README.

**`docs/headers.md`** — one documented pattern was wrong. `/` was described as matching "the home page", but patterns are matched against **asset keys** and no asset is keyed `/` (the root is a synthesized `/ → /index.html` rewrite), so such a block was silently inert. Corrects the list and adds *Patterns match files, not URLs*, covering the three places a URL and a file diverge: clean URLs, `200` rewrites reusing their target's headers, and `3xx` rules as the one exception that matches the rule's `from`. This matters for a SPA — a block written against a route like `/dashboard/*` matches no file and does nothing.

**`examples/spa/`** — a runnable no-build SPA: shell + vanilla `history.pushState` router, a static `legal.html` proving file precedence, and `/assets/* /404.html 404` above the catch-all so a stale bundle URL returns a real 404 instead of the HTML shell (the failure mode that turns a missing script into a MIME-type error and a `fetch()` for missing JSON into unparseable HTML).

**`crates/e2e/tests/spa.rs`** — 6 tests, all through the browser-style subdomain URL that forces the gateway's full v2 verification:

| Test | Covers |
|---|---|
| `spa_fallback_serves_shell_and_files_still_win` | shell at any depth; `/legal` wins; `/index`, `/legal/` still 307 |
| `root_catchall_suppresses_site_wide_404` | no branded default injected; unknown paths are client routes |
| `scoped_4xx_rule_shields_asset_subtree_from_the_catchall` | the snippet the docs recommend, verified |
| `shell_headers_reach_client_routes` | `Cache-Control` inherited through the rewrite at depth |
| `conditional_request_on_client_route_yields_certified_304` | **first e2e coverage for 8ef911f** |

Adds `http_fetch_subdomain_with_headers` to the harness for the 304 test; `http_fetch_subdomain` now delegates to it.

## Verification

```
6 tests (spa.rs) — passed, live replica
436 tests (workspace) — passed
cargo fmt --check, cargo clippy -p e2e --tests — clean
```

Every claim I put in prose is pinned by an assertion, including the surprising one: shipping a `404.html` under a SPA `/*` rule makes it reachable at `/404.html` *and* `/404` with a **200**, since nothing routes it as an error page. That's called out in the example's caveats.

## Notes for review

- No canister, plugin, or wire-type changes — docs, one new example, and tests only. No stable-state or recipe-schema surface is touched.
- The `_redirects` in the example carries two rules rather than the minimal one. The scoped `/assets/*` 404 is a deliberate inclusion: it's what a production SPA wants, and it demonstrates rule ordering concretely. Happy to strip it back to the single rule if you'd rather the example stay minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
