### PR TITLE
perf(sync): encode only what changed, and detect when the compressors move

### DIFF
--- a/.claude/rules/project-stage.md
+++ b/.claude/rules/project-stage.md
@@ -25,14 +25,16 @@ The compatibility contract is the one the release machinery already encodes — 
   fields (`dir`, `build`, `presync`, `metadata`) live in users' committed project
   files. Renaming or removing one breaks those projects — treat the recipe schema like
   any other released API.
-- **Asset-preparation parameters are frozen within a series.** The compressor
-  settings (gzip level, brotli quality/window) and `MAX_CHUNK_SIZE` may only change
-  on a series bump. Two things depend on it: the state-hash contract documented in
-  [`docs/verifying-contents.md`](../../docs/verifying-contents.md), and `sync-core`'s
-  skip-if-unchanged diff, which infers that a matching *uncompressed* hash implies
-  matching compressed encodings. Note the version lock does **not** protect this: it
-  pairs canister and plugin *code*, while a canister upgraded in place still holds
-  content written by an earlier build of the same series.
+- **Changing asset preparation is expensive, not unsafe.** The compressor settings
+  (gzip level, brotli quality/window), the compressor *implementations* (a `brotli`
+  or `flate2` bump, or a different `flate2` backend selected by feature
+  unification), and `MAX_CHUNK_SIZE` all change the bytes a sync stores. Nothing
+  needs freezing to stay correct: `asset-prep`'s compression canary detects a change
+  and makes the next sync re-prepare and re-upload every asset, and the
+  [`docs/verifying-contents.md`](../../docs/verifying-contents.md) contract is
+  already version-scoped. But each change costs every deployed canister one full
+  re-upload and invalidates previously-published state hashes, so make it
+  deliberately — ideally on a series bump — rather than as a drive-by `cargo update`.
 
 Two things do **not** change:
 

--- a/.claude/rules/project-stage.md
+++ b/.claude/rules/project-stage.md
@@ -25,6 +25,14 @@ The compatibility contract is the one the release machinery already encodes — 
   fields (`dir`, `build`, `presync`, `metadata`) live in users' committed project
   files. Renaming or removing one breaks those projects — treat the recipe schema like
   any other released API.
+- **Asset-preparation parameters are frozen within a series.** The compressor
+  settings (gzip level, brotli quality/window) and `MAX_CHUNK_SIZE` may only change
+  on a series bump. Two things depend on it: the state-hash contract documented in
+  [`docs/verifying-contents.md`](../../docs/verifying-contents.md), and `sync-core`'s
+  skip-if-unchanged diff, which infers that a matching *uncompressed* hash implies
+  matching compressed encodings. Note the version lock does **not** protect this: it
+  pairs canister and plugin *code*, while a canister upgraded in place still holds
+  content written by an earlier build of the same series.
 
 Two things do **not** change:
 

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -7,9 +7,11 @@ Tests are organized around these components. Each runs independently.
 - **Location**: inline `#[cfg(test)]` modules in each [`crates/asset-prep/src/`](../../crates/asset-prep/src/)`*.rs` file
 - **Run**: `cargo test -p asset-prep`
 
-`asset-prep` is the native, local-only crate that turns a `dist/` directory into prepared assets + redirect rules + the canonical `state-hash::Manifest` (shared by `sync-core` and the `state-hash-cli` verifier). It owns directory scanning, MIME detection, encoding selection, `_headers`/`_redirects` parsing, html-handling synthesis, the 404 convention, content chunking/hashing, and the `dist → Manifest` builder.
+`asset-prep` is the native, local-only crate that turns a `dist/` directory into prepared assets + redirect rules + the canonical `state-hash::Manifest` (shared by `sync-core` and the `state-hash-cli` verifier). It owns directory scanning, MIME detection, encoding selection, `_headers`/`_redirects` parsing, html-handling synthesis, the 404 convention, content chunking/hashing, the compression canary, and the `dist → Manifest` builder.
 
 **Add tests here when** you change how files are discovered, how MIME/encodings are chosen, how `_headers`/`_redirects` parse, how html-handling/404 rules are synthesised, or how content is chunked/hashed into a manifest.
+
+**Golden vectors live here** ([`content.rs`](../../crates/asset-prep/src/content.rs), [`canary.rs`](../../crates/asset-prep/src/canary.rs)): the compressors' output bytes and the canary fingerprint are pinned, because nothing in semver protects them and a drift silently costs every deployed canister a full re-upload. A failure there is a signal, not a nuisance — read the guidance above the vectors before updating them.
 
 ## State hash (`state-hash`)
 
@@ -40,7 +42,7 @@ Tests are organized around these components. Each runs independently.
 
 ## End-to-end (`e2e`)
 
-- **Location**: [`crates/e2e/`](../../crates/e2e/) — split across focused test files (e.g. `sync.rs`, `redirects.rs`, `etag.rs`, `streaming.rs`, `protection.rs`, `recipe.rs`)
+- **Location**: [`crates/e2e/`](../../crates/e2e/) — split across focused test files (e.g. `sync.rs`, `redirects.rs`, `etag.rs`, `streaming.rs`, `protection.rs`, `recipe.rs`, `state_hash.rs`)
 - **Run**: `cargo test -p e2e`
 
 E2E tests verify that the canister and plugin work correctly together through the `icp` CLI against a live local replica — deploy, re-sync, content update/deletion, serving, certification, redirects, headers, streaming/range, ETag, env cookie, upgrade persistence, access protection, and recipe resolution.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,10 +77,15 @@ jobs:
           exit 1
         env:
           ICP_CLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # `--locked` everywhere: the committed Cargo.lock is what pins the
+      # compressor builds whose output bytes end up in deployed canisters and in
+      # `state_hash` (see the golden vectors in `asset-prep`). Without it a stale
+      # lock is silently updated in CI, so a run could test different bytes than
+      # a developer did. With it, that fails the build instead.
       - name: Run tests
         run: | # nextest doesn't run doctests, so those stay on `cargo test --doc`
-          cargo nextest run --all-targets --no-fail-fast
-          cargo test --doc
+          cargo nextest run --locked --all-targets --no-fail-fast
+          cargo test --locked --doc
 
   fmt:
     name: cargo fmt
@@ -110,7 +115,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@150fca883cd4034361b621bd4e6a9d34e5143606 # v1.15.4
       - name: Run clippy
         run: |
-          cargo clippy --tests --benches --keep-going -- -D warnings
+          cargo clippy --locked --tests --benches --keep-going -- -D warnings
 
   benchmark:
     name: canbench

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,12 +1169,14 @@ name = "e2e"
 version = "0.3.1"
 dependencies = [
  "assert_cmd",
+ "asset-prep",
  "candid",
  "hex",
  "ic-agent",
  "recipe-gen",
  "reqwest",
  "serde",
+ "serde_bytes",
  "serde_json",
  "sync-agent",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,16 +20,22 @@ ic-http-certification = "3.0.3"
 ic-response-verification = "3.0.3"
 ic-representation-independent-hash = "3.0.3"
 
+# Compressors. Their output bytes are part of what a deployed canister stores and
+# what `state_hash` covers, and semver doesn't protect them: a compatible bump may
+# re-tune an encoder, and flate2's bytes also depend on which backend feature
+# unification selects. Left unpinned deliberately — a version pin can't see a
+# backend swap, and `asset-prep`'s golden vectors fail on any drift either way.
+brotli = "8.0.2"
+flate2 = "1.0"
+
 # Others
 anyhow = "1.0.103"
 assert_cmd = "2"
 base64 = "0.22.1"
-brotli = "8.0.2"
 canbench-rs = "0.6.0"
 candid = "0.10.18"
 candid_parser = "0.4.0"
 ciborium = "0.2.2"
-flate2 = "1.0"
 futures = "0.3"
 # Pinned to the versions icp-cli uses so recipe-gen's tests render recipes the
 # same way the real CLI does.

--- a/Makefile
+++ b/Makefile
@@ -40,13 +40,16 @@ wasm: canister plugin
 # Recipes are phony on purpose: cargo already does incremental freshness
 # tracking, so we always invoke it (cheap when nothing changed) and let it decide
 # whether a rebuild is needed, then copy the result into dist/.
+#
+# `--locked` because the shipped wasms embed the compressors whose output bytes
+# every deployed canister stores; a silently-updated lock would change them.
 canister:
-	cargo build -p canister --target $(CANISTER_TARGET) --profile $(CANISTER_PROFILE)
+	cargo build --locked -p canister --target $(CANISTER_TARGET) --profile $(CANISTER_PROFILE)
 	@mkdir -p $(DIST)
 	cp $(CANISTER_OUT) $(DIST)/canister.wasm
 
 plugin:
-	cargo build -p sync-plugin --target $(PLUGIN_TARGET) --profile $(PLUGIN_PROFILE)
+	cargo build --locked -p sync-plugin --target $(PLUGIN_TARGET) --profile $(PLUGIN_PROFILE)
 	@mkdir -p $(DIST)
 	cp $(PLUGIN_OUT) $(DIST)/plugin.wasm
 

--- a/certified-assets.did
+++ b/certified-assets.did
@@ -255,7 +255,11 @@ service: {
   upload_chunks: (UploadChunksArguments) -> (vec ChunkId);
 
   // Apply a group of operations. Perform all successfully, or reject.
-  execute_operations: (ExecuteOperationsArguments) -> ();
+  // The call flagged `is_final` finalizes the sync and returns the canonical
+  // state hash recomputed over the now-final state (the same value `state_hash`
+  // then reports); every other call returns `null`. Returning it here saves a
+  // finishing sync a second round trip.
+  execute_operations: (ExecuteOperationsArguments) -> (opt blob);
 
   // ───────── Authorization ─────────
   // A set of extra principals authorized to sync assets. Canister controllers

--- a/certified-assets.did
+++ b/certified-assets.did
@@ -141,6 +141,13 @@ type SetRedirectRulesArguments = record {
   rules: vec RedirectRule;
 };
 
+// Record the client's compression fingerprint over the assets this sync wrote.
+// Emitted only after a sync prepared every asset from scratch, so the stored
+// value describes the whole asset set. See `preparation_canary`.
+type SetPreparationCanaryArguments = record {
+  canary: blob;
+};
+
 // A single mutation applied during a sync.
 type Operation = variant {
   CreateAsset: CreateAssetArguments;
@@ -149,6 +156,7 @@ type Operation = variant {
   DeleteAsset: DeleteAssetArguments;
   SetAssetHeaders: SetAssetHeadersArguments;
   SetRedirectRules: SetRedirectRulesArguments;
+  SetPreparationCanary: SetPreparationCanaryArguments;
 };
 
 // ───────── Sync: session ─────────
@@ -253,6 +261,13 @@ service: {
   // position to reference the chunks in SetAssetContent operations. Because the
   // mapping is positional per call, uploads may be issued concurrently.
   upload_chunks: (UploadChunksArguments) -> (vec ChunkId);
+
+  // The compression fingerprint recorded by the client that last prepared every
+  // asset (32 bytes), or 32 zero bytes if none has. A syncing client compares it
+  // against its own to decide whether the stored compressed encodings are the
+  // ones its compressors would produce — if not, it re-prepares everything
+  // rather than trusting an unchanged uncompressed hash. Opaque to the canister.
+  preparation_canary: () -> (blob) query;
 
   // Apply a group of operations. Perform all successfully, or reject.
   // The call flagged `is_final` finalizes the sync and returns the canonical

--- a/crates/asset-prep/src/canary.rs
+++ b/crates/asset-prep/src/canary.rs
@@ -1,0 +1,173 @@
+//! A fingerprint of *how this build compresses*, used to make lazy encoding safe.
+//!
+//! `sync-core` skips encoding an asset whose uncompressed hash the canister
+//! already holds, inferring that the stored compressed encodings are the ones
+//! this build would produce. That inference is only sound while the compressors
+//! behave identically — and nothing guarantees they will. Compressed output is
+//! not part of a crate's API surface, so a semver-compatible `brotli` bump may
+//! legally re-tune its heuristics; `flate2`'s DEFLATE bytes depend on which
+//! backend feature unification selected; and neither is fixed by a
+//! specification (RFC 7932 and RFC 1951 define *decoders*).
+//!
+//! So instead of freezing those dependencies by convention and hoping nobody
+//! bumps them, the sync records what its compressors actually did. The canary is
+//! the hash of a frozen input compressed by *this* build; the canister stores the
+//! value written alongside its assets. A mismatch means "the compressors moved",
+//! and the sync falls back to re-preparing everything eagerly — which is exactly
+//! the pre-lazy-encoding behaviour, so the canister re-converges on its own.
+//!
+//! **This is detection, not proof.** Compressor behaviour is a function over all
+//! inputs and the canary samples it at one point, so a change that alters real
+//! bundles but not this input would slip through. [`INPUT`] is therefore built
+//! from deliberately varied material — long repeats, prose, structured text and
+//! incompressible noise — to exercise as many encoder decision paths as a few
+//! kilobytes can. What it catches reliably is what actually happens in practice:
+//! a version bump or a backend swap, both of which change essentially every
+//! output. A miss leaves the sync exactly where it would be with no canary at
+//! all, so this can only reduce the exposure, never add to it.
+//!
+//! [`INPUT`] is frozen: changing it changes every canister's canary and forces
+//! one full re-upload each. `input_is_frozen` guards it in CI.
+
+use sha2::{Digest, Sha256};
+use wire_types::Encoding;
+
+use crate::content::Content;
+use crate::prepare::MAX_CHUNK_SIZE;
+
+/// Size of the canary input. Big enough to cross the encoders' internal block
+/// boundaries and exercise several match strategies, small enough that
+/// compressing it costs single-digit milliseconds even at brotli q11.
+const INPUT_LEN: usize = 6 * 1024;
+
+/// The frozen canary input: four regions with deliberately different characters,
+/// so an encoder change that only fires on one kind of data still shows up.
+///
+/// 1. a long repeat (long-match / distance-cache paths),
+/// 2. prose-like text (static dictionary, literal entropy coding),
+/// 3. structured source-like text (mixed punctuation, short repeats),
+/// 4. high-entropy bytes (the no-match path, literal coding).
+fn input() -> Vec<u8> {
+    let mut out = Vec::with_capacity(INPUT_LEN);
+    let quarter = INPUT_LEN / 4;
+
+    while out.len() < quarter {
+        out.extend_from_slice(b"aaaaaaaaaaaaaaaabbbbbbbbbbbbbbbb");
+    }
+    out.truncate(quarter);
+
+    while out.len() < 2 * quarter {
+        out.extend_from_slice(
+            b"the quick brown fox jumps over the lazy dog while the sun sets slowly. ",
+        );
+    }
+    out.truncate(2 * quarter);
+
+    while out.len() < 3 * quarter {
+        out.extend_from_slice(
+            br#"{"key":"value","n":12345,"nested":{"a":[1,2,3],"b":null},"s":"text"}"#,
+        );
+    }
+    out.truncate(3 * quarter);
+
+    // A fixed xorshift64* stream: deterministic, no dependencies, and not
+    // meaningfully compressible. The constants are frozen along with the rest.
+    let mut state: u64 = 0x2545_F491_4F6C_DD1D;
+    while out.len() < INPUT_LEN {
+        state ^= state >> 12;
+        state ^= state << 25;
+        state ^= state >> 27;
+        out.extend_from_slice(&state.wrapping_mul(0x2545_F491_4F6C_DD1D).to_le_bytes());
+    }
+    out.truncate(INPUT_LEN);
+
+    out
+}
+
+/// This build's compression fingerprint: the hash of the frozen input under
+/// every compressor, folded together with the preparation constants that shape
+/// the stored form.
+///
+/// Deliberately routed through [`Content::encode`] — the same call real assets
+/// take — so any change to how we compress is reflected here, not just changes
+/// in the underlying crates. `MAX_CHUNK_SIZE` is folded in because it decides
+/// the chunk layout a skipped asset's manifest entry depends on.
+pub fn fingerprint() -> Result<[u8; 32], String> {
+    let content = Content {
+        data: input(),
+        media_type: mime::APPLICATION_OCTET_STREAM,
+    };
+
+    let mut hasher = Sha256::new();
+    hasher.update(b"certified-assets preparation canary v1");
+    hasher.update((MAX_CHUNK_SIZE as u64).to_le_bytes());
+    for encoding in [Encoding::Gzip, Encoding::Brotli] {
+        let encoded = content.encode(encoding)?;
+        hasher.update(encoding.label().as_bytes());
+        hasher.update((encoded.data.len() as u64).to_le_bytes());
+        hasher.update(Sha256::digest(&encoded.data));
+    }
+    Ok(hasher.finalize().into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The canary input is frozen: changing it invalidates every canister's
+    /// stored canary and forces a full re-upload on each. If this fails because
+    /// you meant to change it, bump the domain-separation string in
+    /// `fingerprint` too, and expect the re-uploads.
+    #[test]
+    fn input_is_frozen() {
+        let digest: [u8; 32] = Sha256::digest(input()).into();
+        assert_eq!(digest, INPUT_DIGEST, "canary input drifted");
+    }
+
+    /// SHA-256 of [`input`]. A golden value, not a derived one.
+    const INPUT_DIGEST: [u8; 32] = [
+        113, 10, 158, 48, 203, 255, 77, 203, 177, 240, 217, 133, 13, 80, 34, 205, 230, 236, 159,
+        173, 213, 2, 80, 98, 23, 34, 183, 131, 37, 107, 232, 145,
+    ];
+
+    #[test]
+    fn input_has_the_expected_shape() {
+        let input = input();
+        assert_eq!(input.len(), INPUT_LEN);
+        // The four regions must actually differ, or the varied-material argument
+        // in this module's docs is false.
+        let quarter = INPUT_LEN / 4;
+        let regions: Vec<&[u8]> = input.chunks(quarter).collect();
+        for (i, a) in regions.iter().enumerate() {
+            for b in regions.iter().skip(i + 1) {
+                assert_ne!(a, b, "canary regions must differ");
+            }
+        }
+    }
+
+    /// The whole point: the fingerprint is stable for a fixed build, so an
+    /// unchanged toolchain never triggers a spurious re-upload.
+    #[test]
+    fn fingerprint_is_deterministic() {
+        assert_eq!(fingerprint().unwrap(), fingerprint().unwrap());
+    }
+
+    /// ...and it is actually sensitive to compressor output, not just to the
+    /// constants folded in around it.
+    #[test]
+    fn fingerprint_tracks_compressed_bytes() {
+        let content = Content {
+            data: input(),
+            media_type: mime::APPLICATION_OCTET_STREAM,
+        };
+        let brotli = content.encode(Encoding::Brotli).unwrap();
+        let mut hasher = Sha256::new();
+        hasher.update(Sha256::digest(&brotli.data));
+        let independent: [u8; 32] = hasher.finalize().into();
+        // Not equal (different domain), but if brotli output were ignored the
+        // fingerprint could not depend on it at all — this asserts the encode
+        // path runs and produces bytes to hash.
+        assert!(!brotli.data.is_empty());
+        assert_ne!(fingerprint().unwrap(), independent);
+    }
+}

--- a/crates/asset-prep/src/canary.rs
+++ b/crates/asset-prep/src/canary.rs
@@ -152,6 +152,23 @@ mod tests {
         assert_eq!(fingerprint().unwrap(), fingerprint().unwrap());
     }
 
+    /// The fingerprint value itself, pinned — the CI half of the pair. A drift
+    /// here means the next deploy against any existing canister re-prepares and
+    /// re-uploads every asset, and every published state hash stops matching.
+    /// That is a legitimate thing to do, but not by accident: see the guidance
+    /// on the golden vectors in `content.rs`, which say *which* compressor moved.
+    #[test]
+    fn fingerprint_is_pinned() {
+        assert_eq!(
+            fingerprint().unwrap(),
+            [
+                245, 226, 54, 136, 144, 3, 34, 211, 233, 170, 231, 7, 236, 41, 240, 14, 77, 42,
+                176, 104, 40, 40, 127, 55, 244, 101, 113, 73, 212, 101, 239, 247,
+            ],
+            "compression fingerprint drifted"
+        );
+    }
+
     /// ...and it is actually sensitive to compressor output, not just to the
     /// constants folded in around it.
     #[test]

--- a/crates/asset-prep/src/content.rs
+++ b/crates/asset-prep/src/content.rs
@@ -8,7 +8,7 @@ use std::io::Write;
 use std::path::Path;
 use wire_types::Encoding;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Content {
     pub data: Vec<u8>,
     pub media_type: Mime,

--- a/crates/asset-prep/src/content.rs
+++ b/crates/asset-prep/src/content.rs
@@ -208,6 +208,71 @@ mod tests {
         assert_eq!(decompressed, original);
     }
 
+    // --- golden vectors ---
+    //
+    // The compressors' *output bytes*, pinned. Nothing in the compressor crates
+    // promises these: compressed output isn't part of a published API, so a
+    // semver-compatible bump may re-tune heuristics, and `flate2`'s DEFLATE
+    // bytes depend on which backend feature unification selected. RFC 1951 and
+    // RFC 7932 don't settle it either — they specify decoders.
+    //
+    // Changing these bytes is legal but expensive: every deployed canister
+    // re-uploads every compressible asset on its next sync, and every
+    // previously-published state hash stops matching. So this fires at PR time,
+    // before anything ships. The canary (`crate::canary`) covers the other
+    // window — a *deploy* whose compressors differ from the canister's,
+    // including builds CI never sees.
+    //
+    // **If this fails**: something changed how we compress. Check for a
+    // dependency bump (`brotli`, `flate2`, `miniz_oxide`), a `flate2` backend
+    // feature pulled in by another crate, or an edit to `encode` above. If the
+    // change is intended, update the goldens here and in
+    // `canary::fingerprint_is_pinned`, and expect the re-uploads.
+
+    /// A fixed input with enough structure for both compressors to make real
+    /// choices — a uniform run would survive almost any heuristic change.
+    fn golden_input() -> Vec<u8> {
+        let mut out = Vec::new();
+        for i in 0..256 {
+            out.extend_from_slice(
+                format!("line {i}: the quick brown fox jumps over it\n").as_bytes(),
+            );
+        }
+        out
+    }
+
+    fn digest_of(data: &[u8]) -> [u8; 32] {
+        Sha256::digest(data).into()
+    }
+
+    #[test]
+    fn gzip_output_is_pinned() {
+        let encoded = content(&golden_input()).encode(Encoding::Gzip).unwrap();
+        assert_eq!(encoded.data.len(), 730, "gzip output length drifted");
+        assert_eq!(
+            digest_of(&encoded.data),
+            [
+                53, 21, 232, 48, 211, 165, 56, 190, 113, 46, 204, 53, 164, 16, 135, 245, 158, 67,
+                167, 35, 218, 133, 12, 150, 25, 243, 215, 140, 95, 197, 49, 211,
+            ],
+            "gzip output bytes drifted"
+        );
+    }
+
+    #[test]
+    fn brotli_output_is_pinned() {
+        let encoded = content(&golden_input()).encode(Encoding::Brotli).unwrap();
+        assert_eq!(encoded.data.len(), 353, "brotli output length drifted");
+        assert_eq!(
+            digest_of(&encoded.data),
+            [
+                212, 217, 148, 219, 167, 195, 250, 83, 46, 171, 21, 217, 14, 42, 139, 156, 216,
+                254, 76, 185, 100, 97, 88, 156, 47, 215, 255, 52, 180, 230, 245, 5,
+            ],
+            "brotli output bytes drifted"
+        );
+    }
+
     // --- sha256 ---
 
     #[test]

--- a/crates/asset-prep/src/lib.rs
+++ b/crates/asset-prep/src/lib.rs
@@ -26,8 +26,8 @@ pub mod scan;
 
 mod prepare;
 pub use prepare::{
-    MAX_CHUNK_SIZE, PreparedAsset, PreparedChunk, PreparedEncoding, PreparedProject, manifest,
-    prepare_project, state_hash_for_dir,
+    MAX_CHUNK_SIZE, PlannedAsset, PreparedAsset, PreparedChunk, PreparedEncoding, PreparedProject,
+    ProjectPlan, manifest, plan_project, prepare_project, state_hash_for_dir,
 };
 
 /// Strips a Netlify-style trailing comment from a single line of a `_redirects`

--- a/crates/asset-prep/src/lib.rs
+++ b/crates/asset-prep/src/lib.rs
@@ -16,6 +16,7 @@
 //! canister's stored-state hash and the verifier's `dist/`-derived hash agree by
 //! construction (the cross-implementation test pins it).
 
+pub mod canary;
 pub mod content;
 pub mod glob;
 pub mod headers;
@@ -26,8 +27,8 @@ pub mod scan;
 
 mod prepare;
 pub use prepare::{
-    MAX_CHUNK_SIZE, PlannedAsset, PreparedAsset, PreparedChunk, PreparedEncoding, PreparedProject,
-    ProjectPlan, manifest, plan_project, prepare_project, state_hash_for_dir,
+    Compression, MAX_CHUNK_SIZE, PlannedAsset, PreparedAsset, PreparedChunk, PreparedEncoding,
+    PreparedProject, ProjectPlan, manifest, plan_project, prepare_project, state_hash_for_dir,
 };
 
 /// Strips a Netlify-style trailing comment from a single line of a `_redirects`

--- a/crates/asset-prep/src/prepare.rs
+++ b/crates/asset-prep/src/prepare.rs
@@ -2,11 +2,22 @@
 //! prepared assets + final redirect rules out — the exact state a finished sync
 //! leaves on the canister, minus the canister diff/upload.
 //!
-//! `sync-core` calls [`prepare_project`] and then diffs/uploads; the
-//! `state-hash-cli` verifier calls [`state_hash_for_dir`]. Both build the
-//! [`state_hash::Manifest`] from the *same* output here, so the canister's
-//! stored-state hash and the verifier's `dist/`-derived hash agree by
-//! construction.
+//! Preparation runs in **two phases**, because they cost wildly different
+//! amounts:
+//!
+//! 1. [`plan_project`] — scan, parse `_redirects`/`_headers`, synthesise rules,
+//!    load each asset and hash its *uncompressed* bytes. Cheap: a read and a
+//!    SHA-256 per file.
+//! 2. [`PlannedAsset::encode`] — gzip + brotli, chunk, hash. Expensive: brotli
+//!    q11 dominates a deploy's local cost.
+//!
+//! Splitting them lets `sync-core` encode only the assets the canister doesn't
+//! already hold (see its `sync()`); [`prepare_project`] is the eager wrapper
+//! that runs both phases over everything, which is what the `state-hash-cli`
+//! verifier needs — it has no canister to compare against and must do the full
+//! work. Both build the [`state_hash::Manifest`] from the *same* output here, so
+//! the canister's stored-state hash and the verifier's `dist/`-derived hash
+//! agree by construction.
 
 use sha2::{Digest, Sha256};
 use std::path::Path;
@@ -57,14 +68,6 @@ pub struct PreparedAsset {
     pub encodings: Vec<PreparedEncoding>,
 }
 
-impl PreparedAsset {
-    /// Whether any encoding will be stored as more than one chunk. Used to reject
-    /// oversized 4xx error-page targets (see `sync-core`).
-    pub fn is_multichunk(&self) -> bool {
-        self.encodings.iter().any(|e| e.chunks.len() > 1)
-    }
-}
-
 /// Everything a sync will install on the canister, derived purely from `dist/`:
 /// every asset (including the injected branded 404 when applicable) and the
 /// final redirect rules in match order, with 3xx rules' `_headers` already
@@ -75,14 +78,115 @@ pub struct PreparedProject {
     pub redirect_rules: Vec<RedirectRule>,
 }
 
-/// Prepares a project's `dist/` directory: scans assets, parses `_redirects` and
-/// `_headers`, synthesizes the html-handling and 404 rules, then loads, encodes,
-/// chunks, and hashes every asset's content and resolves its headers.
+/// One asset discovered in `dist/`: loaded, its media type and headers
+/// resolved, and its **uncompressed** bytes hashed — but not yet encoded.
+///
+/// Everything here is cheap to derive, and it is enough to decide whether an
+/// asset needs encoding at all: a caller that finds the canister already holds
+/// this exact content (same `content_type`, same `identity_sha256`, same
+/// encoding set) can skip [`encode`](PlannedAsset::encode) entirely, because
+/// every compressed encoding is a pure function of the identity bytes for a
+/// given build of this crate.
+#[derive(Clone, Debug)]
+pub struct PlannedAsset {
+    pub key: String,
+    /// The stored media type, after any `_headers` `Content-Type` override.
+    pub content_type: String,
+    /// Per-asset response headers resolved from `_headers`.
+    pub headers: Vec<(String, String)>,
+    /// SHA-256 of the uncompressed bytes — the identity encoding's
+    /// whole-encoding hash, and the identity the sync diff matches on.
+    pub identity_sha256: [u8; 32],
+    /// Length of the uncompressed bytes.
+    pub identity_len: u64,
+    /// Loaded bytes + resolved media type, consumed by `encode`.
+    content: Content,
+}
+
+impl PlannedAsset {
+    /// The encodings preparation will *attempt* for this asset: Identity plus,
+    /// for compressible media types, Gzip and Brotli. Whether a compressed
+    /// encoding is actually kept is decided by the size check in
+    /// [`encode`](PlannedAsset::encode).
+    pub fn attempted_encodings(&self) -> Vec<Encoding> {
+        encoders_for(&self.content.media_type)
+    }
+
+    /// Whether any encoding will be stored as more than one chunk. Used to
+    /// reject oversized 4xx error-page targets (see `sync-core`).
+    ///
+    /// Exact without encoding anything: a compressed encoding is only kept when
+    /// it is *smaller* than identity, so identity is the longest kept encoding
+    /// and its length alone decides this.
+    pub fn is_multichunk(&self) -> bool {
+        self.identity_len > MAX_CHUNK_SIZE as u64
+    }
+
+    /// The expensive half of preparation: encode each attempted encoding, keep a
+    /// compressed one only when it actually saves bytes, then chunk and hash
+    /// every kept encoding.
+    pub fn encode(self) -> Result<PreparedAsset, String> {
+        let mut encodings = Vec::new();
+        for encoding in encoders_for(&self.content.media_type) {
+            let encoded = self.content.encode(encoding)?;
+            // Identity is always kept. A compressed encoding is only kept if it
+            // actually saves bytes vs identity — otherwise storing it just wastes
+            // canister space.
+            if !encoding.is_identity() && encoded.data.len() >= self.content.data.len() {
+                continue;
+            }
+            encodings.push(prepare_encoding(encoding, encoded.data));
+        }
+
+        Ok(PreparedAsset {
+            key: self.key,
+            content_type: self.content_type,
+            headers: self.headers,
+            encodings,
+        })
+    }
+}
+
+/// The cheap half of [`prepare_project`]: every asset located, loaded and
+/// identified, plus the final redirect rules — with no encoding done yet.
+#[derive(Clone, Debug, Default)]
+pub struct ProjectPlan {
+    pub assets: Vec<PlannedAsset>,
+    pub redirect_rules: Vec<RedirectRule>,
+}
+
+/// Prepares a project's `dist/` directory in full: [`plan_project`] followed by
+/// [`PlannedAsset::encode`] on every asset.
 ///
 /// This is the canister-agnostic front half of a sync — no canister diff and no
-/// uploads. Errors carry file paths / line numbers so misconfigurations are
-/// caught before any canister round-trip.
+/// uploads. `sync-core` uses the two phases separately so it can skip encoding
+/// assets the canister already holds; the `state-hash-cli` verifier calls this,
+/// since reproducing the manifest requires every encoding.
 pub fn prepare_project(dir: &str) -> Result<PreparedProject, String> {
+    let ProjectPlan {
+        assets,
+        redirect_rules,
+    } = plan_project(dir)?;
+
+    let assets = assets
+        .into_iter()
+        .map(PlannedAsset::encode)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(PreparedProject {
+        assets,
+        redirect_rules,
+    })
+}
+
+/// Scans assets, parses `_redirects` and `_headers`, synthesizes the
+/// html-handling and 404 rules, then loads each asset's content, resolves its
+/// media type and headers, and hashes its uncompressed bytes.
+///
+/// Everything except encoding. Errors carry file paths / line numbers so
+/// misconfigurations are caught before any canister round-trip — and before any
+/// compression work.
+pub fn plan_project(dir: &str) -> Result<ProjectPlan, String> {
     let sources = scan::scan(dir)?;
     let user_rules = load_redirect_rules(dir)?;
 
@@ -108,10 +212,10 @@ pub fn prepare_project(dir: &str) -> Result<PreparedProject, String> {
 
     let mut assets = Vec::with_capacity(sources.len() + 1);
     for source in sources {
-        assets.push(prepare_asset(source, &header_rules)?);
+        assets.push(plan_asset(source, &header_rules)?);
     }
     if not_found_plan.inject_branded_asset {
-        assets.push(prepare_branded_404(&header_rules)?);
+        assets.push(plan_branded_404(&header_rules)?);
     }
 
     // 3xx rules synthesize their own response (no target asset to inherit
@@ -119,16 +223,13 @@ pub fn prepare_project(dir: &str) -> Result<PreparedProject, String> {
     // form a re-sync diffs cleanly against.
     let redirect_rules = resolve_3xx_rule_headers(&project_rules, &header_rules);
 
-    Ok(PreparedProject {
+    Ok(ProjectPlan {
         assets,
         redirect_rules,
     })
 }
 
-fn prepare_asset(
-    source: AssetSource,
-    header_rules: &[HeaderRule],
-) -> Result<PreparedAsset, String> {
+fn plan_asset(source: AssetSource, header_rules: &[HeaderRule]) -> Result<PlannedAsset, String> {
     let mut content = Content::load(&source.path)?;
     // Apply a per-glob `Content-Type` override from `_headers` before deciding
     // encoders or the stored media type (e.g. a `.did` declared `text/plain`
@@ -136,51 +237,38 @@ fn prepare_asset(
     if let Some(override_mime) = headers::content_type_for(&source.key, header_rules) {
         content.media_type = override_mime;
     }
-    prepare_content_asset(source.key, content, header_rules)
+    Ok(plan_content_asset(source.key, content, header_rules))
 }
 
 /// Builds the in-memory branded `/404.html` injected when a project ships no root
 /// `404.html`. Treated like any other HTML asset, but its bytes come from a
 /// constant and `_headers` content-type overrides are not applied (it is always
 /// `text/html`); its per-asset headers are still resolved from `_headers`.
-fn prepare_branded_404(header_rules: &[HeaderRule]) -> Result<PreparedAsset, String> {
+fn plan_branded_404(header_rules: &[HeaderRule]) -> Result<PlannedAsset, String> {
     let content = Content {
         data: not_found::DEFAULT_404_HTML.as_bytes().to_vec(),
         media_type: mime_guess::from_path(not_found::ROOT_404_KEY)
             .first()
             .unwrap_or(mime::TEXT_HTML),
     };
-    prepare_content_asset(not_found::ROOT_404_KEY.to_string(), content, header_rules)
+    Ok(plan_content_asset(
+        not_found::ROOT_404_KEY.to_string(),
+        content,
+        header_rules,
+    ))
 }
 
-/// Shared tail: pick encoders for `content`, encode each, keep a compressed
-/// encoding only when it actually saves bytes, then chunk and hash each kept
-/// encoding and resolve the asset's headers.
-fn prepare_content_asset(
-    key: String,
-    content: Content,
-    header_rules: &[HeaderRule],
-) -> Result<PreparedAsset, String> {
-    let encoders: Vec<Encoding> = encoders_for(&content.media_type);
-
-    let mut encodings = Vec::new();
-    for encoding in encoders {
-        let encoded = content.encode(encoding)?;
-        // Identity is always kept. A compressed encoding is only kept if it
-        // actually saves bytes vs identity — otherwise storing it just wastes
-        // canister space.
-        if !encoding.is_identity() && encoded.data.len() >= content.data.len() {
-            continue;
-        }
-        encodings.push(prepare_encoding(encoding, encoded.data));
-    }
-
-    Ok(PreparedAsset {
+/// Shared tail of the planning phase: hash the uncompressed bytes and resolve
+/// the asset's stored media type and headers.
+fn plan_content_asset(key: String, content: Content, header_rules: &[HeaderRule]) -> PlannedAsset {
+    PlannedAsset {
         content_type: content.media_type.to_string(),
         headers: headers::resolve(&key, header_rules),
+        identity_sha256: Sha256::digest(&content.data).into(),
+        identity_len: content.data.len() as u64,
         key,
-        encodings,
-    })
+        content,
+    }
 }
 
 /// Slices encoded bytes into ≤ `MAX_CHUNK_SIZE` chunks and hashes each — the
@@ -439,6 +527,72 @@ mod tests {
         assert_eq!(enc.chunks.len(), 1);
         assert_eq!(enc.chunks[0].len, 0);
         assert_eq!(enc.content_len, 0);
+    }
+
+    // --- two-phase planning ---
+
+    /// `PlannedAsset::is_multichunk` must agree with the encoded truth, since
+    /// `sync-core` trusts it for assets it never encodes. `.bin` keeps this fast:
+    /// octet-stream is incompressible, so no brotli pass runs on the big file.
+    #[test]
+    fn planned_multichunk_matches_encoded_chunk_count() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir, "big.bin", &vec![0u8; MAX_CHUNK_SIZE + 1]);
+        write(&dir, "small.bin", &vec![0u8; MAX_CHUNK_SIZE]);
+
+        let plan = plan_project(&dir_str(&dir)).unwrap();
+        for planned in plan.assets {
+            let expected = planned.is_multichunk();
+            let prepared = planned.encode().unwrap();
+            assert_eq!(
+                expected,
+                prepared.encodings.iter().any(|e| e.chunks.len() > 1),
+                "multichunk mismatch for {}",
+                prepared.key
+            );
+        }
+    }
+
+    /// The planning phase must resolve exactly the identity, media type and
+    /// headers the eager path produces — `sync-core` diffs on those without
+    /// encoding.
+    #[test]
+    fn plan_matches_prepare_without_encoding() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir, "index.html", b"<!DOCTYPE html><h1>hi</h1>");
+        write(&dir, "logo.png", &[0u8; 16]);
+        write(&dir, "_headers", b"/*\n  X-Frame-Options: DENY\n");
+
+        let plan = plan_project(&dir_str(&dir)).unwrap();
+        let prepared = prepare_project(&dir_str(&dir)).unwrap();
+        assert_eq!(plan.redirect_rules, prepared.redirect_rules);
+        assert_eq!(plan.assets.len(), prepared.assets.len());
+
+        for (planned, prepared) in plan.assets.iter().zip(&prepared.assets) {
+            assert_eq!(planned.key, prepared.key);
+            assert_eq!(planned.content_type, prepared.content_type);
+            assert_eq!(planned.headers, prepared.headers);
+
+            let identity = prepared
+                .encodings
+                .iter()
+                .find(|e| e.encoding == Encoding::Identity)
+                .expect("identity is always kept");
+            assert_eq!(planned.identity_sha256, identity.sha256);
+            assert_eq!(planned.identity_len, identity.content_len);
+
+            let mut attempted = planned.attempted_encodings();
+            attempted.sort_by_key(|e| e.label());
+            assert_eq!(attempted, encoders_for_sorted(&planned.content_type));
+        }
+    }
+
+    /// The encoding set `encoders_for` attempts, by media type, sorted — mirrors
+    /// the rule under test without reaching into `content`'s private state.
+    fn encoders_for_sorted(content_type: &str) -> Vec<Encoding> {
+        let mut encs = crate::content::encoders_for(&content_type.parse().unwrap());
+        encs.sort_by_key(|e| e.label());
+        encs
     }
 
     fn encodings_of(prepared: &PreparedProject, key: &str) -> Vec<Encoding> {

--- a/crates/asset-prep/src/prepare.rs
+++ b/crates/asset-prep/src/prepare.rs
@@ -78,6 +78,35 @@ pub struct PreparedProject {
     pub redirect_rules: Vec<RedirectRule>,
 }
 
+/// Whether a sync stores compressed encodings alongside the uncompressed copy.
+///
+/// A deploy-time choice, not a project setting: the same `dist/` is a valid
+/// input either way, and which one is right depends on what the deploy is *for*.
+/// The cost is asymmetric and lands on different people — compressing costs the
+/// deployer seconds, and not compressing costs every visitor a 5–6× larger text
+/// transfer for as long as the deploy is live.
+///
+/// [`Compression::Enabled`] is therefore the default everywhere, and the only
+/// mode `icp deploy` uses. [`Compression::Disabled`] exists for a platform that
+/// deploys throwaway builds nobody browses — a preview a developer opens once —
+/// where it removes the compression pass entirely *and* uploads ~20–25% fewer
+/// bytes, since only one copy of each asset goes over the wire.
+///
+/// Switching a canister between modes is safe and needs no bookkeeping: the diff
+/// derives the desired encoding set from the mode, so enabling compresses and
+/// uploads the missing encodings, and disabling unsets them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Compression {
+    /// Store gzip and brotli alongside identity, where they save bytes. The
+    /// canonical preparation, and the one `docs/verifying-contents.md` describes.
+    #[default]
+    Enabled,
+    /// Store only the uncompressed copy. No compressor runs, so preparation is
+    /// just reading and hashing — and nothing about the stored bytes depends on
+    /// a compressor implementation.
+    Disabled,
+}
+
 /// One asset discovered in `dist/`: loaded, its media type and headers
 /// resolved, and its **uncompressed** bytes hashed — but not yet encoded.
 ///
@@ -101,15 +130,20 @@ pub struct PlannedAsset {
     pub identity_len: u64,
     /// Loaded bytes + resolved media type, consumed by `encode`.
     content: Content,
+    /// Whether compressed encodings are wanted at all; fixed by the plan.
+    compression: Compression,
 }
 
 impl PlannedAsset {
     /// The encodings preparation will *attempt* for this asset: Identity plus,
-    /// for compressible media types, Gzip and Brotli. Whether a compressed
-    /// encoding is actually kept is decided by the size check in
-    /// [`encode`](PlannedAsset::encode).
+    /// for compressible media types under [`Compression::Enabled`], Gzip and
+    /// Brotli. Whether a compressed encoding is actually kept is decided by the
+    /// size check in [`encode`](PlannedAsset::encode).
     pub fn attempted_encodings(&self) -> Vec<Encoding> {
-        encoders_for(&self.content.media_type)
+        match self.compression {
+            Compression::Enabled => encoders_for(&self.content.media_type),
+            Compression::Disabled => vec![Encoding::Identity],
+        }
     }
 
     /// Whether any encoding will be stored as more than one chunk. Used to
@@ -127,7 +161,7 @@ impl PlannedAsset {
     /// every kept encoding.
     pub fn encode(self) -> Result<PreparedAsset, String> {
         let mut encodings = Vec::new();
-        for encoding in encoders_for(&self.content.media_type) {
+        for encoding in self.attempted_encodings() {
             let encoded = self.content.encode(encoding)?;
             // Identity is always kept. A compressed encoding is only kept if it
             // actually saves bytes vs identity — otherwise storing it just wastes
@@ -162,11 +196,11 @@ pub struct ProjectPlan {
 /// uploads. `sync-core` uses the two phases separately so it can skip encoding
 /// assets the canister already holds; the `state-hash-cli` verifier calls this,
 /// since reproducing the manifest requires every encoding.
-pub fn prepare_project(dir: &str) -> Result<PreparedProject, String> {
+pub fn prepare_project(dir: &str, compression: Compression) -> Result<PreparedProject, String> {
     let ProjectPlan {
         assets,
         redirect_rules,
-    } = plan_project(dir)?;
+    } = plan_project(dir, compression)?;
 
     let assets = assets
         .into_iter()
@@ -186,7 +220,7 @@ pub fn prepare_project(dir: &str) -> Result<PreparedProject, String> {
 /// Everything except encoding. Errors carry file paths / line numbers so
 /// misconfigurations are caught before any canister round-trip — and before any
 /// compression work.
-pub fn plan_project(dir: &str) -> Result<ProjectPlan, String> {
+pub fn plan_project(dir: &str, compression: Compression) -> Result<ProjectPlan, String> {
     let sources = scan::scan(dir)?;
     let user_rules = load_redirect_rules(dir)?;
 
@@ -212,10 +246,10 @@ pub fn plan_project(dir: &str) -> Result<ProjectPlan, String> {
 
     let mut assets = Vec::with_capacity(sources.len() + 1);
     for source in sources {
-        assets.push(plan_asset(source, &header_rules)?);
+        assets.push(plan_asset(source, &header_rules, compression)?);
     }
     if not_found_plan.inject_branded_asset {
-        assets.push(plan_branded_404(&header_rules)?);
+        assets.push(plan_branded_404(&header_rules, compression)?);
     }
 
     // 3xx rules synthesize their own response (no target asset to inherit
@@ -229,7 +263,11 @@ pub fn plan_project(dir: &str) -> Result<ProjectPlan, String> {
     })
 }
 
-fn plan_asset(source: AssetSource, header_rules: &[HeaderRule]) -> Result<PlannedAsset, String> {
+fn plan_asset(
+    source: AssetSource,
+    header_rules: &[HeaderRule],
+    compression: Compression,
+) -> Result<PlannedAsset, String> {
     let mut content = Content::load(&source.path)?;
     // Apply a per-glob `Content-Type` override from `_headers` before deciding
     // encoders or the stored media type (e.g. a `.did` declared `text/plain`
@@ -237,14 +275,22 @@ fn plan_asset(source: AssetSource, header_rules: &[HeaderRule]) -> Result<Planne
     if let Some(override_mime) = headers::content_type_for(&source.key, header_rules) {
         content.media_type = override_mime;
     }
-    Ok(plan_content_asset(source.key, content, header_rules))
+    Ok(plan_content_asset(
+        source.key,
+        content,
+        header_rules,
+        compression,
+    ))
 }
 
 /// Builds the in-memory branded `/404.html` injected when a project ships no root
 /// `404.html`. Treated like any other HTML asset, but its bytes come from a
 /// constant and `_headers` content-type overrides are not applied (it is always
 /// `text/html`); its per-asset headers are still resolved from `_headers`.
-fn plan_branded_404(header_rules: &[HeaderRule]) -> Result<PlannedAsset, String> {
+fn plan_branded_404(
+    header_rules: &[HeaderRule],
+    compression: Compression,
+) -> Result<PlannedAsset, String> {
     let content = Content {
         data: not_found::DEFAULT_404_HTML.as_bytes().to_vec(),
         media_type: mime_guess::from_path(not_found::ROOT_404_KEY)
@@ -255,12 +301,18 @@ fn plan_branded_404(header_rules: &[HeaderRule]) -> Result<PlannedAsset, String>
         not_found::ROOT_404_KEY.to_string(),
         content,
         header_rules,
+        compression,
     ))
 }
 
 /// Shared tail of the planning phase: hash the uncompressed bytes and resolve
 /// the asset's stored media type and headers.
-fn plan_content_asset(key: String, content: Content, header_rules: &[HeaderRule]) -> PlannedAsset {
+fn plan_content_asset(
+    key: String,
+    content: Content,
+    header_rules: &[HeaderRule],
+    compression: Compression,
+) -> PlannedAsset {
     PlannedAsset {
         content_type: content.media_type.to_string(),
         headers: headers::resolve(&key, header_rules),
@@ -268,6 +320,7 @@ fn plan_content_asset(key: String, content: Content, header_rules: &[HeaderRule]
         identity_len: content.data.len() as u64,
         key,
         content,
+        compression,
     }
 }
 
@@ -406,10 +459,17 @@ pub fn manifest(prepared: &PreparedProject) -> state_hash::Manifest {
     }
 }
 
-/// Convenience for the verifier: prepare `dir` and return its canonical state
-/// hash — the value to compare against a canister's `state_hash()`.
-pub fn state_hash_for_dir(dir: &str) -> Result<[u8; 32], String> {
-    let prepared = prepare_project(dir)?;
+/// Convenience for the verifier: prepare `dir` under `compression` and return the
+/// resulting canonical state hash — the value to compare against a canister's
+/// `state_hash()`.
+///
+/// The mode is an input because it changes the stored state, and therefore the
+/// hash: a canister deployed with [`Compression::Disabled`] holds only identity
+/// encodings and hashes differently from the same `dist/` deployed with
+/// compression on. A verifier who doesn't know which was used can compute both
+/// and see which matches.
+pub fn state_hash_for_dir(dir: &str, compression: Compression) -> Result<[u8; 32], String> {
+    let prepared = prepare_project(dir, compression)?;
     Ok(manifest(&prepared).digest())
 }
 
@@ -434,7 +494,7 @@ mod tests {
     #[test]
     fn empty_dir_injects_branded_404_and_catchall() {
         let dir = tempfile::tempdir().unwrap();
-        let prepared = prepare_project(&dir_str(&dir)).unwrap();
+        let prepared = prepare_project(&dir_str(&dir), Compression::Enabled).unwrap();
         // A project shipping no root `404.html` gets the branded default injected
         // plus the `/* -> /404.html 404` catch-all (see `not_found`).
         assert_eq!(prepared.assets.len(), 1);
@@ -451,7 +511,7 @@ mod tests {
     fn ships_own_404_is_not_overridden() {
         let dir = tempfile::tempdir().unwrap();
         write(&dir, "404.html", b"<h1>my 404</h1>");
-        let prepared = prepare_project(&dir_str(&dir)).unwrap();
+        let prepared = prepare_project(&dir_str(&dir), Compression::Enabled).unwrap();
         // The user's own /404.html is used; no branded duplicate.
         let count_404 = prepared
             .assets
@@ -471,7 +531,7 @@ mod tests {
     fn single_html_asset_is_prepared_with_identity_encoding() {
         let dir = tempfile::tempdir().unwrap();
         write(&dir, "index.html", b"<!DOCTYPE html><html></html>");
-        let prepared = prepare_project(&dir_str(&dir)).unwrap();
+        let prepared = prepare_project(&dir_str(&dir), Compression::Enabled).unwrap();
 
         let index = prepared
             .assets
@@ -498,7 +558,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         // A tiny PNG-typed file: not compressible, so identity only.
         write(&dir, "logo.png", &[0u8; 16]);
-        let prepared = prepare_project(&dir_str(&dir)).unwrap();
+        let prepared = prepare_project(&dir_str(&dir), Compression::Enabled).unwrap();
         let logo = prepared
             .assets
             .iter()
@@ -513,10 +573,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         write(&dir, "index.html", b"<!DOCTYPE html><h1>hi</h1>");
         write(&dir, "style.css", b"body{color:red}");
-        let prepared = prepare_project(&dir_str(&dir)).unwrap();
+        let prepared = prepare_project(&dir_str(&dir), Compression::Enabled).unwrap();
         // The convenience helper equals manifest(&prepared).digest().
         assert_eq!(
-            state_hash_for_dir(&dir_str(&dir)).unwrap(),
+            state_hash_for_dir(&dir_str(&dir), Compression::Enabled).unwrap(),
             manifest(&prepared).digest()
         );
     }
@@ -540,7 +600,7 @@ mod tests {
         write(&dir, "big.bin", &vec![0u8; MAX_CHUNK_SIZE + 1]);
         write(&dir, "small.bin", &vec![0u8; MAX_CHUNK_SIZE]);
 
-        let plan = plan_project(&dir_str(&dir)).unwrap();
+        let plan = plan_project(&dir_str(&dir), Compression::Enabled).unwrap();
         for planned in plan.assets {
             let expected = planned.is_multichunk();
             let prepared = planned.encode().unwrap();
@@ -553,6 +613,77 @@ mod tests {
         }
     }
 
+    // --- compression mode ---
+
+    #[test]
+    fn disabled_compression_keeps_only_identity() {
+        let dir = tempfile::tempdir().unwrap();
+        // Repetitive enough that both compressors would beat identity, so the
+        // absent encodings are a decision and not a size check.
+        write(&dir, "index.html", "<p>hello</p>".repeat(200).as_bytes());
+
+        let prepared = prepare_project(&dir_str(&dir), Compression::Disabled).unwrap();
+        for asset in &prepared.assets {
+            assert_eq!(
+                asset
+                    .encodings
+                    .iter()
+                    .map(|e| e.encoding)
+                    .collect::<Vec<_>>(),
+                vec![Encoding::Identity],
+                "{} should keep only identity",
+                asset.key
+            );
+        }
+
+        let compressed = prepare_project(&dir_str(&dir), Compression::Enabled).unwrap();
+        assert!(
+            compressed.assets.iter().any(|a| a.encodings.len() > 1),
+            "the same project with compression on must keep more encodings"
+        );
+    }
+
+    /// Identity content is identical either way — the mode only decides what is
+    /// stored *alongside* it. This is what makes flipping modes converge without
+    /// re-uploading unchanged uncompressed bytes.
+    #[test]
+    fn compression_mode_does_not_change_identity_content() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir, "index.html", b"<!DOCTYPE html><h1>hi</h1>");
+
+        let identity_of = |compression| {
+            let prepared = prepare_project(&dir_str(&dir), compression).unwrap();
+            prepared
+                .assets
+                .iter()
+                .map(|a| {
+                    let identity = a
+                        .encodings
+                        .iter()
+                        .find(|e| e.encoding == Encoding::Identity)
+                        .expect("identity is always kept");
+                    (a.key.clone(), identity.sha256, identity.content_len)
+                })
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(
+            identity_of(Compression::Enabled),
+            identity_of(Compression::Disabled)
+        );
+    }
+
+    /// The two modes must hash differently, or `state-hash`'s two-line output
+    /// couldn't tell a verifier which one a canister was deployed with.
+    #[test]
+    fn compression_mode_changes_the_state_hash() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir, "index.html", "<p>hello</p>".repeat(200).as_bytes());
+        assert_ne!(
+            state_hash_for_dir(&dir_str(&dir), Compression::Enabled).unwrap(),
+            state_hash_for_dir(&dir_str(&dir), Compression::Disabled).unwrap()
+        );
+    }
+
     /// The planning phase must resolve exactly the identity, media type and
     /// headers the eager path produces — `sync-core` diffs on those without
     /// encoding.
@@ -563,8 +694,8 @@ mod tests {
         write(&dir, "logo.png", &[0u8; 16]);
         write(&dir, "_headers", b"/*\n  X-Frame-Options: DENY\n");
 
-        let plan = plan_project(&dir_str(&dir)).unwrap();
-        let prepared = prepare_project(&dir_str(&dir)).unwrap();
+        let plan = plan_project(&dir_str(&dir), Compression::Enabled).unwrap();
+        let prepared = prepare_project(&dir_str(&dir), Compression::Enabled).unwrap();
         assert_eq!(plan.redirect_rules, prepared.redirect_rules);
         assert_eq!(plan.assets.len(), prepared.assets.len());
 
@@ -615,7 +746,7 @@ mod tests {
         // keep-if-smaller guard drops gzip (identity is always kept).
         let dir = tempfile::tempdir().unwrap();
         write(&dir, "blob.txt", &(0u8..=255u8).collect::<Vec<u8>>());
-        let prepared = prepare_project(&dir_str(&dir)).unwrap();
+        let prepared = prepare_project(&dir_str(&dir), Compression::Enabled).unwrap();
         let encs = encodings_of(&prepared, "/blob.txt");
         assert!(encs.contains(&Encoding::Identity), "identity always kept");
         assert!(
@@ -634,7 +765,7 @@ mod tests {
             "style.css",
             "body { color: red; }\n".repeat(500).as_bytes(),
         );
-        let prepared = prepare_project(&dir_str(&dir)).unwrap();
+        let prepared = prepare_project(&dir_str(&dir), Compression::Enabled).unwrap();
         assert_eq!(
             encodings_of(&prepared, "/style.css"),
             vec![Encoding::Identity, Encoding::Gzip, Encoding::Brotli]
@@ -654,7 +785,7 @@ mod tests {
             b"/old /new 301\n/page /target.html 200\n",
         );
         write(&dir, "_headers", b"/*\n  X-Robots-Tag: noindex\n");
-        let prepared = prepare_project(&dir_str(&dir)).unwrap();
+        let prepared = prepare_project(&dir_str(&dir), Compression::Enabled).unwrap();
 
         let r301 = prepared
             .redirect_rules
@@ -691,7 +822,7 @@ mod tests {
                 .as_ref(),
         );
 
-        let without = prepare_project(&dir_str(&dir)).unwrap();
+        let without = prepare_project(&dir_str(&dir), Compression::Enabled).unwrap();
         let did = without.assets.iter().find(|a| a.key == "/ic.did").unwrap();
         assert_eq!(did.content_type, "application/octet-stream");
         assert_eq!(encodings_of(&without, "/ic.did"), vec![Encoding::Identity]);
@@ -701,7 +832,7 @@ mod tests {
             "_headers",
             b"/*.did\n  Content-Type: text/plain; charset=utf-8\n",
         );
-        let with = prepare_project(&dir_str(&dir)).unwrap();
+        let with = prepare_project(&dir_str(&dir), Compression::Enabled).unwrap();
         let did = with.assets.iter().find(|a| a.key == "/ic.did").unwrap();
         assert_eq!(did.content_type, "text/plain; charset=utf-8");
         assert!(encodings_of(&with, "/ic.did").contains(&Encoding::Gzip));

--- a/crates/canister-core/src/benches.rs
+++ b/crates/canister-core/src/benches.rs
@@ -121,7 +121,8 @@ fn run_to_completion(state: &mut State, args: &ExecuteOperationsArguments, ctx: 
     let mut progress = ExecuteOperationsProgress::default();
     loop {
         match state.execute_operations(args, progress, ctx) {
-            ComputationStatus::Done(()) => return,
+            // `Done` carries the state hash on a final call; benches ignore it.
+            ComputationStatus::Done(_) => return,
             ComputationStatus::InProgress(p) => progress = p,
             ComputationStatus::Error(e) => panic!("execute_operations failed: {e}"),
         }

--- a/crates/canister-core/src/lib.rs
+++ b/crates/canister-core/src/lib.rs
@@ -128,6 +128,18 @@ pub fn state_hash() -> ByteBuf {
     STATE.with_borrow(|s| ByteBuf::from(s.cached_state_hash().to_vec()))
 }
 
+/// The compression fingerprint of the client that last prepared every asset (see
+/// `asset-prep::canary`), or 32 zero bytes if no client has recorded one.
+///
+/// A syncing client reads this to decide whether the compressed encodings stored
+/// here are the ones its own compressors would produce. If they differ — a
+/// dependency bump, a different DEFLATE backend, a different target — it must
+/// re-prepare every asset instead of trusting an unchanged uncompressed hash to
+/// imply unchanged compressed bytes. The canister assigns the bytes no meaning.
+pub fn preparation_canary() -> ByteBuf {
+    STATE.with_borrow(|s| ByteBuf::from(s.preparation_canary().to_vec()))
+}
+
 pub fn http_request(req: HttpRequest) -> HttpResponse {
     if req.certificate_version != Some(2) {
         trap("Only support V2 certification");

--- a/crates/canister-core/src/lib.rs
+++ b/crates/canister-core/src/lib.rs
@@ -83,18 +83,28 @@ pub fn upload_chunks(arg: UploadChunksArguments) -> Vec<ChunkId> {
     })
 }
 
-pub async fn execute_operations(arg: ExecuteOperationsArguments) {
+/// Applies a group of sync operations. The call flagged `is_final` finalizes the
+/// sync and returns the canonical state hash recomputed over the now-final
+/// state; every other call returns `None`. Reporting it here means a client
+/// never needs a second `state_hash()` round trip to learn what it just
+/// installed — though that value is *canister-reported*, so a third party
+/// verifying a deploy still reproduces the hash from source (see
+/// `docs/verifying-contents.md`).
+pub async fn execute_operations(arg: ExecuteOperationsArguments) -> Option<ByteBuf> {
     let system_context = SystemContext::new();
     let arg_ref = &arg;
 
-    loop_with_message_extension_until_completion(|progress| {
+    let state_hash = loop_with_message_extension_until_completion(|progress| {
         STATE.with_borrow_mut(|s| s.execute_operations(arg_ref, progress, &system_context))
     })
     .await
     .map_err(|msg| trap(&msg))
-    .ok();
+    .ok()
+    .flatten();
 
     STATE.with_borrow_mut(|s| certified_data_set(s.root_hash()));
+
+    state_hash.map(|hash| ByteBuf::from(hash.to_vec()))
 }
 
 pub fn get_asset_details(start_after: Option<String>) -> Vec<AssetDetails> {

--- a/crates/canister-core/src/state/hashing.rs
+++ b/crates/canister-core/src/state/hashing.rs
@@ -16,6 +16,18 @@ impl State {
         self.store.cached_state_hash()
     }
 
+    /// The compression fingerprint of the client that last prepared every asset
+    /// (see `asset-prep::canary`), or `[0; 32]` if unknown. Read by the public
+    /// `preparation_canary` endpoint; the canister itself never interprets it.
+    pub fn preparation_canary(&self) -> [u8; 32] {
+        self.store.preparation_canary()
+    }
+
+    /// Records a syncing client's compression fingerprint.
+    pub(super) fn set_preparation_canary(&mut self, canary: [u8; 32]) {
+        self.store.set_preparation_canary(canary);
+    }
+
     /// Number of assets the staged hash will fold in — the `asset_count` written
     /// into the digest header (see `state_hash::StateHasher::begin`).
     pub(super) fn state_hash_asset_count(&self) -> u64 {

--- a/crates/canister-core/src/state/sync.rs
+++ b/crates/canister-core/src/state/sync.rs
@@ -197,6 +197,16 @@ impl State {
                         Ok(())
                     }
                     Operation::SetAssetHeaders(arg) => self.set_asset_headers(arg.clone()),
+                    Operation::SetPreparationCanary(arg) => match arg.canary.as_ref().try_into() {
+                        Ok(canary) => {
+                            self.set_preparation_canary(canary);
+                            Ok(())
+                        }
+                        Err(_) => Err(format!(
+                            "preparation canary must be 32 bytes, got {}",
+                            arg.canary.len()
+                        )),
+                    },
                     Operation::SetRedirectRules(arg) => {
                         // Validate every rule before mutating state so a single
                         // bad rule fails the whole op with no partial update.

--- a/crates/canister-core/src/state/sync.rs
+++ b/crates/canister-core/src/state/sync.rs
@@ -98,12 +98,15 @@ impl State {
         Ok(ids)
     }
 
+    /// Completes with the canonical state hash recomputed over the now-final
+    /// state when `arg.is_final`, and `None` otherwise — so the finalizing call
+    /// hands the client its hash without a second round trip.
     pub fn execute_operations(
         &mut self,
         arg: &ExecuteOperationsArguments,
         progress: ExecuteOperationsProgress,
         system_context: &SystemContext,
-    ) -> ComputationStatus<(), ExecuteOperationsProgress, String> {
+    ) -> ComputationStatus<Option<[u8; 32]>, ExecuteOperationsProgress, String> {
         match progress {
             ExecuteOperationsProgress::Starting => {
                 // Reject calls that don't belong to the active sync, and reset
@@ -144,7 +147,7 @@ impl State {
                         );
                     }
 
-                    return ComputationStatus::Done(());
+                    return ComputationStatus::Done(None);
                 }
 
                 let op = &arg.operations[operation_index];
@@ -249,10 +252,12 @@ impl State {
                         },
                     );
                 }
-                // Keyspace exhausted: fold the redirect rules, finalize, cache.
+                // Keyspace exhausted: fold the redirect rules, finalize, cache,
+                // and hand the hash back to the client that finalized the sync.
                 self.fold_redirect_rules(&mut hasher);
-                self.cache_state_hash(hasher.finish());
-                ComputationStatus::Done(())
+                let hash = hasher.finish();
+                self.cache_state_hash(hash);
+                ComputationStatus::Done(Some(hash))
             }
         }
     }

--- a/crates/canister-core/src/state/tests.rs
+++ b/crates/canister-core/src/state/tests.rs
@@ -859,14 +859,17 @@ mod hashing {
         write("_redirects", b"/old /new 301\n");
 
         let dir_str = dir.path().to_str().unwrap();
-        let prepared = asset_prep::prepare_project(dir_str).expect("prepare project");
+        let prepared = asset_prep::prepare_project(dir_str, asset_prep::Compression::Enabled)
+            .expect("prepare project");
 
         let mut state = State::default();
         let ctx = mock_system_context();
         apply_prepared(&mut state, &ctx, &prepared);
 
         let canister_hash = state.cached_state_hash();
-        let verifier_hash = asset_prep::state_hash_for_dir(dir_str).expect("verifier hash");
+        let verifier_hash =
+            asset_prep::state_hash_for_dir(dir_str, asset_prep::Compression::Enabled)
+                .expect("verifier hash");
         assert_eq!(
             hex::encode(canister_hash),
             hex::encode(verifier_hash),

--- a/crates/canister-core/src/state/tests.rs
+++ b/crates/canister-core/src/state/tests.rs
@@ -2254,6 +2254,7 @@ mod redirect_rules {
                 &system_context,
             )
         })
+        .map(|_| ())
     }
 
     fn sample_rules() -> Vec<RedirectRule> {

--- a/crates/canister-core/src/state/tests.rs
+++ b/crates/canister-core/src/state/tests.rs
@@ -17,7 +17,8 @@ use std::str::FromStr;
 use std::time::{SystemTime, UNIX_EPOCH};
 use wire_types::{
     CreateAssetArguments, DeleteAssetArguments, Encoding, ExecuteOperationsArguments, Operation,
-    SessionId, SetAssetContentArguments, SetAssetHeadersArguments, StartSyncResult,
+    SessionId, SetAssetContentArguments, SetAssetHeadersArguments, SetPreparationCanaryArguments,
+    StartSyncResult,
 };
 
 // from ic-response-verification tests
@@ -777,6 +778,67 @@ mod hashing {
         // a recompute (no sync runs during post_upgrade_rebuild).
         let restored = upgrade(state, memory);
         assert_eq!(restored.cached_state_hash(), before);
+    }
+
+    /// The recorded compression fingerprint must outlive an upgrade, or every
+    /// patch release would look like a compressor change to the next sync and
+    /// re-upload every asset. Unset until a client records one.
+    #[test]
+    fn preparation_canary_survives_upgrade() {
+        let memory = DefaultMemoryImpl::default();
+        let mut state = State::new(memory.clone());
+        let ctx = mock_system_context();
+
+        assert_eq!(
+            state.preparation_canary(),
+            [0u8; 32],
+            "a canister nobody has synced reports the unknown canary"
+        );
+
+        let canary = [7u8; 32];
+        let session_id = start_session(&mut state, &ctx);
+        execute_all(
+            &mut state,
+            session_id,
+            vec![Operation::SetPreparationCanary(
+                SetPreparationCanaryArguments {
+                    canary: ByteBuf::from(canary.to_vec()),
+                },
+            )],
+            &ctx,
+        );
+        assert_eq!(state.preparation_canary(), canary);
+
+        let restored = upgrade(state, memory);
+        assert_eq!(restored.preparation_canary(), canary);
+    }
+
+    /// A malformed canary is rejected rather than silently truncated — a wrong
+    /// value here would make a client trust encodings it shouldn't.
+    #[test]
+    fn preparation_canary_rejects_wrong_length() {
+        let mut state = State::new(DefaultMemoryImpl::default());
+        let ctx = mock_system_context();
+        let session_id = start_session(&mut state, &ctx);
+
+        let err = run_computation_until_completion(|progress| {
+            state.execute_operations(
+                &ExecuteOperationsArguments {
+                    session_id,
+                    operations: vec![Operation::SetPreparationCanary(
+                        SetPreparationCanaryArguments {
+                            canary: ByteBuf::from(vec![1u8; 16]),
+                        },
+                    )],
+                    is_final: true,
+                },
+                progress,
+                &ctx,
+            )
+        })
+        .expect_err("a 16-byte canary must be rejected");
+        assert!(err.contains("32 bytes"), "got: {err}");
+        assert_eq!(state.preparation_canary(), [0u8; 32]);
     }
 
     /// Drives an `asset-prep` `PreparedProject` into `state` the way a real sync

--- a/crates/canister-core/src/store/mod.rs
+++ b/crates/canister-core/src/store/mod.rs
@@ -89,6 +89,12 @@ const NEXT_CONTENT_ID_MEMORY: MemoryId = MemoryId::new(31);
 /// final sync. Its own cell so the frequent counter bumps don't touch it.
 const STATE_HASH_MEMORY: MemoryId = MemoryId::new(40);
 
+// 50–59 — provenance about the client that wrote the current state.
+/// The compression fingerprint reported by the last client that prepared every
+/// asset (`PreparationCanary`). A region unused by earlier builds, so a canister
+/// upgraded in place reads the default — see the field's doc.
+const PREPARATION_CANARY_MEMORY: MemoryId = MemoryId::new(50);
+
 // Two newtypes with no domain module of their own: they exist only to give a
 // storage-internal value a `Storable` impl (the orphan rule forbids implementing
 // it on the bare `BTreeSet`/`[u8; 32]`), so they live here in the storage layer.
@@ -104,6 +110,16 @@ pub struct AuthorizedSet(pub BTreeSet<Principal>);
 /// first sync. Its own fixed 32-byte cell.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct StateHash(pub [u8; 32]);
+
+/// The syncing client's **compression fingerprint** (see `asset-prep::canary`),
+/// recorded by the last sync that prepared every asset from scratch. The
+/// canister attaches no meaning to the bytes; it stores and reports them so a
+/// client can tell whether the compressed encodings on this canister are the
+/// ones its own compressors would produce. `[0; 32]` means unknown — the value a
+/// canister upgraded from a build without this cell reports, which makes clients
+/// re-prepare everything and write a real one. Its own fixed 32-byte cell.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct PreparationCanary(pub [u8; 32]);
 
 /// Per-chunk certification data — the value type of the `chunk_certs` map below,
 /// keyed by the same [`ContentChunkKey`] as the content chunk (that key lives with
@@ -170,6 +186,13 @@ pub struct Store {
     /// and returned verbatim by the public `state_hash` endpoint. `[0; 32]`
     /// until the first sync finalizes.
     state_hash: StableCell<StateHash, Mem>,
+
+    // Provenance.
+    /// The syncing client's compression fingerprint, as of the last sync that
+    /// prepared every asset. `[0; 32]` means "unknown" — which is what a
+    /// canister upgraded from a build without this cell reports, and what makes
+    /// a client fall back to preparing everything.
+    preparation_canary: StableCell<PreparationCanary, Mem>,
 }
 
 impl Store {
@@ -203,6 +226,11 @@ impl Store {
             next_content_id: StableCell::init(mm.get(NEXT_CONTENT_ID_MEMORY), 0),
             // Derived cache.
             state_hash: StableCell::init(mm.get(STATE_HASH_MEMORY), StateHash::default()),
+            // Provenance.
+            preparation_canary: StableCell::init(
+                mm.get(PREPARATION_CANARY_MEMORY),
+                PreparationCanary::default(),
+            ),
         }
     }
 
@@ -372,6 +400,18 @@ impl Store {
         self.state_hash.set(StateHash(hash));
     }
 
+    /// The compression fingerprint recorded by the last client that prepared
+    /// every asset; `[0; 32]` if none ever did (fresh canister, or one upgraded
+    /// from a build predating this cell).
+    pub fn preparation_canary(&self) -> [u8; 32] {
+        self.preparation_canary.get().0
+    }
+
+    /// Records the syncing client's compression fingerprint.
+    pub fn set_preparation_canary(&mut self, canary: [u8; 32]) {
+        self.preparation_canary.set(PreparationCanary(canary));
+    }
+
     // ---- redirect rules ----
 
     /// The redirect-rule list in match order. Returns the `StableCell`'s cached
@@ -484,6 +524,29 @@ impl Storable for StateHash {
         let mut hash = [0u8; 32];
         hash.copy_from_slice(&bytes);
         Self(hash)
+    }
+
+    const BOUND: Bound = Bound::Bounded {
+        max_size: 32,
+        is_fixed_size: true,
+    };
+}
+
+// Same fixed 32-byte encoding as `StateHash`; kept as a distinct type so the two
+// cells can never be swapped by mistake.
+impl Storable for PreparationCanary {
+    fn to_bytes(&self) -> Cow<'_, [u8]> {
+        Cow::Owned(self.0.to_vec())
+    }
+
+    fn into_bytes(self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+
+    fn from_bytes(bytes: Cow<[u8]>) -> Self {
+        let mut canary = [0u8; 32];
+        canary.copy_from_slice(&bytes);
+        Self(canary)
     }
 
     const BOUND: Bound = Bound::Bounded {

--- a/crates/canister/src/lib.rs
+++ b/crates/canister/src/lib.rs
@@ -94,8 +94,11 @@ fn upload_chunks(arg: UploadChunksArguments) -> Vec<ChunkId> {
     canister_core::upload_chunks(arg)
 }
 
+// Returns the canonical state hash on the call flagged `is_final` (`None`
+// otherwise), so a finishing sync learns what it installed without a second
+// round trip. Canister-reported: a self-consistency read, not verification.
 #[update(guard = "guard_can_sync")]
-async fn execute_operations(arg: ExecuteOperationsArguments) {
+async fn execute_operations(arg: ExecuteOperationsArguments) -> Option<ByteBuf> {
     canister_core::execute_operations(arg).await
 }
 

--- a/crates/canister/src/lib.rs
+++ b/crates/canister/src/lib.rs
@@ -77,6 +77,17 @@ fn state_hash() -> ByteBuf {
     canister_core::state_hash()
 }
 
+// The compression fingerprint of the client that last prepared every asset (see
+// `asset-prep::canary`), or 32 zero bytes if none has. A syncing client reads it
+// to decide whether it may trust unchanged uncompressed hashes to imply
+// unchanged compressed bytes. A **query**: it only steers the client's own local
+// work, so a stale read costs at worst some redundant preparation, never
+// incorrect state — unlike `state_hash`, which a third party trusts.
+#[query]
+fn preparation_canary() -> ByteBuf {
+    canister_core::preparation_canary()
+}
+
 // Whether the calling identity may sync assets (authorized or a controller).
 // Lets a client check access up front instead of discovering it mid-sync.
 #[query]

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 publish.workspace = true
 
 [dependencies]
+asset-prep = { path = "../asset-prep" }
 recipe-gen = { path = "../recipe-gen" }
 wire-types = { path = "../wire-types" }
 assert_cmd.workspace = true
@@ -15,6 +16,7 @@ candid.workspace = true
 hex.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
 serde.workspace = true
+serde_bytes.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -314,6 +314,32 @@ pub fn http_post_form(
         .unwrap_or_else(|e| panic!("POST {url} failed: {e}"))
 }
 
+/// Call `state_hash` on the `frontend` canister and return the 32-byte digest it
+/// reports over its stored state.
+pub fn canister_state_hash(project: &Path) -> [u8; 32] {
+    let stdout = icp_cmd(project)
+        .args([
+            "canister",
+            "call",
+            "frontend",
+            "state_hash",
+            "()",
+            "-o",
+            "hex",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    let hex_str = String::from_utf8_lossy(&stdout);
+    let bytes = hex::decode(hex_str.trim()).expect("failed to decode hex response");
+    let (hash,) = candid::decode_args::<(serde_bytes::ByteBuf,)>(&bytes)
+        .expect("failed to decode candid response");
+    <[u8; 32]>::try_from(hash.as_ref()).expect("state_hash must be 32 bytes")
+}
+
 /// Call `get_asset_details` on the `frontend` canister and return all asset details.
 pub fn list_assets(project: &Path) -> Vec<AssetDetails> {
     let stdout = icp_cmd(project)

--- a/crates/e2e/tests/latency.rs
+++ b/crates/e2e/tests/latency.rs
@@ -22,16 +22,33 @@
 //! (The future plugin bench will do the same, sweeping the icp-cli runtime's
 //! batch-import cap over {1, N}.)
 //!
-//! # Why this is safe to gate on
+//! # Why this is safe to gate on, and how the margin was chosen
 //!
 //! It asserts a *ratio* between two runs done back-to-back in one test, on one
-//! machine, so machine-to-machine speed and CI load cancel out. The dominant
-//! cost — the artificial delay — is a replica-side wait, not client compute, so
-//! it doesn't shrink under CPU contention (which would only inflate the serial
-//! run more, never the concurrent one). The assertion keeps a wide margin below
-//! the observed ratio, so it trips on a real regression — uploads silently
-//! serialized — not on noise. If it ever does flake on a runner, re-add
-//! `#[ignore]` rather than widening the margin into meaninglessness.
+//! machine. That was expected to cancel out machine speed and CI load; measured,
+//! it does not. Observed for identical code:
+//!
+//! | Machine | serial | concurrent | ratio |
+//! |---|---|---|---|
+//! | local (Apple silicon) | 9.81s | 3.79s | 2.59× |
+//! | CI macos-15 | 12.71s | 9.01s | 1.41× |
+//!
+//! The delay *is* a replica-side wait that survives CPU contention, but it is
+//! not the whole cost: the concurrent run also pays real transfer and polling
+//! for ~13 MB, and on a loaded runner that floor dominates (9s of the macOS
+//! run). So the ratio itself is machine-dependent, and a threshold inside the
+//! observed spread flakes by construction — an earlier 1.5× did.
+//!
+//! Hence **1.2×**, which is chosen against the failure this guards: uploads
+//! silently serialized drives the ratio to ~1.0, so a 20% floor still trips on
+//! it while clearing the worst observed run by a comfortable margin. Raising
+//! `artificial-delay-ms` was considered instead and rejected — it lifts the mean
+//! without touching the macOS transfer floor, and taxes every run. Shrinking the
+//! payload isn't available either: each file must exceed half the 1.9 MB chunk
+//! budget or files share upload calls and the call count collapses.
+//!
+//! If it flakes again at 1.2×, re-add `#[ignore]` rather than widening further —
+//! below ~1.2 this stops distinguishing "concurrent" from "serial" at all.
 //!
 //! # Running
 //!
@@ -157,14 +174,14 @@ fn native_transport_concurrency_speedup() {
         "\nserial (1) {serial:?}  vs  concurrent ({MAX_IN_FLIGHT}) {concurrent:?}  →  {speedup:.2}× faster"
     );
 
-    // Concurrency should be well clear of serial. We don't assert a specific
-    // multiple — the fixed sequential calls (start_sync, execute_operations) and
-    // real transfer/polling put a floor on the concurrent run, so the local
-    // ratio is a "trend", not the full round-trip speedup (that shows on
-    // mainnet). Require a solid margin so the guard trips on a real regression
-    // (e.g. uploads accidentally serialized) but not on machine-to-machine noise.
+    // Concurrency should be clear of serial. We don't assert a specific multiple
+    // — the fixed sequential calls (start_sync, execute_operations) and real
+    // transfer/polling put a floor on the concurrent run, so the local ratio is a
+    // "trend", not the full round-trip speedup (that shows on mainnet). The 1.2×
+    // floor is measured, not guessed: see "how the margin was chosen" above
+    // before changing it.
     assert!(
-        serial.as_secs_f64() > concurrent.as_secs_f64() * 1.5,
+        serial.as_secs_f64() > concurrent.as_secs_f64() * 1.2,
         "expected concurrent uploads clearly faster than serial, \
          got serial={serial:?} concurrent={concurrent:?}"
     );

--- a/crates/e2e/tests/latency.rs
+++ b/crates/e2e/tests/latency.rs
@@ -93,9 +93,17 @@ async fn sync_timed(
         .await
         .expect("fetch_root_key (local replica)");
     let started = Instant::now();
-    let summary = sync(Arc::new(agent), canister, dir, SyncOpts { max_in_flight })
-        .await
-        .expect("sync failed");
+    let summary = sync(
+        Arc::new(agent),
+        canister,
+        dir,
+        SyncOpts {
+            max_in_flight,
+            ..SyncOpts::default()
+        },
+    )
+    .await
+    .expect("sync failed");
     let elapsed = started.elapsed();
     println!("  max_in_flight={max_in_flight}: {elapsed:?}\n  {summary}");
     elapsed

--- a/crates/e2e/tests/state_hash.rs
+++ b/crates/e2e/tests/state_hash.rs
@@ -1,0 +1,68 @@
+//! The reproducible-frontend claim, end to end.
+//!
+//! [`docs/verifying-contents.md`](../../../docs/verifying-contents.md) tells a
+//! verifier to reproduce `dist/` from source, run the `state-hash` tool on it,
+//! and compare against the canister's `state_hash()`. Every other test covers
+//! one side or the other; this covers the equality itself.
+//!
+//! It is the only test where the two sides are built for *different targets*.
+//! The plugin prepared and uploaded these assets compiled to `wasm32-wasip2` and
+//! running under wasmtime; `asset-prep` here is compiled natively for the host.
+//! Both hash the same `dist/` through the same code, so a divergence would mean
+//! the compressors disagree across targets — which would silently break
+//! verification for every deployed canister while leaving every other test green.
+
+use e2e::{LocalNetwork, canister_state_hash, icp_cmd, setup_example};
+
+/// Deploy, then verify exactly the way the docs tell a third party to.
+#[test]
+fn verifier_hash_matches_canister_after_deploy() {
+    let tmp = setup_example("static-site");
+    let project = tmp.path();
+    let _network = LocalNetwork::start(project);
+
+    icp_cmd(project).arg("deploy").assert().success();
+
+    let dist = project.join("dist");
+    let dist = dist.to_str().expect("dist path is utf-8");
+
+    // `icp deploy` always uses the canonical (compressed) preparation.
+    let verifier_hash = asset_prep::state_hash_for_dir(dist, asset_prep::Compression::Enabled)
+        .expect("compute state hash from dist");
+
+    assert_eq!(
+        hex::encode(canister_state_hash(project)),
+        hex::encode(verifier_hash),
+        "the canister's state hash must equal the one a verifier computes from the same dist/"
+    );
+}
+
+/// The same equality must survive an ordinary edit-and-redeploy — the path where
+/// the plugin skips encoding for assets the canister already holds. If a skip
+/// ever left a stale encoding behind, the canister's hash would drift from the
+/// verifier's while every serving test still passed.
+#[test]
+fn verifier_hash_still_matches_after_a_partial_redeploy() {
+    let tmp = setup_example("static-site");
+    let project = tmp.path();
+    let _network = LocalNetwork::start(project);
+
+    icp_cmd(project).arg("deploy").assert().success();
+
+    let index = project.join("dist").join("index.html");
+    let edited = std::fs::read_to_string(&index).expect("read index.html") + "\n<!-- edited -->\n";
+    std::fs::write(&index, edited).expect("write index.html");
+
+    icp_cmd(project).arg("deploy").assert().success();
+
+    let dist = project.join("dist");
+    let dist = dist.to_str().expect("dist path is utf-8");
+    let verifier_hash = asset_prep::state_hash_for_dir(dist, asset_prep::Compression::Enabled)
+        .expect("compute state hash from dist");
+
+    assert_eq!(
+        hex::encode(canister_state_hash(project)),
+        hex::encode(verifier_hash),
+        "a re-deploy that re-encoded only the changed asset must still leave a canonical state"
+    );
+}

--- a/crates/e2e/tests/sync.rs
+++ b/crates/e2e/tests/sync.rs
@@ -3,20 +3,35 @@ use e2e::{AssetDetails, Encoding, LocalNetwork, icp_cmd, list_assets, setup_exam
 use std::fs;
 
 /// Deploy the `static-site` example to a local replica and verify that
-/// `/index.html` appears in the canister's asset list.
+/// `/index.html` appears in the canister's asset list, and that the finalizing
+/// call handed the state hash back for the summary.
 #[test]
 fn basic_deploy() {
     let tmp = setup_example("static-site");
     let project = tmp.path();
     let _network = LocalNetwork::start(project);
 
-    icp_cmd(project).arg("deploy").assert().success();
+    let output = icp_cmd(project)
+        .args(["--debug", "deploy"])
+        .assert()
+        .success()
+        .get_output()
+        .clone();
+    let combined = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
 
     let assets = list_assets(project);
 
     assert!(
         assets.iter().any(|a| a.key == "/index.html"),
         "expected /index.html in canister asset list; got: {assets:#?}",
+    );
+    assert!(
+        combined.contains("canister reports state hash"),
+        "expected the finalizing call to report a state hash; got:\n{combined}",
     );
 }
 
@@ -52,8 +67,9 @@ fn basic_deploy_with_proxy() {
     );
 }
 
-/// Run sync twice without modifying any files.
-/// The second deploy must report "up to date" and must not change canister state.
+/// Run sync twice without modifying any files. The second deploy must report
+/// "up to date", must not change canister state, and — the point of preparing
+/// lazily — must not compress a single asset to find that out.
 #[test]
 fn no_op_sync() {
     let tmp = setup_example("static-site");
@@ -82,6 +98,10 @@ fn no_op_sync() {
     assert!(
         combined.contains("up to date"),
         "expected 'up to date' in deploy output on second run; got:\n{combined}",
+    );
+    assert!(
+        combined.contains("encoded 0 asset(s)"),
+        "a re-deploy of an unchanged project must encode nothing; got:\n{combined}",
     );
 
     let mut assets_after = list_assets(project);

--- a/crates/state-hash-cli/src/main.rs
+++ b/crates/state-hash-cli/src/main.rs
@@ -16,13 +16,18 @@
 //!   state-hash <dist-dir>
 //!
 //! `<dist-dir>` is the built site directory (the same one passed to a deploy),
-//! including any `_headers` / `_redirects` files. Prints the 64-char hex hash on
-//! success; on error, prints a message to stderr and exits non-zero.
+//! including any `_headers` / `_redirects` files. Prints one 64-char hex hash
+//! per preparation mode — `compressed` (what `icp deploy` produces) and
+//! `uncompressed` — since the same directory hashes differently depending on
+//! whether compressed encodings were stored. A canister matches exactly one.
+//! On error, prints a message to stderr and exits non-zero.
 //!
-//! The hash is bound to a frozen contract — the compressor parameters (gzip
-//! `flate2` default; brotli quality 11 / window 22) and `MAX_CHUNK_SIZE` — so a
-//! verifier must use a `state-hash` build matching the deploying plugin's
-//! version. See `docs/verifying-contents.md`.
+//! The `compressed` hash is bound to a contract — the compressor parameters
+//! (gzip `flate2` default; brotli quality 11 / window 22), the compressor
+//! implementations themselves, and `MAX_CHUNK_SIZE` — so a verifier must use a
+//! `state-hash` build matching the deploying plugin's version. The
+//! `uncompressed` hash depends on no compressor at all. See
+//! `docs/verifying-contents.md`.
 
 use std::process::ExitCode;
 
@@ -43,16 +48,25 @@ fn main() -> ExitCode {
         }
     };
 
-    match asset_prep::state_hash_for_dir(&dir) {
-        Ok(hash) => {
-            println!("{}", hex::encode(hash));
-            ExitCode::SUCCESS
-        }
-        Err(e) => {
-            eprintln!("error: {e}");
-            ExitCode::FAILURE
+    // A deploy either stores compressed encodings alongside the uncompressed
+    // copy or doesn't, and the two produce different state hashes from the same
+    // directory. Rather than ask the verifier which was used — a question they
+    // often can't answer, and a flag that would invite more flags — print both
+    // and let them see which one the canister reports.
+    let modes = [
+        (asset_prep::Compression::Enabled, "compressed"),
+        (asset_prep::Compression::Disabled, "uncompressed"),
+    ];
+    for (compression, label) in modes {
+        match asset_prep::state_hash_for_dir(&dir, compression) {
+            Ok(hash) => println!("{label:<14}{}", hex::encode(hash)),
+            Err(e) => {
+                eprintln!("error: {e}");
+                return ExitCode::FAILURE;
+            }
         }
     }
+    ExitCode::SUCCESS
 }
 
 fn print_usage(program: &str) {

--- a/crates/sync-agent/src/lib.rs
+++ b/crates/sync-agent/src/lib.rs
@@ -19,6 +19,8 @@ use futures::stream::{self, StreamExt};
 use ic_agent::Agent;
 use sync_core::{Call, CallType, CanisterCall};
 
+pub use sync_core::Compression;
+
 /// A `sync-core` transport backed by a live `ic-agent`.
 ///
 /// `dispatch` (single call) blocks on the agent; `dispatch_batch` runs the
@@ -87,11 +89,24 @@ pub struct SyncOpts {
     /// Maximum number of update calls in flight at once. Defaults, via
     /// [`SyncOpts::default`], to 16 — matching the legacy `dfx` uploader's cap.
     pub max_in_flight: usize,
+    /// Whether to store compressed encodings alongside the uncompressed copy.
+    /// Defaults to [`Compression::Enabled`], the canonical preparation.
+    ///
+    /// This is the seam for a platform that deploys builds nobody browses —
+    /// previews, drafts, CI artifacts — where [`Compression::Disabled`] removes
+    /// the compression pass entirely and uploads ~20–25% fewer bytes. It is
+    /// deliberately not reachable from `icp deploy`: the saving goes to whoever
+    /// runs the deploy while the 5–6× larger transfers go to whoever visits the
+    /// site, so it is only a sound trade when the deployer knows nobody will.
+    pub compression: Compression,
 }
 
 impl Default for SyncOpts {
     fn default() -> Self {
-        Self { max_in_flight: 16 }
+        Self {
+            max_in_flight: 16,
+            compression: Compression::default(),
+        }
     }
 }
 
@@ -118,7 +133,7 @@ pub async fn sync(
             max_in_flight: opts.max_in_flight.max(1),
         };
         // Native clients call the canister directly, so no proxy id.
-        sync_core::sync(&call, &[dir], &identity, None)
+        sync_core::sync(&call, &[dir], &identity, None, opts.compression)
     })
     .await
     .map_err(|e| anyhow::anyhow!("sync task panicked: {e}"))?

--- a/crates/sync-core/src/canister.rs
+++ b/crates/sync-core/src/canister.rs
@@ -142,6 +142,18 @@ pub fn version(c: &impl CanisterCall) -> Result<Version, String> {
     c.call("version", (), CallType::Query, true)
 }
 
+/// The compression fingerprint recorded by the client that last prepared every
+/// asset, or `None` when the canister reports the "unknown" value (32 zero
+/// bytes) or something that isn't a 32-byte hash — both of which mean the same
+/// thing to a caller: nothing here may be trusted to match local compression.
+pub fn preparation_canary(c: &impl CanisterCall) -> Result<Option<[u8; 32]>, String> {
+    let reported: ByteBuf = c.call("preparation_canary", (), CallType::Query, true)?;
+    let Ok(canary) = <[u8; 32]>::try_from(reported.as_ref()) else {
+        return Ok(None);
+    };
+    Ok((canary != [0u8; 32]).then_some(canary))
+}
+
 // Fetch the complete asset list by paging through `get_asset_details`, returned
 // as a map keyed by asset key — the shape the sync diff consumes. Building the
 // map directly avoids materializing an intermediate Vec of every asset and a

--- a/crates/sync-core/src/canister.rs
+++ b/crates/sync-core/src/canister.rs
@@ -213,10 +213,13 @@ pub fn upload_chunks(
     c.call("upload_chunks", req, CallType::Update, true)
 }
 
+/// Applies a group of operations. The call flagged `is_final` finalizes the sync
+/// and returns the canonical state hash the canister recomputed over the now-
+/// final state; every other call returns `None`.
 pub fn execute_operations(
     c: &impl CanisterCall,
     args: ExecuteOperationsArguments,
-) -> Result<(), String> {
+) -> Result<Option<ByteBuf>, String> {
     c.call("execute_operations", args, CallType::Update, true)
 }
 

--- a/crates/sync-core/src/lib.rs
+++ b/crates/sync-core/src/lib.rs
@@ -9,5 +9,6 @@
 mod canister;
 mod sync;
 
+pub use asset_prep::Compression;
 pub use canister::{Call, CallType, CanisterCall};
 pub use sync::sync;

--- a/crates/sync-core/src/sync.rs
+++ b/crates/sync-core/src/sync.rs
@@ -12,7 +12,9 @@ use crate::canister::{
     CallType, CanisterCall, authorize_via_proxy, can_sync, execute_operations, list_all_assets,
     list_all_redirect_rules, start_sync, version,
 };
-use asset_prep::{MAX_CHUNK_SIZE, PreparedAsset, PreparedChunk, PreparedProject, prepare_project};
+use asset_prep::{
+    MAX_CHUNK_SIZE, PlannedAsset, PreparedAsset, PreparedChunk, ProjectPlan, plan_project,
+};
 use wire_types::{
     AssetDetails, ChunkId, CreateAssetArguments, DeleteAssetArguments, Encoding,
     ExecuteOperationsArguments, Operation, RedirectRule, RulePattern, SetAssetContentArguments,
@@ -41,65 +43,167 @@ struct ProjectAsset {
     key: String,
     content_type: String,
     /// Per-asset response headers, already resolved from `_headers` by
-    /// `asset-prep::prepare_project` — the canonical stored form. Used as-is by
+    /// `asset-prep`'s planning phase — the canonical stored form. Used as-is by
     /// `build_operations` (no re-resolution).
     headers: Vec<(String, String)>,
     encodings: HashMap<Encoding, ProjectAssetEncoding>,
-}
-
-impl ProjectAsset {
     /// Whether any encoding will be stored as more than one chunk. Used to reject
     /// 4xx error-page rules whose target is too large to serve as a single inline
     /// body (see [`validate_error_page_targets`]).
-    fn is_multichunk(&self) -> bool {
-        self.encodings.values().any(|e| e.chunks.len() > 1)
-    }
+    ///
+    /// Carried as a flag rather than derived from `encodings` because an asset
+    /// the canister already holds is never encoded, so it has no chunks here.
+    /// `asset-prep` decides it from the uncompressed length alone.
+    multichunk: bool,
 }
 
-/// Adapts the canister-agnostic [`PreparedAsset`]s from `asset-prep` into the
-/// keyed diff structure the sync pipeline operates on, carrying the headers
-/// `prepare_project` already resolved and marking each encoding already-in-place
-/// when the canister already holds that exact content.
+/// Turns the planned assets into the keyed diff structure the sync pipeline
+/// operates on — **encoding only what the canister doesn't already hold.**
+///
+/// For each planned asset, [`current_encodings`] asks whether the canister's
+/// stored content is already exactly what preparation would produce. When it is,
+/// the asset is adopted as-is (every encoding already in place, nothing to
+/// upload) and the expensive gzip/brotli pass is skipped entirely — which is
+/// where a re-deploy's local cost goes. Otherwise it is encoded and diffed
+/// per-encoding, so a partially-current asset still uploads only what's missing.
+///
+/// Note this skips *encoding*, never *diffing*: headers and content_type are
+/// compared for every asset either way, since `_headers` can change while
+/// content doesn't.
 fn diff_assets(
-    assets: Vec<PreparedAsset>,
+    planned: Vec<PlannedAsset>,
     canister_assets: &HashMap<String, AssetDetails>,
-) -> HashMap<String, ProjectAsset> {
-    assets
-        .into_iter()
-        .map(|pa| {
-            let encodings = pa
-                .encodings
-                .into_iter()
-                .map(|enc| {
-                    let already_in_place = is_already_in_place(
-                        &pa.key,
-                        &pa.content_type,
-                        enc.encoding,
-                        &enc.sha256,
-                        canister_assets,
-                    );
-                    (
-                        enc.encoding,
-                        ProjectAssetEncoding {
-                            sha256: enc.sha256,
-                            chunks: enc.chunks,
-                            already_in_place,
-                            chunk_ids: Vec::new(),
-                        },
-                    )
-                })
-                .collect();
-            (
-                pa.key.clone(),
+) -> Result<HashMap<String, ProjectAsset>, String> {
+    let mut project_assets = HashMap::with_capacity(planned.len());
+    let mut reused = 0usize;
+
+    for asset in planned {
+        let multichunk = asset.is_multichunk();
+        let project_asset = match current_encodings(&asset, canister_assets.get(&asset.key)) {
+            Some(encodings) => {
+                reused += 1;
                 ProjectAsset {
-                    key: pa.key,
-                    content_type: pa.content_type,
-                    headers: pa.headers,
+                    key: asset.key,
+                    content_type: asset.content_type,
+                    headers: asset.headers,
                     encodings,
-                },
-            )
+                    multichunk,
+                }
+            }
+            None => {
+                let PreparedAsset {
+                    key,
+                    content_type,
+                    headers,
+                    encodings,
+                } = asset.encode()?;
+                let encodings = encodings
+                    .into_iter()
+                    .map(|enc| {
+                        let already_in_place = is_already_in_place(
+                            &key,
+                            &content_type,
+                            enc.encoding,
+                            &enc.sha256,
+                            canister_assets,
+                        );
+                        (
+                            enc.encoding,
+                            ProjectAssetEncoding {
+                                sha256: enc.sha256,
+                                chunks: enc.chunks,
+                                already_in_place,
+                                chunk_ids: Vec::new(),
+                            },
+                        )
+                    })
+                    .collect();
+                ProjectAsset {
+                    key,
+                    content_type,
+                    headers,
+                    encodings,
+                    multichunk,
+                }
+            }
+        };
+
+        project_assets.insert(project_asset.key.clone(), project_asset);
+    }
+
+    println!(
+        "encoded {} asset(s); {reused} already current on the canister",
+        project_assets.len() - reused
+    );
+    Ok(project_assets)
+}
+
+/// The canister's encodings for `planned`, when the canister already holds
+/// exactly the content preparation would produce — so encoding can be skipped.
+///
+/// Sound because compression is deterministic: for a given build of
+/// `asset-prep`, every compressed encoding is a pure function of the identity
+/// bytes. So if the canister holds the same identity hash under the same
+/// `content_type`, its compressed encodings are byte-identical to the ones we
+/// would spend brotli time recomputing.
+///
+/// Three things must line up, and the third is deliberately strict:
+///
+/// 1. same `content_type` — it is part of the stored, certified response;
+/// 2. same identity hash — identity is always kept, so it is always reported;
+/// 3. the stored encoding set is *exactly* the set preparation attempts.
+///
+/// (3) is what makes this safe without extra canister state. A missing
+/// compressed encoding is ambiguous — it could mean "compression didn't shrink
+/// this asset" or "an earlier deploy died mid-upload" — and the two are
+/// indistinguishable without doing the compression. Treating any mismatch as
+/// stale re-encodes those assets on every sync, but an asset whose compressed
+/// form isn't smaller than its identity form is tiny by definition, so the cost
+/// is noise.
+///
+/// This also relies on preparation parameters being frozen within a release
+/// series: the version lock pairs *code*, but a canister upgraded in place still
+/// holds content written by an earlier build of the same series.
+fn current_encodings(
+    planned: &PlannedAsset,
+    canister_asset: Option<&AssetDetails>,
+) -> Option<HashMap<Encoding, ProjectAssetEncoding>> {
+    let canister_asset = canister_asset?;
+    if canister_asset.content_type != planned.content_type {
+        return None;
+    }
+
+    let attempted = planned.attempted_encodings();
+    if canister_asset.encodings.len() != attempted.len()
+        || !attempted.iter().all(|encoding| {
+            canister_asset
+                .encodings
+                .iter()
+                .any(|d| d.encoding == *encoding)
         })
-        .collect()
+    {
+        return None;
+    }
+
+    let mut encodings = HashMap::with_capacity(canister_asset.encodings.len());
+    for details in &canister_asset.encodings {
+        // A malformed hash can't be matched or reused; treat the asset as stale
+        // and let the normal path re-upload it.
+        let sha256: [u8; 32] = details.sha256.as_ref().try_into().ok()?;
+        if details.encoding.is_identity() && sha256 != planned.identity_sha256 {
+            return None;
+        }
+        encodings.insert(
+            details.encoding,
+            ProjectAssetEncoding {
+                sha256,
+                chunks: Vec::new(),
+                already_in_place: true,
+                chunk_ids: Vec::new(),
+            },
+        );
+    }
+    Some(encodings)
 }
 
 /// Rejects 404/410 rules whose target asset will be multi-chunk. A custom error
@@ -116,10 +220,7 @@ fn validate_error_page_targets(
         if !matches!(rule.status, 404 | 410) {
             continue;
         }
-        if project_assets
-            .get(&rule.to)
-            .is_some_and(ProjectAsset::is_multichunk)
-        {
+        if project_assets.get(&rule.to).is_some_and(|a| a.multichunk) {
             let from = match &rule.from {
                 RulePattern::Exact(p) | RulePattern::Subtree(p) => p,
             };
@@ -219,30 +320,26 @@ pub fn sync<C: CanisterCall>(
     }
     println!("version: {canister_version}");
 
-    // Prepare the project's `dist/` once: scan + parse `_redirects`/`_headers` +
-    // synthesise html-handling/404 rules + load, encode, chunk, and hash every
-    // asset. This is the single, canister-agnostic preparation path shared with
-    // the offline `state-hash-cli` verifier (see `asset-prep`), so the content
-    // the canister stores and the hash a verifier reproduces from source match
-    // by construction.
-    let prepared = prepare_project(dir)?;
-    println!("prepared {} asset(s) from {dir}", prepared.assets.len());
+    // Plan the project's `dist/`: scan + parse `_redirects`/`_headers` +
+    // synthesise html-handling/404 rules + load each asset, resolve its media
+    // type and headers, and hash its uncompressed bytes. This is the cheap half
+    // of the canister-agnostic preparation path shared with the offline
+    // `state-hash-cli` verifier (see `asset-prep`); the expensive half —
+    // gzip/brotli — is deferred to `diff_assets`, which runs it only for assets
+    // the canister doesn't already hold.
+    let plan = plan_project(dir)?;
+    println!("planned {} asset(s) from {dir}", plan.assets.len());
     println!(
         "{} redirect rule(s) (incl. synthesised)",
-        prepared.redirect_rules.len()
+        plan.redirect_rules.len()
     );
 
-    // The state hash a verifier can compare against the canister's `state_hash()`,
-    // built from the same prepared project — so it equals the value the canister
-    // recomputes at the end of this sync. Printed in the result either way.
-    let state_hash = hex::encode(asset_prep::manifest(&prepared).digest());
-
-    let PreparedProject {
-        assets: prepared_assets,
+    let ProjectPlan {
+        assets: planned_assets,
         // Already in canonical stored form — 3xx rules carry their resolved
         // `_headers`. Used directly in the diff; no re-resolution.
         redirect_rules: project_rules,
-    } = prepared;
+    } = plan;
 
     let canister_assets: HashMap<String, AssetDetails> = list_all_assets(canister)?;
     println!("canister currently has {} asset(s)", canister_assets.len());
@@ -253,8 +350,8 @@ pub fn sync<C: CanisterCall>(
         canister_rules.len()
     );
 
-    // Phase 1: compute the diff only — no batch created yet.
-    let mut project_assets = diff_assets(prepared_assets, &canister_assets);
+    // Phase 1: encode what's stale and compute the diff — no batch created yet.
+    let mut project_assets = diff_assets(planned_assets, &canister_assets)?;
 
     // Reject oversized 4xx error-page targets before starting a sync.
     validate_error_page_targets(&project_rules, &project_assets)?;
@@ -269,7 +366,7 @@ pub fn sync<C: CanisterCall>(
     {
         println!("canister is up to date, nothing to commit");
         return Ok(format!(
-            "{} asset(s) already up to date; state hash {state_hash}",
+            "{} asset(s) already up to date",
             project_assets.len()
         ));
     }
@@ -288,12 +385,22 @@ pub fn sync<C: CanisterCall>(
     );
     println!("executing {} operation(s)", operations.len());
 
-    execute_in_stages(canister, session_id, operations)?;
+    // The canister recomputes its canonical state hash while finalizing the last
+    // group and hands it back, so the summary can report it without a second
+    // round trip. It is *canister-reported* — a self-consistency read, not
+    // third-party verification; for that, run `state-hash <dist>` offline and
+    // compare against the canister's `state_hash()` (see
+    // `docs/verifying-contents.md`).
+    let state_hash = execute_in_stages(canister, session_id, operations)?;
 
-    Ok(format!(
-        "synced {} asset(s) to canister; state hash {state_hash}",
-        project_assets.len()
-    ))
+    Ok(match state_hash {
+        Some(hash) => format!(
+            "synced {} asset(s) to canister; canister reports state hash {}",
+            project_assets.len(),
+            hex::encode(hash)
+        ),
+        None => format!("synced {} asset(s) to canister", project_assets.len()),
+    })
 }
 
 /// Whether the canister already holds this exact encoding (same `content_type`
@@ -468,6 +575,11 @@ fn pack_and_upload_chunks<C: CanisterCall>(
 /// open. Staged chunks survive between calls because the canister only drops
 /// them on sync start/finish, not between `execute_operations` calls.
 ///
+/// Returns the canonical state hash the canister recomputed while finalizing —
+/// the `is_final` call carries it back, so reporting it costs no extra round
+/// trip. `None` if the canister returned no hash (or a malformed one), which is
+/// cosmetic: the sync itself has already succeeded by then.
+///
 /// Trade-off: splitting forfeits cross-call atomicity. A failure mid-deploy
 /// leaves the canister with the operations from previously successful calls
 /// applied; the next sync run diffs against the canister and resumes from
@@ -476,7 +588,13 @@ fn execute_in_stages<C: CanisterCall>(
     canister: &C,
     session_id: u64,
     operations: Vec<Operation>,
-) -> Result<(), String> {
+) -> Result<Option<[u8; 32]>, String> {
+    /// A reported hash is cosmetic, so a wrong-sized blob degrades to `None`
+    /// rather than failing a sync that has already been applied.
+    fn as_hash(reported: Option<ByteBuf>) -> Option<[u8; 32]> {
+        reported.and_then(|h| h.as_ref().try_into().ok())
+    }
+
     let groups = split_operation_groups(operations);
     // The caller only reaches this with a non-empty diff, so there is always at
     // least one group. Guard anyway: we hold a session and must release it.
@@ -488,9 +606,11 @@ fn execute_in_stages<C: CanisterCall>(
                 operations: vec![],
                 is_final: true,
             },
-        );
+        )
+        .map(as_hash);
     }
     let total = groups.len();
+    let mut state_hash = None;
     for (i, ops) in groups.into_iter().enumerate() {
         let is_final = i + 1 == total;
         if total > 1 {
@@ -501,16 +621,17 @@ fn execute_in_stages<C: CanisterCall>(
                 ops.len()
             );
         }
-        execute_operations(
+        // Only the `is_final` call reports a hash; earlier groups return `None`.
+        state_hash = as_hash(execute_operations(
             canister,
             ExecuteOperationsArguments {
                 session_id,
                 operations: ops,
                 is_final,
             },
-        )?;
+        )?);
     }
-    Ok(())
+    Ok(state_hash)
 }
 
 /// Splits `operations` into groups, each small enough that a single
@@ -828,6 +949,9 @@ mod tests {
                 content_type: "application/octet-stream".to_string(),
                 headers: vec![],
                 encodings: enc_map,
+                // Same rule `asset-prep` applies: identity is the longest kept
+                // encoding, so its length alone decides this.
+                multichunk: data.len() > MAX_CHUNK_SIZE,
             },
         )
     }
@@ -1380,6 +1504,7 @@ mod tests {
                 content_type: content_type.to_string(),
                 headers: vec![],
                 encodings: enc_map,
+                multichunk: false,
             },
         )
     }
@@ -1447,6 +1572,8 @@ mod tests {
                         | (Operation::CreateAsset(_), "CreateAsset")
                         | (Operation::SetAssetContent(_), "SetAssetContent")
                         | (Operation::UnsetAssetContent(_), "UnsetAssetContent")
+                        | (Operation::SetAssetHeaders(_), "SetAssetHeaders")
+                        | (Operation::SetRedirectRules(_), "SetRedirectRules")
                 )
             })
             .count()
@@ -2422,5 +2549,181 @@ mod tests {
         )
         .unwrap_err();
         assert!(err.contains("not authorized"), "got: {err}");
+    }
+
+    // ───────── Lazy encoding ─────────
+    //
+    // `diff_assets` must encode an asset only when the canister doesn't already
+    // hold exactly what preparation would produce. "Was it encoded?" is directly
+    // observable: a reused asset carries no chunks at all (an encoded one always
+    // has at least one per encoding, even for empty content).
+
+    /// A body repetitive enough that both gzip and brotli beat identity, so the
+    /// asset keeps the full `{identity, gzip, brotli}` set — the case where
+    /// skipping the encode pass actually saves work.
+    fn compressible_html() -> Vec<u8> {
+        format!("<!DOCTYPE html><h1>{}</h1>", "hello world ".repeat(200)).into_bytes()
+    }
+
+    /// The `AssetDetails` map the canister would report after a full sync of
+    /// `dir` — i.e. what the diff sees on a re-deploy of an unchanged project.
+    fn canister_view(dir: &str) -> HashMap<String, AssetDetails> {
+        asset_prep::prepare_project(dir)
+            .expect("prepare project")
+            .assets
+            .into_iter()
+            .map(|a| {
+                let details = AssetDetails {
+                    encodings: a
+                        .encodings
+                        .iter()
+                        .map(|e| AssetEncodingDetails {
+                            encoding: e.encoding,
+                            sha256: ByteBuf::from(e.sha256.to_vec()),
+                        })
+                        .collect(),
+                    content_type: a.content_type,
+                    headers: a.headers,
+                    key: a.key.clone(),
+                };
+                (a.key, details)
+            })
+            .collect()
+    }
+
+    fn was_encoded(assets: &HashMap<String, ProjectAsset>, key: &str) -> bool {
+        assets[key].encodings.values().any(|e| !e.chunks.is_empty())
+    }
+
+    #[test]
+    fn unchanged_asset_is_not_encoded() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), compressible_html()).unwrap();
+        let dir_str = dir.path().to_str().unwrap();
+
+        let canister = canister_view(dir_str);
+        // Full set kept, so this exercises the reuse path rather than the
+        // "compression didn't help" one.
+        assert_eq!(canister["/index.html"].encodings.len(), 3);
+
+        let plan = plan_project(dir_str).unwrap();
+        let project = diff_assets(plan.assets, &canister).unwrap();
+
+        for key in project.keys() {
+            assert!(!was_encoded(&project, key), "{key} should not be encoded");
+        }
+        assert!(
+            build_operations(
+                &project,
+                &canister,
+                &plan.redirect_rules,
+                &plan.redirect_rules
+            )
+            .is_empty(),
+            "an unchanged project must produce no operations"
+        );
+    }
+
+    #[test]
+    fn header_only_change_reuses_content_and_sets_headers() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), compressible_html()).unwrap();
+        let dir_str = dir.path().to_str().unwrap();
+
+        // Canister state from before the `_headers` file existed.
+        let canister = canister_view(dir_str);
+        std::fs::write(
+            dir.path().join("_headers"),
+            b"/*\n  X-Frame-Options: DENY\n",
+        )
+        .unwrap();
+
+        let plan = plan_project(dir_str).unwrap();
+        let project = diff_assets(plan.assets, &canister).unwrap();
+
+        assert!(
+            !was_encoded(&project, "/index.html"),
+            "content is unchanged, so it must not be re-encoded"
+        );
+        let ops = build_operations(
+            &project,
+            &canister,
+            &plan.redirect_rules,
+            &plan.redirect_rules,
+        );
+        assert_eq!(count_op(&ops, "SetAssetHeaders"), project.len());
+        assert_eq!(count_op(&ops, "SetAssetContent"), 0);
+    }
+
+    #[test]
+    fn changed_asset_is_re_encoded_and_uploaded() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), compressible_html()).unwrap();
+        let dir_str = dir.path().to_str().unwrap();
+
+        let canister = canister_view(dir_str);
+        std::fs::write(dir.path().join("index.html"), b"<h1>new</h1>").unwrap();
+
+        let plan = plan_project(dir_str).unwrap();
+        let project = diff_assets(plan.assets, &canister).unwrap();
+
+        assert!(was_encoded(&project, "/index.html"));
+        assert!(
+            !was_encoded(&project, not_found::ROOT_404_KEY),
+            "the untouched branded 404 must still be reused"
+        );
+        let ops = build_operations(
+            &project,
+            &canister,
+            &plan.redirect_rules,
+            &plan.redirect_rules,
+        );
+        assert!(count_op(&ops, "SetAssetContent") > 0);
+    }
+
+    #[test]
+    fn missing_encoding_forces_re_encode_and_uploads_only_the_gap() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), compressible_html()).unwrap();
+        let dir_str = dir.path().to_str().unwrap();
+
+        // Simulate a deploy that died before brotli landed: identity and gzip
+        // match, brotli is absent. Indistinguishable from "brotli didn't shrink
+        // this asset" without encoding, so the asset must be re-encoded.
+        let mut canister = canister_view(dir_str);
+        canister
+            .get_mut("/index.html")
+            .unwrap()
+            .encodings
+            .retain(|e| e.encoding != Encoding::Brotli);
+
+        let plan = plan_project(dir_str).unwrap();
+        let project = diff_assets(plan.assets, &canister).unwrap();
+
+        assert!(was_encoded(&project, "/index.html"));
+        // ...but only the missing encoding is actually uploaded: the per-encoding
+        // hash check still marks identity and gzip as already in place.
+        let ops = build_operations(
+            &project,
+            &canister,
+            &plan.redirect_rules,
+            &plan.redirect_rules,
+        );
+        assert_eq!(count_op(&ops, "SetAssetContent"), 1);
+    }
+
+    #[test]
+    fn content_type_drift_forces_re_encode() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), compressible_html()).unwrap();
+        let dir_str = dir.path().to_str().unwrap();
+
+        let mut canister = canister_view(dir_str);
+        canister.get_mut("/index.html").unwrap().content_type = "text/plain".to_string();
+
+        let plan = plan_project(dir_str).unwrap();
+        let project = diff_assets(plan.assets, &canister).unwrap();
+
+        assert!(was_encoded(&project, "/index.html"));
     }
 }

--- a/crates/sync-core/src/sync.rs
+++ b/crates/sync-core/src/sync.rs
@@ -2243,13 +2243,22 @@ mod tests {
 
     struct SyncMock {
         queue: MockQueue,
+        /// Every operation passed to `execute_operations`, in call order — so a
+        /// test can assert on what a whole sync emitted, not just how many calls
+        /// it made.
+        executed: RefCell<Vec<Operation>>,
     }
 
     impl SyncMock {
         fn new() -> Self {
             Self {
                 queue: RefCell::new(HashMap::new()),
+                executed: RefCell::new(Vec::new()),
             }
+        }
+
+        fn executed_operations(&self) -> Vec<Operation> {
+            self.executed.borrow().clone()
         }
 
         fn push_ok<R: CandidType>(&self, method: &str, value: R) {
@@ -2292,6 +2301,11 @@ mod tests {
                     Decode!(&call.arg, ChunksReqMirror).map_err(|e| e.to_string())?;
                 let ids: Vec<u64> = (0..req.chunks.len() as u64).collect();
                 return candid::encode_one(ids).map_err(|e| e.to_string());
+            }
+            if call.method == "execute_operations" {
+                let req =
+                    Decode!(&call.arg, ExecuteOperationsArguments).map_err(|e| e.to_string())?;
+                self.executed.borrow_mut().extend(req.operations);
             }
             self.queue
                 .borrow_mut()
@@ -2876,6 +2890,50 @@ mod tests {
                 "{key} must be re-encoded when the compressors may have changed"
             );
         }
+    }
+
+    /// The canary op must be the *last* operation, so it lands in the group
+    /// flagged `is_final`. A sync that dies before then must leave the old canary
+    /// in place, or the next sync would trust encodings this one never finished
+    /// writing.
+    #[test]
+    fn canary_op_is_emitted_last() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), compressible_html()).unwrap();
+        let dir_str = dir.path().to_str().unwrap();
+
+        let mock = SyncMock::new();
+        mock.push_ok("version", wire_types::VERSION);
+        mock.push_ok("can_sync", true);
+        // An empty canister: unknown canary, so the sync records a new one.
+        mock.push_ok("preparation_canary", ByteBuf::from(vec![0u8; 32]));
+        mock.push_ok("get_asset_details", Vec::<AssetDetails>::new());
+        mock.push_ok("get_redirect_rules", Vec::<RedirectRule>::new());
+        mock.push_ok("start_sync", StartSyncOk::Started { session_id: 1 });
+        mock.push_ok("execute_operations", None::<ByteBuf>);
+
+        sync(
+            &mock,
+            &[dir_str.to_string()],
+            &Principal::anonymous().to_text(),
+            None,
+            Compression::Enabled,
+        )
+        .expect("sync should succeed");
+
+        let ops = mock.executed_operations();
+        assert!(
+            matches!(ops.last(), Some(Operation::SetPreparationCanary(_))),
+            "the canary must be the final operation; got: {:?}",
+            ops.last()
+        );
+        assert_eq!(
+            ops.iter()
+                .filter(|op| matches!(op, Operation::SetPreparationCanary(_)))
+                .count(),
+            1,
+            "exactly one canary op per sync"
+        );
     }
 
     #[test]

--- a/crates/sync-core/src/sync.rs
+++ b/crates/sync-core/src/sync.rs
@@ -10,16 +10,17 @@ use std::collections::HashMap;
 
 use crate::canister::{
     CallType, CanisterCall, authorize_via_proxy, can_sync, execute_operations, list_all_assets,
-    list_all_redirect_rules, start_sync, version,
+    list_all_redirect_rules, preparation_canary, start_sync, version,
 };
 use asset_prep::{
-    MAX_CHUNK_SIZE, PlannedAsset, PreparedAsset, PreparedChunk, ProjectPlan, plan_project,
+    Compression, MAX_CHUNK_SIZE, PlannedAsset, PreparedAsset, PreparedChunk, ProjectPlan,
+    plan_project,
 };
 use wire_types::{
     AssetDetails, ChunkId, CreateAssetArguments, DeleteAssetArguments, Encoding,
     ExecuteOperationsArguments, Operation, RedirectRule, RulePattern, SetAssetContentArguments,
-    SetAssetHeadersArguments, SetRedirectRulesArguments, UnsetAssetContentArguments,
-    UploadChunksArguments,
+    SetAssetHeadersArguments, SetPreparationCanaryArguments, SetRedirectRulesArguments,
+    UnsetAssetContentArguments, UploadChunksArguments,
 };
 
 /// One encoding of an asset, as the canister diff/upload sees it: the prepared
@@ -70,16 +71,26 @@ struct ProjectAsset {
 /// Note this skips *encoding*, never *diffing*: headers and content_type are
 /// compared for every asset either way, since `_headers` can change while
 /// content doesn't.
+///
+/// `compressors_agree` gates the whole optimization: reuse is only sound while
+/// the canister's stored encodings came from compressors that behave like ours
+/// (see [`compressors_agree`] and `asset-prep::canary`). When they don't, every
+/// asset is re-prepared — the pre-lazy-encoding behaviour, which is what lets
+/// the canister re-converge after a compressor change.
 fn diff_assets(
     planned: Vec<PlannedAsset>,
     canister_assets: &HashMap<String, AssetDetails>,
+    compressors_agree: bool,
 ) -> Result<HashMap<String, ProjectAsset>, String> {
     let mut project_assets = HashMap::with_capacity(planned.len());
     let mut reused = 0usize;
 
     for asset in planned {
         let multichunk = asset.is_multichunk();
-        let project_asset = match current_encodings(&asset, canister_assets.get(&asset.key)) {
+        let current = compressors_agree
+            .then(|| current_encodings(&asset, canister_assets.get(&asset.key)))
+            .flatten();
+        let project_asset = match current {
             Some(encodings) => {
                 reused += 1;
                 ProjectAsset {
@@ -276,6 +287,7 @@ pub fn sync<C: CanisterCall>(
     dirs: &[String],
     identity_principal: &str,
     proxy_canister_id: Option<&str>,
+    compression: Compression,
 ) -> Result<String, String> {
     // The assets plugin owns the URL space of its canister: every key starts at
     // `/`, `_redirects` lives at the project root, and the canister has no
@@ -327,8 +339,11 @@ pub fn sync<C: CanisterCall>(
     // `state-hash-cli` verifier (see `asset-prep`); the expensive half —
     // gzip/brotli — is deferred to `diff_assets`, which runs it only for assets
     // the canister doesn't already hold.
-    let plan = plan_project(dir)?;
+    let plan = plan_project(dir, compression)?;
     println!("planned {} asset(s) from {dir}", plan.assets.len());
+    if compression == Compression::Disabled {
+        println!("compression disabled: storing uncompressed content only");
+    }
     println!(
         "{} redirect rule(s) (incl. synthesised)",
         plan.redirect_rules.len()
@@ -350,18 +365,55 @@ pub fn sync<C: CanisterCall>(
         canister_rules.len()
     );
 
+    // Reusing a stored encoding rests on it being byte-identical to what this
+    // build would produce, which holds only while the compressors behave the
+    // same. Compare fingerprints; a mismatch (or an "unknown" canary, i.e. a
+    // fresh canister or one upgraded from a build predating it) means prepare
+    // everything and record the new fingerprint below.
+    //
+    // With compression disabled none of that applies: no compressor touches the
+    // stored bytes, so an unchanged uncompressed hash is all the evidence reuse
+    // needs, and there is no fingerprint worth computing or recording.
+    let local_canary = match compression {
+        Compression::Enabled => Some(asset_prep::canary::fingerprint()?),
+        Compression::Disabled => None,
+    };
+    let compressors_agree = match local_canary {
+        Some(local) => preparation_canary(canister)? == Some(local),
+        None => true,
+    };
+    if !compressors_agree {
+        println!("compression fingerprint differs from the canister's; preparing every asset");
+    }
+
     // Phase 1: encode what's stale and compute the diff — no batch created yet.
-    let mut project_assets = diff_assets(planned_assets, &canister_assets)?;
+    let mut project_assets = diff_assets(planned_assets, &canister_assets, compressors_agree)?;
 
     // Reject oversized 4xx error-page targets before starting a sync.
     validate_error_page_targets(&project_rules, &project_assets)?;
 
-    if build_operations(
+    // Every asset was just prepared from scratch, so once these operations land
+    // the canister's whole asset set was written by this build's compressors —
+    // record that, or the next sync repeats the full pass. Appended last so it
+    // rides in the `is_final` group: a sync that dies partway leaves the old
+    // canary in place, and the next one re-prepares everything, as it must.
+    let record_canary = |mut ops: Vec<Operation>| {
+        if let Some(local) = local_canary.filter(|_| !compressors_agree) {
+            ops.push(Operation::SetPreparationCanary(
+                SetPreparationCanaryArguments {
+                    canary: ByteBuf::from(local.to_vec()),
+                },
+            ));
+        }
+        ops
+    };
+
+    if record_canary(build_operations(
         &project_assets,
         &canister_assets,
         &project_rules,
         &canister_rules,
-    )
+    ))
     .is_empty()
     {
         println!("canister is up to date, nothing to commit");
@@ -377,12 +429,12 @@ pub fn sync<C: CanisterCall>(
 
     pack_and_upload_chunks(canister, session_id, &mut project_assets)?;
 
-    let operations = build_operations(
+    let operations = record_canary(build_operations(
         &project_assets,
         &canister_assets,
         &project_rules,
         &canister_rules,
-    );
+    ));
     println!("executing {} operation(s)", operations.len());
 
     // The canister recomputes its canonical state hash while finalizing the last
@@ -698,7 +750,8 @@ fn header_bytes_of(op: &Operation) -> usize {
         Operation::SetRedirectRules(a) => a.rules.iter().map(|r| sum(&r.headers)).sum(),
         Operation::DeleteAsset(_)
         | Operation::UnsetAssetContent(_)
-        | Operation::SetAssetContent(_) => 0,
+        | Operation::SetAssetContent(_)
+        | Operation::SetPreparationCanary(_) => 0,
     }
 }
 
@@ -849,7 +902,8 @@ mod tests {
     /// project's `_headers`. Lets the short-circuit tests assert "a second sync of
     /// a 404-augmented project is a no-op" without hard-coding the page.
     fn branded_404_canister_asset(dir: &str) -> AssetDetails {
-        let prepared = asset_prep::prepare_project(dir).expect("prepare project");
+        let prepared = asset_prep::prepare_project(dir, asset_prep::Compression::Enabled)
+            .expect("prepare project");
         let asset = prepared
             .assets
             .into_iter()
@@ -1822,6 +1876,7 @@ mod tests {
         let mock = SyncMock::new();
         mock.push_ok("version", wire_types::VERSION);
         mock.push_ok("can_sync", true);
+        push_matching_canary(&mock);
         mock.push_ok(
             "get_asset_details",
             vec![branded_404_canister_asset(dir.path().to_str().unwrap())],
@@ -1837,6 +1892,7 @@ mod tests {
             &[dir.path().to_str().unwrap().to_string()],
             &Principal::anonymous().to_text(),
             None,
+            Compression::Enabled,
         );
         // No start_sync / execute_operations programmed — if sync reached them
         // SyncMock would panic with "no programmed response".
@@ -1871,6 +1927,7 @@ mod tests {
         let mock = SyncMock::new();
         mock.push_ok("version", wire_types::VERSION);
         mock.push_ok("can_sync", true);
+        push_matching_canary(&mock);
         mock.push_ok("get_asset_details", Vec::<AssetDetails>::new());
         mock.push_ok("get_redirect_rules", Vec::<RedirectRule>::new());
         mock.push_ok("start_sync", StartSyncOk::Started { session_id: 1 });
@@ -1883,6 +1940,7 @@ mod tests {
             &[dir.path().to_str().unwrap().to_string()],
             &Principal::anonymous().to_text(),
             None,
+            Compression::Enabled,
         );
         assert!(result.is_ok(), "expected success, got: {result:?}");
     }
@@ -2211,6 +2269,17 @@ mod tests {
         }
     }
 
+    /// Programs the canary query with *this build's own* fingerprint — i.e. the
+    /// canister's stored encodings came from compressors that behave like ours,
+    /// which is the normal case and the one where reuse is allowed. Tests that
+    /// want the mismatch path program a different value themselves.
+    fn push_matching_canary(mock: &SyncMock) {
+        mock.push_ok(
+            "preparation_canary",
+            ByteBuf::from(asset_prep::canary::fingerprint().unwrap().to_vec()),
+        );
+    }
+
     impl CanisterCall for SyncMock {
         fn dispatch(&self, call: Call) -> Result<Vec<u8>, String> {
             // The upload wire contract — return one id per staged chunk, in
@@ -2275,7 +2344,14 @@ mod tests {
     #[test]
     fn sync_rejects_zero_input_dirs() {
         let mock = SyncMock::new();
-        let err = sync(&mock, &[], &Principal::anonymous().to_text(), None).unwrap_err();
+        let err = sync(
+            &mock,
+            &[],
+            &Principal::anonymous().to_text(),
+            None,
+            Compression::Enabled,
+        )
+        .unwrap_err();
         assert!(
             err.contains("expected exactly one input directory"),
             "got: {err}"
@@ -2290,6 +2366,7 @@ mod tests {
             &["dist-a".to_string(), "dist-b".to_string()],
             &Principal::anonymous().to_text(),
             None,
+            Compression::Enabled,
         )
         .unwrap_err();
         assert!(err.contains("got 2"), "got: {err}");
@@ -2318,11 +2395,14 @@ mod tests {
         // html-handling rules and the `/*` catch-all; the canister must already
         // hold all of it for the short-circuit to fire. The exact stored rules
         // are whatever `prepare_project` produces (3xx headers already resolved).
-        let canister_rules = asset_prep::prepare_project(dir_str).unwrap().redirect_rules;
+        let canister_rules = asset_prep::prepare_project(dir_str, asset_prep::Compression::Enabled)
+            .unwrap()
+            .redirect_rules;
 
         let mock = SyncMock::new();
         mock.push_ok("version", wire_types::VERSION);
         mock.push_ok("can_sync", true);
+        push_matching_canary(&mock);
         mock.push_ok(
             "get_asset_details",
             vec![
@@ -2348,6 +2428,7 @@ mod tests {
             &[dir.path().to_str().unwrap().to_string()],
             &Principal::anonymous().to_text(),
             None,
+            Compression::Enabled,
         );
         // No start_sync / execute_operations programmed — would panic if reached.
         assert!(result.is_ok(), "expected success, got: {result:?}");
@@ -2368,6 +2449,7 @@ mod tests {
         let mock = SyncMock::new();
         mock.push_ok("version", wire_types::VERSION);
         mock.push_ok("can_sync", true);
+        push_matching_canary(&mock);
         mock.push_ok("get_asset_details", Vec::<AssetDetails>::new());
         mock.push_ok("get_redirect_rules", Vec::<RedirectRule>::new());
         mock.push_ok("start_sync", StartSyncOk::Started { session_id: 1 });
@@ -2379,6 +2461,7 @@ mod tests {
             &[dir.path().to_str().unwrap().to_string()],
             &Principal::anonymous().to_text(),
             None,
+            Compression::Enabled,
         );
         assert!(result.is_ok(), "expected success, got: {result:?}");
     }
@@ -2465,6 +2548,7 @@ mod tests {
         let mock = SyncMock::new();
         mock.push_ok("version", wire_types::VERSION);
         mock.push_ok("can_sync", true);
+        push_matching_canary(&mock);
         mock.push_ok(
             "get_asset_details",
             vec![
@@ -2490,6 +2574,7 @@ mod tests {
             &[dir.path().to_str().unwrap().to_string()],
             &Principal::anonymous().to_text(),
             None,
+            Compression::Enabled,
         );
         // No start_sync / execute_operations programmed — would panic if reached.
         assert!(result.is_ok(), "expected success, got: {result:?}");
@@ -2506,6 +2591,7 @@ mod tests {
         let mock = SyncMock::new();
         mock.push_ok("version", wire_types::VERSION);
         mock.push_ok("can_sync", true);
+        push_matching_canary(&mock);
         // Empty canister → build_operations will produce work → start_sync is called.
         mock.push_ok("get_asset_details", Vec::<AssetDetails>::new());
         mock.push_ok("get_redirect_rules", Vec::<RedirectRule>::new());
@@ -2519,6 +2605,7 @@ mod tests {
             &[dir.path().to_str().unwrap().to_string()],
             &Principal::anonymous().to_text(),
             None,
+            Compression::Enabled,
         );
 
         let err = result.unwrap_err();
@@ -2546,6 +2633,7 @@ mod tests {
             &[dir.path().to_str().unwrap().to_string()],
             &Principal::anonymous().to_text(),
             None,
+            Compression::Enabled,
         )
         .unwrap_err();
         assert!(err.contains("not authorized"), "got: {err}");
@@ -2568,7 +2656,7 @@ mod tests {
     /// The `AssetDetails` map the canister would report after a full sync of
     /// `dir` — i.e. what the diff sees on a re-deploy of an unchanged project.
     fn canister_view(dir: &str) -> HashMap<String, AssetDetails> {
-        asset_prep::prepare_project(dir)
+        asset_prep::prepare_project(dir, asset_prep::Compression::Enabled)
             .expect("prepare project")
             .assets
             .into_iter()
@@ -2606,8 +2694,8 @@ mod tests {
         // "compression didn't help" one.
         assert_eq!(canister["/index.html"].encodings.len(), 3);
 
-        let plan = plan_project(dir_str).unwrap();
-        let project = diff_assets(plan.assets, &canister).unwrap();
+        let plan = plan_project(dir_str, Compression::Enabled).unwrap();
+        let project = diff_assets(plan.assets, &canister, true).unwrap();
 
         for key in project.keys() {
             assert!(!was_encoded(&project, key), "{key} should not be encoded");
@@ -2638,8 +2726,8 @@ mod tests {
         )
         .unwrap();
 
-        let plan = plan_project(dir_str).unwrap();
-        let project = diff_assets(plan.assets, &canister).unwrap();
+        let plan = plan_project(dir_str, Compression::Enabled).unwrap();
+        let project = diff_assets(plan.assets, &canister, true).unwrap();
 
         assert!(
             !was_encoded(&project, "/index.html"),
@@ -2664,8 +2752,8 @@ mod tests {
         let canister = canister_view(dir_str);
         std::fs::write(dir.path().join("index.html"), b"<h1>new</h1>").unwrap();
 
-        let plan = plan_project(dir_str).unwrap();
-        let project = diff_assets(plan.assets, &canister).unwrap();
+        let plan = plan_project(dir_str, Compression::Enabled).unwrap();
+        let project = diff_assets(plan.assets, &canister, true).unwrap();
 
         assert!(was_encoded(&project, "/index.html"));
         assert!(
@@ -2697,8 +2785,8 @@ mod tests {
             .encodings
             .retain(|e| e.encoding != Encoding::Brotli);
 
-        let plan = plan_project(dir_str).unwrap();
-        let project = diff_assets(plan.assets, &canister).unwrap();
+        let plan = plan_project(dir_str, Compression::Enabled).unwrap();
+        let project = diff_assets(plan.assets, &canister, true).unwrap();
 
         assert!(was_encoded(&project, "/index.html"));
         // ...but only the missing encoding is actually uploaded: the per-encoding
@@ -2712,6 +2800,107 @@ mod tests {
         assert_eq!(count_op(&ops, "SetAssetContent"), 1);
     }
 
+    /// Turning compression off against a canister synced with it on must unset
+    /// the stored compressed encodings — the diff derives the desired set from
+    /// the mode, so no canister-side record of "which mode" is needed.
+    #[test]
+    fn disabling_compression_unsets_stored_encodings() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), compressible_html()).unwrap();
+        let dir_str = dir.path().to_str().unwrap();
+
+        let canister = canister_view(dir_str);
+        assert_eq!(canister["/index.html"].encodings.len(), 3);
+
+        let plan = plan_project(dir_str, Compression::Disabled).unwrap();
+        let project = diff_assets(plan.assets, &canister, true).unwrap();
+
+        let ops = build_operations(
+            &project,
+            &canister,
+            &plan.redirect_rules,
+            &plan.redirect_rules,
+        );
+        // gzip + brotli dropped for each of the two assets; identity is unchanged
+        // and is not re-uploaded.
+        assert_eq!(count_op(&ops, "UnsetAssetContent"), 4);
+        assert_eq!(count_op(&ops, "SetAssetContent"), 0);
+    }
+
+    /// ...and turning it back on re-uploads only the compressed encodings.
+    #[test]
+    fn enabling_compression_uploads_only_the_missing_encodings() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), compressible_html()).unwrap();
+        let dir_str = dir.path().to_str().unwrap();
+
+        // A canister in the uncompressed state: identity only.
+        let mut canister = canister_view(dir_str);
+        for details in canister.values_mut() {
+            details.encodings.retain(|e| e.encoding.is_identity());
+        }
+
+        let plan = plan_project(dir_str, Compression::Enabled).unwrap();
+        let project = diff_assets(plan.assets, &canister, true).unwrap();
+
+        let ops = build_operations(
+            &project,
+            &canister,
+            &plan.redirect_rules,
+            &plan.redirect_rules,
+        );
+        assert_eq!(count_op(&ops, "SetAssetContent"), 4);
+        assert_eq!(count_op(&ops, "UnsetAssetContent"), 0);
+    }
+
+    #[test]
+    fn compressor_mismatch_forces_re_encode_of_everything() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), compressible_html()).unwrap();
+        let dir_str = dir.path().to_str().unwrap();
+
+        let canister = canister_view(dir_str);
+        let plan = plan_project(dir_str, Compression::Enabled).unwrap();
+
+        // Same inputs, same canister — only the compressor agreement differs.
+        let trusted = diff_assets(plan.assets, &canister, true).unwrap();
+        for key in trusted.keys() {
+            assert!(!was_encoded(&trusted, key));
+        }
+
+        let plan = plan_project(dir_str, Compression::Enabled).unwrap();
+        let untrusted = diff_assets(plan.assets, &canister, false).unwrap();
+        for key in untrusted.keys() {
+            assert!(
+                was_encoded(&untrusted, key),
+                "{key} must be re-encoded when the compressors may have changed"
+            );
+        }
+    }
+
+    #[test]
+    fn compressor_mismatch_still_uploads_nothing_when_bytes_agree() {
+        // The fallback re-prepares, but the resulting bytes are compared as
+        // usual — so a canary that drifted without the output actually changing
+        // costs CPU, not a pointless re-upload. Only the canary op is emitted.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("index.html"), compressible_html()).unwrap();
+        let dir_str = dir.path().to_str().unwrap();
+
+        let canister = canister_view(dir_str);
+        let plan = plan_project(dir_str, Compression::Enabled).unwrap();
+        let project = diff_assets(plan.assets, &canister, false).unwrap();
+
+        let ops = build_operations(
+            &project,
+            &canister,
+            &plan.redirect_rules,
+            &plan.redirect_rules,
+        );
+        assert_eq!(count_op(&ops, "SetAssetContent"), 0);
+        assert_eq!(count_op(&ops, "CreateAsset"), 0);
+    }
+
     #[test]
     fn content_type_drift_forces_re_encode() {
         let dir = tempfile::tempdir().unwrap();
@@ -2721,8 +2910,8 @@ mod tests {
         let mut canister = canister_view(dir_str);
         canister.get_mut("/index.html").unwrap().content_type = "text/plain".to_string();
 
-        let plan = plan_project(dir_str).unwrap();
-        let project = diff_assets(plan.assets, &canister).unwrap();
+        let plan = plan_project(dir_str, Compression::Enabled).unwrap();
+        let project = diff_assets(plan.assets, &canister, true).unwrap();
 
         assert!(was_encoded(&project, "/index.html"));
     }

--- a/crates/sync-core/src/sync.rs
+++ b/crates/sync-core/src/sync.rs
@@ -164,13 +164,24 @@ fn diff_assets(
 /// 2. same identity hash — identity is always kept, so it is always reported;
 /// 3. the stored encoding set is *exactly* the set preparation attempts.
 ///
-/// (3) is what makes this safe without extra canister state. A missing
-/// compressed encoding is ambiguous — it could mean "compression didn't shrink
+/// (3) is what makes this safe without extra canister state, and it does two
+/// jobs. A missing compressed encoding is ambiguous — "compression didn't shrink
 /// this asset" or "an earlier deploy died mid-upload" — and the two are
-/// indistinguishable without doing the compression. Treating any mismatch as
-/// stale re-encodes those assets on every sync, but an asset whose compressed
-/// form isn't smaller than its identity form is tiny by definition, so the cost
-/// is noise.
+/// indistinguishable without doing the compression. It is also what makes a
+/// [`Compression`] mode switch converge: after a `Disabled` sync the stored set
+/// is identity-only, and only a strict comparison notices that `Enabled` now
+/// wants more. A subset rule would satisfy the first job and silently break the
+/// second.
+///
+/// The cost is that any asset whose set can't match is re-encoded on **every**
+/// sync. Usually that's noise, because the usual reason a compressed encoding
+/// wasn't kept is a file small enough that gzip's framing outweighs the saving.
+/// It is not always noise: a large, high-entropy asset with a compressible
+/// content type — natively, or via a `_headers` `Content-Type` override — also
+/// fails to shrink, and then pays full brotli on every deploy (measured: ~1.5 s
+/// per 4 MB). Removing that would take per-asset state recording which encodings
+/// were attempted, which isn't worth it for how rare the shape is — but it is a
+/// real worst case, not a rounding error.
 ///
 /// This also relies on preparation parameters being frozen within a release
 /// series: the version lock pairs *code*, but a canister upgraded in place still
@@ -2838,6 +2849,51 @@ mod tests {
         // gzip + brotli dropped for each of the two assets; identity is unchanged
         // and is not re-uploaded.
         assert_eq!(count_op(&ops, "UnsetAssetContent"), 4);
+        assert_eq!(count_op(&ops, "SetAssetContent"), 0);
+    }
+
+    /// The documented worst case of the strict encoding-set rule: an asset whose
+    /// compressed form isn't smaller keeps identity only, so its set never
+    /// matches and it is re-encoded every sync. Pinned so the doc comment on
+    /// `current_encodings` stays honest about it.
+    #[test]
+    fn asset_that_does_not_compress_is_re_encoded_every_sync() {
+        let dir = tempfile::tempdir().unwrap();
+        // High-entropy bytes under a compressible content type: both compressors
+        // come out larger than identity, so neither is kept.
+        let mut state: u64 = 0x1234_5678_9abc_def0;
+        let mut data = vec![0u8; 64 * 1024];
+        for b in data.iter_mut() {
+            state ^= state >> 12;
+            state ^= state << 25;
+            state ^= state >> 27;
+            *b = (state.wrapping_mul(0x2545_F491_4F6C_DD1D) >> 33) as u8;
+        }
+        std::fs::write(dir.path().join("random.txt"), &data).unwrap();
+        let dir_str = dir.path().to_str().unwrap();
+
+        let canister = canister_view(dir_str);
+        assert_eq!(
+            canister["/random.txt"].encodings.len(),
+            1,
+            "neither compressor beats identity on this content"
+        );
+
+        let plan = plan_project(dir_str, Compression::Enabled).unwrap();
+        let project = diff_assets(plan.assets, &canister, true).unwrap();
+
+        assert!(
+            was_encoded(&project, "/random.txt"),
+            "identity-only sets are indistinguishable from a half-finished upload, \
+             so the asset is re-encoded"
+        );
+        // The cost is CPU only — nothing is uploaded, since the bytes still match.
+        let ops = build_operations(
+            &project,
+            &canister,
+            &plan.redirect_rules,
+            &plan.redirect_rules,
+        );
         assert_eq!(count_op(&ops, "SetAssetContent"), 0);
     }
 

--- a/crates/sync-core/tests/call_pattern.rs
+++ b/crates/sync-core/tests/call_pattern.rs
@@ -21,7 +21,7 @@ use candid::{CandidType, Decode, Encode, Principal};
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::path::Path;
-use sync_core::{Call, CanisterCall, sync};
+use sync_core::{Call, CanisterCall, Compression, sync};
 use wire_types::{AssetDetails, RedirectRule, UploadChunksArguments};
 
 // Wire-compatible mirrors of the response types defined privately in
@@ -111,10 +111,13 @@ impl CanisterCall for RecordingMock {
                 let ids: Vec<u64> = (0..req.chunks.len() as u64).collect();
                 Encode!(&ids)
             }
-            "execute_operations" => Encode!(&()),
+            "execute_operations" => Encode!(&None::<serde_bytes::ByteBuf>),
             // The test drives sync() in direct mode, which checks can_sync up
             // front; report the identity as allowed so it proceeds.
             "can_sync" => Encode!(&true),
+            // An empty canister has no recorded compression fingerprint, so
+            // report the "unknown" value — every asset is new here anyway.
+            "preparation_canary" => Encode!(&serde_bytes::ByteBuf::from(vec![0u8; 32])),
             other => panic!("RecordingMock: unexpected method '{other}'"),
         }
         .map_err(|e| e.to_string())
@@ -145,7 +148,13 @@ fn run_scenario(label: &str, count: usize, size_bytes: usize) -> CallFingerprint
 
     let mock = RecordingMock::new();
     let started = std::time::Instant::now();
-    let result = sync(&mock, &dirs, &Principal::anonymous().to_text(), None);
+    let result = sync(
+        &mock,
+        &dirs,
+        &Principal::anonymous().to_text(),
+        None,
+        Compression::Enabled,
+    );
     let elapsed = started.elapsed();
     result.expect("sync failed");
 
@@ -196,13 +205,14 @@ fn many_tiny_files() {
             &[
                 ("version", 1),
                 ("can_sync", 1),
+                ("preparation_canary", 1),
                 ("get_asset_details", 1),
                 ("get_redirect_rules", 1),
                 ("start_sync", 1),
                 ("upload_chunks", 1),
                 ("execute_operations", 5),
             ],
-            1_160_809,
+            1_160_920,
         ),
     );
 }
@@ -217,13 +227,14 @@ fn many_small_files() {
             &[
                 ("version", 1),
                 ("can_sync", 1),
+                ("preparation_canary", 1),
                 ("get_asset_details", 1),
                 ("get_redirect_rules", 1),
                 ("start_sync", 1),
                 ("upload_chunks", 1),
                 ("execute_operations", 1),
             ],
-            528_149,
+            528_204,
         ),
     );
 }
@@ -237,13 +248,14 @@ fn few_medium_files() {
             &[
                 ("version", 1),
                 ("can_sync", 1),
+                ("preparation_canary", 1),
                 ("get_asset_details", 1),
                 ("get_redirect_rules", 1),
                 ("start_sync", 1),
                 ("upload_chunks", 12),
                 ("execute_operations", 1),
             ],
-            20_976_522,
+            20_976_577,
         ),
     );
 }
@@ -258,13 +270,14 @@ fn one_huge_file() {
             &[
                 ("version", 1),
                 ("can_sync", 1),
+                ("preparation_canary", 1),
                 ("get_asset_details", 1),
                 ("get_redirect_rules", 1),
                 ("start_sync", 1),
                 ("upload_chunks", 28),
                 ("execute_operations", 1),
             ],
-            52_433_888,
+            52_433_943,
         ),
     );
 }

--- a/crates/sync-plugin/src/lib.rs
+++ b/crates/sync-plugin/src/lib.rs
@@ -9,7 +9,7 @@ wit_bindgen::generate!({
 });
 use crate::icp::sync_plugin::types as ty;
 
-use sync_core::{Call, CallType, CanisterCall, sync};
+use sync_core::{Call, CallType, CanisterCall, Compression, sync};
 
 struct WasiCall;
 
@@ -44,11 +44,17 @@ impl Guest for Plugin {
             "sync plugin: starting for canister {} (environment: {})",
             input.canister_id, input.environment
         );
+        // Always the canonical preparation. Turning compression off is a
+        // deploy-time trade a *platform* makes for builds nobody browses (see
+        // `asset-prep::Compression`); every `icp deploy` serves real visitors, so
+        // the plugin never offers the choice — the cost would land on them, not
+        // on whoever typed the command.
         let summary = sync(
             &WasiCall,
             &input.dirs,
             &input.identity_principal,
             input.proxy_canister_id.as_deref(),
+            Compression::Enabled,
         )?;
         eprintln!("{summary}");
         Ok(())

--- a/crates/wire-types/src/lib.rs
+++ b/crates/wire-types/src/lib.rs
@@ -176,6 +176,16 @@ pub struct SetAssetHeadersArguments {
     pub headers: Vec<(String, String)>,
 }
 
+/// Record the client's compression fingerprint over the assets this sync wrote.
+///
+/// The canister only stores it; the meaning lives in `asset-prep::canary`. A
+/// client emits this after re-preparing *every* asset eagerly, which is what
+/// makes the stored value describe the whole asset set rather than part of it.
+#[derive(Clone, Debug, PartialEq, Eq, CandidType, Serialize, Deserialize)]
+pub struct SetPreparationCanaryArguments {
+    pub canary: ByteBuf,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Serialize, Deserialize)]
 pub enum RulePattern {
     /// Matches a single absolute path, e.g. `/old-page`.
@@ -218,6 +228,7 @@ pub enum Operation {
     DeleteAsset(DeleteAssetArguments),
     SetAssetHeaders(SetAssetHeadersArguments),
     SetRedirectRules(SetRedirectRulesArguments),
+    SetPreparationCanary(SetPreparationCanaryArguments),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, CandidType, Serialize, Deserialize)]

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -63,6 +63,20 @@ one file in a large site therefore costs one file's worth of compression, and
 re-deploying an unchanged site costs none at all. (Header and redirect changes are
 still detected for every asset — those don't depend on content.)
 
+Reusing what's already stored assumes the compressors still behave the same way, and
+that isn't something a version number can promise — compressed output isn't part of
+a library's published interface. So each sync also records a small fingerprint of how
+its compressors actually behaved. If a later deploy's fingerprint differs — a
+dependency update, a different backend — it stops trusting the shortcut and
+re-prepares every asset, restoring the canister to exactly what the new build
+produces.
+
+Compression is on for every `icp deploy`. A platform building on these crates can
+turn it off for deploys nobody browses — a preview opened once by its author — which
+removes the compression pass and uploads less, at the cost of much larger transfers
+for anyone who does visit. Switching a canister between the two needs no cleanup:
+turning compression on uploads the missing encodings, turning it off removes them.
+
 ## ETag and conditional requests
 
 Every asset is served with an `ETag` — a strong validator derived from the SHA-256

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -55,6 +55,14 @@ At request time the canister reads the browser's `Accept-Encoding` header and se
 the best encoding both sides support, setting `Content-Encoding` accordingly. You get
 smaller transfers for free, with no build-step configuration.
 
+Compressing is the slowest part of a deploy, so a sync does it only where it has to.
+It first reads each file and hashes it uncompressed, then asks the canister what it
+already holds; any asset whose uncompressed hash, content type and encoding set
+already match is left alone, and only the rest are compressed and uploaded. Editing
+one file in a large site therefore costs one file's worth of compression, and
+re-deploying an unchanged site costs none at all. (Header and redirect changes are
+still detected for every asset — those don't depend on content.)
+
 ## ETag and conditional requests
 
 Every asset is served with an `ETag` — a strong validator derived from the SHA-256

--- a/docs/verifying-contents.md
+++ b/docs/verifying-contents.md
@@ -42,8 +42,15 @@ that produce the served directory).
 
    ```sh
    state-hash ./dist
-   # 8150a65e854b9bbb…  (64 hex chars)
+   # compressed    8150a65e854b9bbb…  (64 hex chars)
+   # uncompressed  3f0c1d92ab77e410…
    ```
+
+   Two hashes, because a deploy either stores compressed encodings alongside the
+   uncompressed copy or doesn't, and the same directory hashes differently either
+   way. `icp deploy` always produces the `compressed` form; the `uncompressed`
+   form comes from a platform that deployed with compression turned off (see
+   [how it works](how-it-works.md)). A canister matches exactly one of the two.
 
 3. **Read the canister's hash.** `state_hash` is a public, unguarded method — and
    an *update* call, so the reply is consensus-backed and trustworthy:
@@ -53,9 +60,9 @@ that produce the served directory).
    # (blob "\81\50\a6\5e…")
    ```
 
-4. **Compare.** If the two hashes are equal, the canister serves exactly the build
-   you reproduced from source. If they differ, the served content, headers, or
-   redirects do not match that source.
+4. **Compare.** If the canister's hash equals either of the two you computed, it
+   serves exactly the build you reproduced from source. If it matches neither, the
+   served content, headers, or redirects do not match that source.
 
 The deploy also prints a hash in the `icp deploy` / sync result (`canister reports
 state hash <hex>`). That value comes back from the canister on the call that
@@ -70,8 +77,12 @@ The hash is bound to how content is prepared, so a verifier must use a
 parameters baked into the hash:
 
 - **Compression** — gzip at `flate2`'s default level; brotli at quality 11,
-  window 22. Compressed encodings are not reproducible by an independent
-  reimplementation, so the verifier reuses this project's preparation code.
+  window 22, **as produced by the exact compressor builds this version links**.
+  RFC 7932 and RFC 1951 specify *decoders*, so those settings don't determine the
+  bytes: a different encoder — or a different version of the same one — may emit
+  a different valid stream. That is why the verifier reuses this project's
+  preparation code rather than reimplementing it, and why the `uncompressed`
+  hash, which involves no compressor at all, is the more durable of the two.
 - **Chunk boundary** — `MAX_CHUNK_SIZE` (1,900,000 bytes). Per-chunk hashes for
   large assets depend on where chunks split.
 - **Byte format** — a versioned, length-prefixed, domain-separated SHA-256

--- a/docs/verifying-contents.md
+++ b/docs/verifying-contents.md
@@ -57,9 +57,11 @@ that produce the served directory).
    you reproduced from source. If they differ, the served content, headers, or
    redirects do not match that source.
 
-The deploy also prints the hash in the `icp deploy` / sync result (`state hash
-<hex>`), so the operator can confirm their own deploy is self-consistent — but
-again, that is not third-party verification.
+The deploy also prints a hash in the `icp deploy` / sync result (`canister reports
+state hash <hex>`). That value comes back from the canister on the call that
+finalizes the sync, so it tells the operator what the canister now holds — it is
+*not* a locally-derived cross-check, and not third-party verification. Only the
+`state-hash` tool above, run against source you reproduced, is that.
 
 ## The frozen contract
 
@@ -76,9 +78,10 @@ parameters baked into the hash:
   stream (see the `state-hash` crate). Independent of map/header iteration order,
   but bound to this layout version.
 
-Because there are no production instances and no stored hashes to preserve, this
-contract can change between releases; when it does, the format version is bumped
-and every previously-computed hash is expected to change.
+The contract can change between releases; when it does, the format version is
+bumped and every previously-computed hash is expected to change. Within a release
+series it is frozen — a patch upgrade preserves stored content, so a build that
+changed these parameters would silently invalidate every deployed canister's hash.
 
 ## Relationship to certification
 


### PR DESCRIPTION
Three related changes to what a deploy spends locally.

**Lazy encoding.** Preparation compressed every asset on every sync, and only then did the diff discover most were already in place — so a re-deploy paid full brotli q11 to learn it had nothing to upload. It now hashes uncompressed bytes first and compresses only what the canister doesn't already hold.

**Compressor canary.** That skip infers "unchanged uncompressed hash ⇒ unchanged compressed encodings", which holds only while the compressors behave identically — and nothing guarantees that: compressed output isn't part of a crate's published API, and RFCs 7932/1951 specify decoders. Left alone it fails silently and permanently. So each sync records a fingerprint of how its compressors actually behaved; a mismatch re-prepares everything, restoring the pre-lazy-encoding converging behaviour automatically. Golden vectors pin the same bytes at PR time, and CI now builds `--locked`.

**`Compression::{Enabled, Disabled}`** on `sync-agent::SyncOpts`. `Disabled` stores identity only — no compressor runs, and ~20–25% fewer bytes upload since one copy goes over the wire instead of three. Deliberately unreachable from `icp deploy`: the saving goes to whoever runs the deploy, the 5–6× larger transfers go to whoever visits the site.

### Notes for the 0.3.2 release

- Patch-compatible: the canary is a new stable cell on a previously unused `MemoryId`, so `post_upgrade` needs no migration.
- After upgrading an existing canister, the **first sync re-encodes everything but uploads nothing** — the canary reads "unknown", and since the compressors haven't actually changed every hash matches. One slow deploy, then fast.
- `state-hash` now prints two hashes (`compressed` / `uncompressed`), since the two modes hash the same `dist/` differently.

### Not included

`state-hash ./dist` still rejects relative paths (pre-existing `scan::absolute_root`, correct for the WASI preopen and wrong natively). Separate PR.