### PR TITLE
feat: accept explicit asset content types from native embedders

### DIFF
--- a/crates/asset-prep/src/lib.rs
+++ b/crates/asset-prep/src/lib.rs
@@ -35,8 +35,10 @@ pub use compressors::{CompressFn, Compressors};
 
 mod prepare;
 pub use prepare::{
-    MAX_CHUNK_SIZE, PlannedAsset, PreparedAsset, PreparedChunk, PreparedEncoding, PreparedProject,
-    ProjectPlan, manifest, plan_project, prepare_project, state_hash_for_dir,
+    ContentTypeOverrides, MAX_CHUNK_SIZE, PlannedAsset, PreparedAsset, PreparedChunk,
+    PreparedEncoding, PreparedProject, ProjectPlan, manifest, plan_project,
+    plan_project_with_content_types, prepare_project, prepare_project_with_content_types,
+    state_hash_for_dir,
 };
 
 /// Strips a Netlify-style trailing comment from a single line of a `_redirects`

--- a/crates/asset-prep/src/prepare.rs
+++ b/crates/asset-prep/src/prepare.rs
@@ -20,7 +20,9 @@
 //! the canister's stored-state hash and the verifier's `dist/`-derived hash
 //! agree by construction.
 
+use mime::Mime;
 use sha2::{Digest, Sha256};
+use std::collections::HashMap;
 use std::path::Path;
 
 use wire_types::{Encoding, RedirectRule, RulePattern};
@@ -37,6 +39,12 @@ use crate::{html_handling, not_found};
 /// it, so a verifier must use a `state-hash-cli` built with this same value.
 /// Stays safely under the canister's ~2 MB ingress message limit.
 pub const MAX_CHUNK_SIZE: usize = 1_900_000;
+
+/// Exact asset keys mapped to caller-declared media types.
+///
+/// These declarations take precedence over both extension inference and
+/// `_headers` `Content-Type` rules.
+pub type ContentTypeOverrides = HashMap<String, Mime>;
 
 /// One chunk of a prepared encoding: its length and SHA-256 (folded into the
 /// state hash for multi-chunk encodings) plus the bytes themselves (consumed by
@@ -179,10 +187,20 @@ pub struct ProjectPlan {
 /// assets the canister already holds; the `state-hash-cli` verifier calls this,
 /// since reproducing the manifest requires every encoding.
 pub fn prepare_project(dir: &str, compressors: &Compressors) -> Result<PreparedProject, String> {
+    prepare_project_with_content_types(dir, compressors, &ContentTypeOverrides::new())
+}
+
+/// Prepares a project while applying caller-declared media types by exact asset
+/// key.
+pub fn prepare_project_with_content_types(
+    dir: &str,
+    compressors: &Compressors,
+    content_types: &ContentTypeOverrides,
+) -> Result<PreparedProject, String> {
     let ProjectPlan {
         assets,
         redirect_rules,
-    } = plan_project(dir, compressors)?;
+    } = plan_project_with_content_types(dir, compressors, content_types)?;
 
     let assets = assets
         .into_iter()
@@ -203,6 +221,16 @@ pub fn prepare_project(dir: &str, compressors: &Compressors) -> Result<PreparedP
 /// misconfigurations are caught before any canister round-trip — and before any
 /// compression work.
 pub fn plan_project(dir: &str, compressors: &Compressors) -> Result<ProjectPlan, String> {
+    plan_project_with_content_types(dir, compressors, &ContentTypeOverrides::new())
+}
+
+/// Plans a project while applying caller-declared media types by exact asset
+/// key.
+pub fn plan_project_with_content_types(
+    dir: &str,
+    compressors: &Compressors,
+    content_types: &ContentTypeOverrides,
+) -> Result<ProjectPlan, String> {
     let sources = scan::scan(dir)?;
     let user_rules = load_redirect_rules(dir)?;
 
@@ -228,7 +256,12 @@ pub fn plan_project(dir: &str, compressors: &Compressors) -> Result<ProjectPlan,
 
     let mut assets = Vec::with_capacity(sources.len() + 1);
     for source in sources {
-        assets.push(plan_asset(source, &header_rules, compressors)?);
+        assets.push(plan_asset(
+            source,
+            &header_rules,
+            content_types,
+            compressors,
+        )?);
     }
     if not_found_plan.inject_branded_asset {
         assets.push(plan_branded_404(&header_rules, compressors)?);
@@ -248,6 +281,7 @@ pub fn plan_project(dir: &str, compressors: &Compressors) -> Result<ProjectPlan,
 fn plan_asset(
     source: AssetSource,
     header_rules: &[HeaderRule],
+    content_types: &ContentTypeOverrides,
     compressors: &Compressors,
 ) -> Result<PlannedAsset, String> {
     let mut content = Content::load(&source.path)?;
@@ -256,6 +290,9 @@ fn plan_asset(
     // then picks up gzip and the correct certified `Content-Type`).
     if let Some(override_mime) = headers::content_type_for(&source.key, header_rules) {
         content.media_type = override_mime;
+    }
+    if let Some(override_mime) = content_types.get(&source.key) {
+        content.media_type = override_mime.clone();
     }
     Ok(plan_content_asset(
         source.key,
@@ -539,6 +576,42 @@ mod tests {
             let total: u64 = enc.chunks.iter().map(|c| c.len as u64).sum();
             assert_eq!(enc.content_len, total);
         }
+    }
+
+    #[test]
+    fn caller_content_type_overrides_inference_and_headers() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            &dir,
+            ".well-known/ic-architecture",
+            br#"{"version":"1.0.0"}"#,
+        );
+        write(
+            &dir,
+            "_headers",
+            b"/.well-known/ic-architecture\n  Content-Type: text/plain\n",
+        );
+        let content_types = ContentTypeOverrides::from([(
+            "/.well-known/ic-architecture".to_string(),
+            "application/json".parse().unwrap(),
+        )]);
+
+        let prepared = prepare_project_with_content_types(
+            &dir_str(&dir),
+            &Compressors::none(),
+            &content_types,
+        )
+        .unwrap();
+
+        assert_eq!(
+            prepared
+                .assets
+                .iter()
+                .find(|asset| asset.key == "/.well-known/ic-architecture")
+                .unwrap()
+                .content_type,
+            "application/json"
+        );
     }
 
     #[test]

--- a/crates/sync-core/src/lib.rs
+++ b/crates/sync-core/src/lib.rs
@@ -9,6 +9,6 @@
 mod canister;
 mod sync;
 
-pub use asset_prep::{CompressFn, Compressors};
+pub use asset_prep::{CompressFn, Compressors, ContentTypeOverrides};
 pub use canister::{Call, CallType, CanisterCall};
-pub use sync::sync;
+pub use sync::{sync, sync_with_content_types};

--- a/crates/sync-core/src/sync.rs
+++ b/crates/sync-core/src/sync.rs
@@ -13,8 +13,8 @@ use crate::canister::{
     list_all_redirect_rules, preparation_canary, start_sync, version,
 };
 use asset_prep::{
-    Compressors, MAX_CHUNK_SIZE, PlannedAsset, PreparedAsset, PreparedChunk, ProjectPlan,
-    plan_project,
+    Compressors, ContentTypeOverrides, MAX_CHUNK_SIZE, PlannedAsset, PreparedAsset, PreparedChunk,
+    ProjectPlan, plan_project_with_content_types,
 };
 use wire_types::{
     AssetDetails, ChunkId, CreateAssetArguments, DeleteAssetArguments, Encoding,
@@ -302,6 +302,25 @@ pub fn sync<C: CanisterCall>(
     proxy_canister_id: Option<&str>,
     compressors: &Compressors,
 ) -> Result<String, String> {
+    sync_with_content_types(
+        canister,
+        dirs,
+        identity_principal,
+        proxy_canister_id,
+        compressors,
+        &ContentTypeOverrides::new(),
+    )
+}
+
+/// Syncs assets while applying caller-declared media types by exact asset key.
+pub fn sync_with_content_types<C: CanisterCall>(
+    canister: &C,
+    dirs: &[String],
+    identity_principal: &str,
+    proxy_canister_id: Option<&str>,
+    compressors: &Compressors,
+    content_types: &ContentTypeOverrides,
+) -> Result<String, String> {
     // The assets plugin owns the URL space of its canister: every key starts at
     // `/`, `_redirects` lives at the project root, and the canister has no
     // notion of "merge two trees together". Multiple input directories would
@@ -352,7 +371,7 @@ pub fn sync<C: CanisterCall>(
     // `state-hash-cli` verifier (see `asset-prep`); the expensive half —
     // gzip/brotli — is deferred to `diff_assets`, which runs it only for assets
     // the canister doesn't already hold.
-    let plan = plan_project(dir, compressors)?;
+    let plan = plan_project_with_content_types(dir, compressors, content_types)?;
     println!("planned {} asset(s) from {dir}", plan.assets.len());
     if compressors.is_empty() {
         println!("no compressors set: storing uncompressed content only");
@@ -896,7 +915,7 @@ fn update_headers(
 mod tests {
     use super::*;
     use crate::{Call, CanisterCall};
-    use asset_prep::not_found;
+    use asset_prep::{not_found, plan_project};
     use candid::{CandidType, Decode, Principal};
     use sha2::{Digest, Sha256};
     use std::cell::RefCell;

--- a/crates/sync-core/src/sync.rs
+++ b/crates/sync-core/src/sync.rs
@@ -2514,6 +2514,54 @@ mod tests {
     }
 
     #[test]
+    fn sync_uses_the_explicit_content_type_in_create_asset() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join(".well-known")).unwrap();
+        std::fs::write(
+            dir.path().join(".well-known/ic-architecture"),
+            br#"{"version":"1.0.0"}"#,
+        )
+        .unwrap();
+
+        let mock = SyncMock::new();
+        mock.push_ok("version", wire_types::VERSION);
+        mock.push_ok("can_sync", true);
+        push_matching_canary(&mock);
+        mock.push_ok("get_asset_details", Vec::<AssetDetails>::new());
+        mock.push_ok("get_redirect_rules", Vec::<RedirectRule>::new());
+        mock.push_ok("start_sync", StartSyncOk::Started { session_id: 1 });
+        mock.push_ok("execute_operations", ());
+
+        let content_types = ContentTypeOverrides::from([(
+            "/.well-known/ic-architecture".to_string(),
+            "application/json".parse().unwrap(),
+        )]);
+        sync_with_content_types(
+            &mock,
+            &[dir.path().to_str().unwrap().to_string()],
+            &Principal::anonymous().to_text(),
+            None,
+            &Compressors::none(),
+            &content_types,
+        )
+        .unwrap();
+
+        let manifest = mock
+            .executed_operations()
+            .into_iter()
+            .find_map(|operation| match operation {
+                Operation::CreateAsset(arguments)
+                    if arguments.key == "/.well-known/ic-architecture" =>
+                {
+                    Some(arguments)
+                }
+                _ => None,
+            })
+            .expect("CreateAsset for the architecture manifest");
+        assert_eq!(manifest.content_type, "application/json");
+    }
+
+    #[test]
     fn synthesised_rules_win_over_user_rule_at_same_from() {
         // Synthesised rules are emitted **before** the user's `_redirects` —
         // synth must come first so html-handling Exact rules don't get


### PR DESCRIPTION
## Summary

- add compatible `plan_project_with_content_types` and `prepare_project_with_content_types` entry points to `asset-prep`
- add `sync_with_content_types` to `sync-core` while preserving the existing `sync` API
- apply exact caller declarations after inference and `_headers` content-type rules, without changing response headers

This lets native embedders pass media types as structured data instead of synthesizing a Netlify-style `_headers` file and parsing it back. Existing callers continue through the old entry points with an empty override map.

Closes #120.

## Test plan

- [x] `cargo test -p asset-prep` (162 passed)
- [x] `cargo test -p sync-core` (84 unit and 4 call-pattern tests passed)
- [x] `cargo build -p asset-prep --no-default-features`
- [x] `cargo clippy -p asset-prep -p sync-core --all-targets`