### PR TITLE
docs: add sync frontmatter and drop em-dashes from docs/

### DIFF
--- a/docs/access-protection.md
+++ b/docs/access-protection.md
@@ -1,16 +1,21 @@
-# Access protection (private apps)
+---
+title: "Access protection"
+description: "Put a login page in front of a private or preview site with revocable, expiring access tokens"
+sidebar:
+  order: 6
+---
 
 By default every deployed app is public. **Access protection** puts a login screen
 in front of it: unauthenticated visitors get a certified redirect to your login
 page (or a `401` for non-page assets) instead of your content. It's meant to
-**deter casual/public access** to in-progress or preview work — not to provide
+**deter casual/public access** to in-progress or preview work, not to provide
 confidentiality against a determined attacker (see [Threat model](#threat-model)).
 
 Access is a set of **labeled tokens**. The cookie *is* the token: a visitor presents
 a token, the canister sets it as a cookie, and every request re-validates that cookie
 against the token store. A classic single "password" is just one long-lived token.
 
-When protection is off, the app is **completely unchanged** — no gate, no extra
+When protection is off, the app is **completely unchanged**: no gate, no extra
 headers, no cost difference. Everything below applies only once you enable it.
 
 ## Quick start
@@ -30,7 +35,7 @@ icp canister call frontend issue_token \
   '(record { label = "owner"; ttl_secs = 31536000 : nat32; value = opt "my-passphrase" })'
 ```
 
-That's it — `https://<canister-id>.icp0.io/` now redirects strangers to
+That's it: `https://<canister-id>.icp0.io/` now redirects strangers to
 `/login.html`, and visitors who present `my-passphrase` get in.
 
 > **Enable before the first sync for a brand-new private app.** Enabling on an empty
@@ -42,29 +47,29 @@ That's it — `https://<canister-id>.icp0.io/` now redirects strangers to
 | Method | Call | Effect |
 |---|---|---|
 | Issue | `issue_token '(record { label = "<label>"; ttl_secs = <secs> : nat32; value = opt "<value>" })'` | Mints a token and **returns its value**. Pass `value = null` (or leave the field out) to get a high-entropy random token instead of a chosen passphrase. |
-| Revoke | `revoke_token '("<label>")'` | Removes every token with that label — **live**, so the next request bearing it is rejected. |
+| Revoke | `revoke_token '("<label>")'` | Removes every token with that label. Takes effect **live**, so the next request bearing it is rejected. |
 | List | `list_tokens '()'` | Returns `{ label; expires_at }` for every live token (controller-only). |
 | Status | `check_protection_status '()'` | `Disabled`, `Enabled`, or `EnabledLoginPageMissing` (controller-only). |
 | Disable | `disable_protection '()'` | Turns the gate off and drops all tokens. |
 
-Always pass the argument explicitly — `'()'` for the methods that take none. Given no
+Always pass the argument explicitly (`'()'` for the methods that take none). Given no
 argument, `icp canister call` opens an interactive prompt instead of sending an empty one.
 
-Each token has its **own expiry** and is **individually revocable** — revoking one
+Each token has its **own expiry** and is **individually revocable**: revoking one
 leaked share doesn't disturb anyone else. Expired tokens are rejected immediately
 whether or not they've been swept, and are garbage-collected as new ones are issued.
 
 **Random vs. chosen value.** A random token (omit the chosen value) is unguessable
 and never transits the subnet in readable form. A chosen passphrase is typeable but
 brute-forceable, and is visible to node operators in the block that carries the
-`issue_token` call — acceptable under the threat model, but prefer random tokens for
-share links.
+`issue_token` call. That is acceptable under the threat model, but prefer random
+tokens for share links.
 
 ## The login page
 
 The login page is **your own asset**, synced in `dist/` and named when you
 `enable_protection`. The canister serves it certified like any other page; it is the
-**only gate-exempt path**, so it must be **fully self-contained** — inline its CSS and
+**only gate-exempt path**, so it must be **fully self-contained**: inline its CSS and
 JS, and use `data:` URIs for images. Any external subresource it referenced would
 itself be gated and fail to load for a logged-out visitor.
 
@@ -105,7 +110,7 @@ A minimal page that does both:
 
 | Request | Response |
 |---|---|
-| An HTML page (or any path with no exact asset — SPA routes, 404s) | Certified `307 → <login_page>` |
+| An HTML page (or any path with no exact asset, such as SPA routes and 404s) | Certified `307 → <login_page>` |
 | A non-HTML asset (JS/CSS/image/JSON) | Certified `401` (a redirect would hand a `<script>` the wrong content type) |
 | The login page itself | Always served (gate-exempt) |
 
@@ -116,12 +121,12 @@ cookie-blind boundary cache can never replay one visitor's response to another.
 
 `check_protection_status` reports one of:
 
-- **`Disabled`** — public app.
-- **`Enabled`** — gate on, login page present.
-- **`EnabledLoginPageMissing`** — gate on, but the named login-page asset isn't
+- **`Disabled`**: public app.
+- **`Enabled`**: gate on, login page present.
+- **`EnabledLoginPageMissing`**: gate on, but the named login-page asset isn't
   synced. The app **stays protected** (no content is served); requests redirect to a
-  page that 404s until you sync it. It **self-heals** to `Enabled` once the page lands
-  — no need to re-enable.
+  page that 404s until you sync it. It **self-heals** to `Enabled` once the page
+  lands, with no need to re-enable.
 
 The gate **fails closed**: a sync that removes the login page, or enabling before the
 first sync, never exposes content.
@@ -136,27 +141,27 @@ store, so a token replayed against another canister isn't in *its* store.
 
 The canister serves **response-only** certified responses: the HTTP gateway (and any
 verifier) checks that each response is an *authentic, certified* response for the
-requested path — but **not** which of several certified responses the canister chose to
-return. Choosing one is ordinary application logic.
+requested path, but **not** which of several certified responses the canister chose
+to return. Choosing one is ordinary application logic.
 
 That is the same mechanism the canister already uses to serve more than one response
-per URL — different content encodings, `200` vs `304`, `206` range responses, and the
+per URL: different content encodings, `200` vs `304`, `206` range responses, and the
 redirect/rewrite rules that serve one asset's body under another path. Access
 protection has the same shape: under every protected path the canister certifies
-**both** the asset's normal responses **and** a certified *unauthenticated sibling* —
-the `307 → <login_page>` (HTML pages) or the `401` (other types). At serve time it
-reads the `certified_assets_access` cookie and returns the sibling when it's missing or
-invalid, the real asset when it's valid — each one independently verified by the
+**both** the asset's normal responses **and** a certified *unauthenticated sibling*,
+either the `307 → <login_page>` (HTML pages) or the `401` (other types). At serve time
+it reads the `certified_assets_access` cookie and returns the sibling when it's missing
+or invalid, the real asset when it's valid; each one is independently verified by the
 gateway. The login page's path additionally carries the certified `302 + Set-Cookie`
 redeem (one per token) and the `401` re-prompt, so a login `POST` is honored only
 because its outcome is certified too.
 
 **Why not certify the request?** Doing so would let the canister prove *which* request
-it answered, but request certification hashes the whole `Cookie` header verbatim — it
-can't match on a single *named* cookie. Nor would it fire: the canister sets its own
+it answered, but request certification hashes the whole `Cookie` header verbatim, so
+it can't match on a single *named* cookie. Nor would it fire: the canister sets its own
 `ic_env` cookie on HTML responses, so a browser always sends
 `Cookie: ic_env=…; certified_assets_access=…`, never a bare value. Picking one cookie
-out of many is necessarily app-side logic — hence response-only.
+out of many is necessarily app-side logic, hence response-only.
 
 **The caveat this creates.** Because the cookie→response choice is uncertified app
 logic, *which* response a request receives is **not** covered by the certificate. An
@@ -168,16 +173,16 @@ and it sets up the trust boundary the threat model below makes precise.
 ## Threat model
 
 This is **access gating, not confidentiality.** Under the IC's honest-replica /
-honest-boundary-node assumption — the same assumption all query serving already makes
-— unauthorized visitors can't pull your content. But:
+honest-boundary-node assumption (the same assumption all query serving already
+makes), unauthorized visitors can't pull your content. But:
 
 - Asset bytes and the token store live in replicated canister state, so a **node
   operator can read both**. Protection does not hide content from operators. (Random
   token values are stored hashed; a low-entropy chosen passphrase is still
   brute-forceable, like any password hash.)
 - TLS terminates at the boundary node, which sees the cookie in clear.
-- There is **no brute-force protection, lockout, or rate-limiting** — login attempts
+- There is **no brute-force protection, lockout, or rate-limiting**: login attempts
   are unbilled, untracked queries. The deterrent is high-entropy random tokens.
 
-Use it to keep a preview or in-progress app out of public view — not to protect
+Use it to keep a preview or in-progress app out of public view, not to protect
 secrets from a determined adversary.

--- a/docs/headers.md
+++ b/docs/headers.md
@@ -1,7 +1,12 @@
-# Custom headers
+---
+title: "Custom headers"
+description: "The _headers file: cache-control, security headers, content types, and how rules combine"
+sidebar:
+  order: 4
+---
 
 Add a file named `_headers` to the root of your asset directory to attach response
-headers — cache-control, a Content Security Policy, other security headers — to files
+headers (cache-control, a Content Security Policy, other security headers) to files
 on your site. The syntax follows [Netlify's `_headers`](https://docs.netlify.com/manage/routing/headers/):
 a path pattern on its own line, followed by indented `Name: value` lines.
 
@@ -20,19 +25,19 @@ A blank line or a `#` comment ends a block.
 
 A pattern is an absolute path (leading `/`) with an optional `*` wildcard:
 
-- `/index.html` — one exact file (the home page).
-- `/about.html` — likewise, one exact file.
-- `/assets/*` — everything under `/assets/`.
-- `/*.css` — every file ending in `.css`.
-- `/*` — every file.
+- `/index.html`: one exact file (the home page).
+- `/about.html`: likewise, one exact file.
+- `/assets/*`: everything under `/assets/`.
+- `/*.css`: every file ending in `.css`.
+- `/*`: every file.
 
 The single `*` matches any run of characters, including `/`. There is no `**`, no
 `?`, and no `:placeholder` capture (see [why dynamic rules aren't supported](redirects.md#what-isnt-supported-dynamic-rules)).
 
 ### Patterns match files, not URLs
 
-A pattern is matched against the **path of the file inside your directory** — its
-asset key — not against the URL a visitor typed. For most sites the two are the same
+A pattern is matched against the **path of the file inside your directory** (its
+asset key), not against the URL a visitor typed. For most sites the two are the same
 string and the distinction never comes up, but it matters wherever a URL and a file
 differ:
 
@@ -40,8 +45,8 @@ differ:
   page. There is no file at `/`, so a `/` pattern matches nothing at all.
 - **Rewrites.** A `200` [rewrite](redirects.md) serves its target file's contents,
   and reuses that file's headers. So the headers for `/article` come from the pattern
-  matching `/content/article.html`. For a [SPA](routing.md#single-page-apps-spa) — where
-  a single `/*` rewrite serves the shell at every client route — this means a
+  matching `/content/article.html`. For a [SPA](routing.md#single-page-apps-spa), where
+  a single `/*` rewrite serves the shell at every client route, this means a
   `Cache-Control` declared for `/index.html` reaches all of them, and a block written
   against a route like `/dashboard/*` matches no file and does nothing.
 - **Redirects.** A `3xx` rule is the one exception: it synthesizes its own response
@@ -51,7 +56,7 @@ differ:
 ## How rules combine
 
 A file can match several blocks at once, and **all matching blocks contribute** their
-headers — patterns don't override each other wholesale. For a single header name:
+headers; patterns don't override each other wholesale. For a single header name:
 
 - Values from different matching blocks are combined into one header, comma-separated
   (per the HTTP spec).
@@ -76,7 +81,7 @@ Unlike other headers, `Content-Type` is single-valued and first-match-wins.
 
 ## No headers are added for you
 
-The canister applies **no default headers** — no `Cache-Control`, no security headers,
+The canister applies **no default headers**: no `Cache-Control`, no security headers,
 no CSP. If you want them, declare them in `_headers`. The only response headers the
 canister manages on its own are the ones tied to how it serves and certifies content:
 `Content-Type`, `Content-Encoding`, `ETag`, `Content-Range` (on large-asset
@@ -92,7 +97,7 @@ A useful baseline to copy and adapt:
   Referrer-Policy: strict-origin-when-cross-origin
   Content-Security-Policy: default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'
 
-# Fingerprinted build assets never change — cache them hard
+# Fingerprinted build assets never change, so cache them hard
 /assets/*
   Cache-Control: public, max-age=31536000, immutable
 
@@ -107,8 +112,8 @@ HTML responses, so don't reuse that name.
 ## Reserved headers
 
 Some headers can't be set in `_headers`. The canister either computes them itself or
-they have no meaning for a certified asset served through the IC HTTP gateway — a
-wrong value would corrupt the response or simply be unverifiable. Rather than silently
+they have no meaning for a certified asset served through the IC HTTP gateway, where
+a wrong value would corrupt the response or simply be unverifiable. Rather than silently
 ignore these (as some CDNs do, which leads to confusing bugs), the sync plugin
 **rejects them at deploy time** with an explanatory error, so you find out
 immediately.
@@ -124,5 +129,5 @@ immediately.
 | `IC-Certificate`, `IC-CertificateExpression` | These carry the response certificate and are canister-managed. |
 | `Location` | A `Location` here wouldn't redirect (the status stays `200`). Use [`_redirects`](redirects.md) instead. |
 
-This list is intentionally conservative and may be relaxed in future releases — it's
+This list is intentionally conservative and may be relaxed in future releases; it's
 easier to allow a header later than to start rejecting one that sites already rely on.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,14 +1,19 @@
-# Under the hood
+---
+title: "Under the hood"
+description: "How the canister certifies responses, serves large assets, negotiates encodings, and persists state across upgrades"
+sidebar:
+  order: 8
+---
 
-You don't need any of this to use certified-assets — the [overview](overview.md) is
+You don't need any of this to use certified-assets; the [overview](overview.md) is
 enough to ship a site. But the pieces below explain *why* it behaves the way it does,
 and they're the features that set it apart from an ordinary static host. (For the
-code-level layout, contributors should read [`ARCHITECTURE.md`](../ARCHITECTURE.md).)
+code-level layout, contributors should read [`ARCHITECTURE.md`](https://github.com/dfinity/certified-assets/blob/main/ARCHITECTURE.md).)
 
 ## Response certification
 
 This is the headline feature. When the sync plugin uploads your files, it also builds
-a **certification tree** — a hash structure the canister commits to as part of its
+a **certification tree**, a hash structure the canister commits to as part of its
 public state. For every path, the canister can produce a proof that "this exact
 response is what I committed to serve here."
 
@@ -32,21 +37,21 @@ certified **`206 Partial Content`** response carrying a `Content-Range`. For an
 ordinary request the **[HTTP gateway](https://docs.internetcomputer.org/references/http-gateway-protocol-spec/)**
 fetches the chunks and reassembles them into the full `200` the browser sees; a client
 that sends a `Range` header gets back the chunk covering the bytes it asked for. Either
-way every chunk is certified, so a large file is exactly as tamper-proof as a small one
-— and it's all transparent to the client.
+way every chunk is certified, so a large file is exactly as tamper-proof as a small
+one, and it's all transparent to the client.
 
 ## The sync plugin and its sandbox
 
 The thing that uploads your files is a WebAssembly **sync plugin** that `icp-cli`
 loads and runs in a sandboxed [WASI](https://wasi.dev) runtime. The plugin can only
-touch the directories the CLI explicitly grants it — your asset directory — and has
+touch the directories the CLI explicitly grants it (your asset directory) and has
 no ambient access to the rest of your machine. The canister and the plugin are shipped
 as a version-locked pair (the [recipe](overview.md) pins both), so the upload format
 and the serving logic always agree.
 
 ## Content encoding
 
-Text-like assets — HTML, CSS, JavaScript, JSON, SVG, WebAssembly, and similar — are
+Text-like assets (HTML, CSS, JavaScript, JSON, SVG, WebAssembly, and similar) are
 stored in three forms: uncompressed (identity), gzip, and Brotli. A compressed copy is
 only kept if it's actually smaller than the original. Already-compressed formats
 (images, video, `woff2` fonts, archives) are stored as-is.
@@ -61,29 +66,29 @@ already holds; any asset whose uncompressed hash, content type and encoding set
 already match is left alone, and only the rest are compressed and uploaded. Editing
 one file in a large site therefore costs one file's worth of compression, and
 re-deploying an unchanged site costs none at all. (Header and redirect changes are
-still detected for every asset — those don't depend on content.)
+still detected for every asset; those don't depend on content.)
 
 Reusing what's already stored assumes the compressors still behave the same way, and
-that isn't something a version number can promise — compressed output isn't part of
+that isn't something a version number can promise: compressed output isn't part of
 a library's published interface. So each sync also records a small fingerprint of how
-its compressors actually behaved. If a later deploy's fingerprint differs — a
+its compressors actually behaved. If a later deploy's fingerprint differs (a
 dependency update, a different backend, or a deploy that simply used different
-compressors — it stops trusting the shortcut and re-prepares every asset, restoring
+compressors), it stops trusting the shortcut and re-prepares every asset, restoring
 the canister to exactly what the new build produces.
 
 Every `icp deploy` uses the same compressors: gzip at its default level and Brotli at
 quality 11, the settings the `state-hash` verifier reproduces. A platform building on
-these crates supplies its own — it can tune Brotli down for short-lived preview
+these crates supplies its own: it can tune Brotli down for short-lived preview
 canisters, drop gzip, or store nothing but the uncompressed copy for deploys nobody
 browses. That is a trade only the deploying platform can make: it keeps the saved
 seconds while the larger transfers go to whoever visits the site. Changing them needs
-no cleanup — the fingerprint above catches it, and the next sync re-prepares the
-canister to match — but a canister prepared with anything other than the standard
+no cleanup (the fingerprint above catches it, and the next sync re-prepares the
+canister to match), but a canister prepared with anything other than the standard
 settings won't match what `state-hash` computes.
 
 ## ETag and conditional requests
 
-Every asset is served with an `ETag` — a strong validator derived from the SHA-256
+Every asset is served with an `ETag`, a strong validator derived from the SHA-256
 hash of its content. On a repeat visit the browser sends that value back in an
 `If-None-Match` header; if it still matches, the canister returns a certified
 `304 Not Modified` with an empty body instead of resending the file. Both the `200`
@@ -94,11 +99,11 @@ the integrity guarantee.
 
 The canister keeps your assets and rules in **stable memory** using
 [`ic-stable-structures`](https://crates.io/crates/ic-stable-structures), so its state
-lives directly in the structure the IC preserves across canister upgrades — there's no
-serialize-everything-on-upgrade / deserialize-on-boot step that could fail or grow
+lives directly in the structure the IC preserves across canister upgrades. There is
+no serialize-everything-on-upgrade / deserialize-on-boot step that could fail or grow
 unbounded as a site gets large.
 
 This ties into how releases are versioned: a **patch** release can be applied as an
 in-place upgrade that keeps all state, while a **breaking** release reinstalls and a
-fresh sync re-uploads everything. See [Releasing](../README.md#releasing) for the
-details.
+fresh sync re-uploads everything. See
+[Releasing](https://github.com/dfinity/certified-assets/blob/main/README.md#releasing) for the details.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,14 +1,19 @@
-# Overview
+---
+title: "Static site overview"
+description: "Deploy a static site to a certified assets canister with the static-site recipe"
+sidebar:
+  order: 1
+---
 
-**Certified Assets** deploys a static site — a built frontend, docs, or any folder of
-files — to a canister on the [Internet Computer](https://internetcomputer.org) that
+**Certified Assets** deploys a static site (a built frontend, docs, or any folder of
+files) to a canister on the [Internet Computer](https://internetcomputer.org) that
 serves it over HTTP with **response certification**. You point it at your build
 directory; it uploads your files, certifies them, and serves them.
 
 Certification is what makes this different from a plain web host: every response the
 canister returns carries a cryptographic proof, and the IC's HTTP gateway verifies
 that proof before handing the response to the browser. Visitors get content the
-canister has provably committed to — no boundary node or gateway can tamper with it
+canister has provably committed to; no boundary node or gateway can tamper with it
 in transit.
 
 You configure it through [`icp-cli`](https://github.com/dfinity/icp-cli) using a
@@ -28,9 +33,9 @@ canisters:
         dir: dist          # the directory of files to serve
 ```
 
-Replace `<version>` with a released version (e.g. `v1.0.0`); see the
+Replace `<version>` with a released version (e.g. `v0.3.3`); see the
 [available versions](https://github.com/dfinity/icp-cli-recipes/releases?q=static-site&expanded=true).
-Pick the version here — because the recipe pins a matched canister + plugin pair,
+Pick the version here: because the recipe pins a matched canister + plugin pair,
 there is no separate canister version to choose.
 
 ### 2. Deploy
@@ -43,7 +48,7 @@ This installs the canister, then runs the sync plugin to upload and certify ever
 file in `dir`. Re-running `icp deploy` syncs again: the plugin diffs your directory
 against the canister and uploads only what changed.
 
-That's it — your site is live and certified.
+That's it: your site is live and certified.
 
 ## Configuration
 
@@ -80,7 +85,7 @@ canisters:
 
 `build` runs before the canister is created, so it can't know any canister IDs.
 When a client-side app needs to embed the ID of a canister it will call, build it
-in `presync` instead — that runs at sync time, once the IDs exist, and exports
+in `presync` instead. That runs at sync time, once the IDs exist, and exports
 them to your commands:
 
 ```yaml
@@ -97,42 +102,42 @@ canisters:
 ```
 
 The variables available to `presync`: `ICP_CLI_CID` (this canister's principal),
-`ICP_CLI_CID_<NAME>` (each project canister's principal — the name upper-cased,
-non-alphanumerics as `_`, e.g. `backend` → `ICP_CLI_CID_BACKEND`), `ICP_CLI_NETWORK`,
-and `ICP_CLI_ENVIRONMENT`.
+`ICP_CLI_CID_<NAME>` (each project canister's principal, with the name upper-cased
+and non-alphanumerics replaced by `_`, e.g. `backend` → `ICP_CLI_CID_BACKEND`),
+`ICP_CLI_NETWORK`, and `ICP_CLI_ENVIRONMENT`.
 
 ## What you get automatically
 
-You don't have to configure any of these — they're on by default:
+You don't have to configure any of these; they're on by default:
 
-- **Response certification** — every response is certified and gateway-verified.
-- **[Clean URLs](routing.md)** — `/about` serves `/about.html`, `/blog/` serves
+- **Response certification.** Every response is certified and gateway-verified.
+- **[Clean URLs](routing.md).** `/about` serves `/about.html`, `/blog/` serves
   `/blog/index.html`, with redirects that keep one canonical URL per page.
-- **[Compression](how-it-works.md#content-encoding)** — text, JS, JSON, SVG, and
+- **[Compression](how-it-works.md#content-encoding).** Text, JS, JSON, SVG, and
   wasm are stored gzip- and Brotli-compressed and negotiated per request via
   `Accept-Encoding`.
-- **[ETag / `304 Not Modified`](how-it-works.md#etag-and-conditional-requests)** —
-  each asset gets a content-hash ETag, so unchanged files aren't re-downloaded.
-- **[A default `404` page](routing.md#not-found-handling)** — a built-in, certified
+- **[ETag / `304 Not Modified`](how-it-works.md#etag-and-conditional-requests).**
+  Each asset gets a content-hash ETag, so unchanged files aren't re-downloaded.
+- **[A default `404` page](routing.md#not-found-handling).** A built-in, certified
   fallback you can replace by adding your own `/404.html`.
 
 ## Customize further
 
 When you need finer control, each topic has its own page:
 
-- **[Routing & clean URLs](routing.md)** — how request paths map to files, trailing
+- **[Routing & clean URLs](routing.md).** How request paths map to files, trailing
   slashes, and 404 handling.
-- **[Single-page apps](routing.md#single-page-apps-spa)** — the one `_redirects` rule a
+- **[Single-page apps](routing.md#single-page-apps-spa).** The one `_redirects` rule a
   client-side-routed app needs, so every URL loads (and reloads) your shell.
-- **[Redirects & rewrites](redirects.md)** — the `_redirects` file: send `/old` to
+- **[Redirects & rewrites](redirects.md).** The `_redirects` file: send `/old` to
   `/new`, serve one file at another path, set custom error pages.
-- **[Custom headers](headers.md)** — the `_headers` file: cache-control, a Content
+- **[Custom headers](headers.md).** The `_headers` file: cache-control, a Content
   Security Policy, and other security headers.
-- **[Site files & conventions](site-files.md)** — what gets uploaded, the special
+- **[Site files & conventions](site-files.md).** What gets uploaded, the special
   `_redirects`/`_headers` files, excluded files, and custom domains.
-- **[Access protection](access-protection.md)** — put a login screen in front of a
+- **[Access protection](access-protection.md).** Put a login screen in front of a
   private/preview app with revocable, expiring access tokens.
-- **[Verifying contents](verifying-contents.md)** — the canister's state hash:
-  prove to a third party that it serves exactly a known build, from source.
+- **[Verifying contents](verifying-contents.md).** The canister's state hash: prove
+  to a third party that it serves exactly a known build, from source.
 
 Curious how it works underneath? See [Under the hood](how-it-works.md).

--- a/docs/redirects.md
+++ b/docs/redirects.md
@@ -1,4 +1,9 @@
-# Redirects & rewrites
+---
+title: "Redirects and rewrites"
+description: "The _redirects file: permanent and temporary redirects, rewrites, subtree moves, and custom error pages"
+sidebar:
+  order: 3
+---
 
 Add a file named `_redirects` to the root of your asset directory to send one path
 to another, serve a file's contents at a different URL, or set custom error pages.
@@ -9,25 +14,25 @@ with one rule per line:
 /old-path   /new-path   301
 ```
 
-Each line is three whitespace-separated fields — `from`, `to`, and `status`. Blank
+Each line is three whitespace-separated fields: `from`, `to`, and `status`. Blank
 lines and lines starting with `#` are ignored.
 
 ## The three fields
 
-**`from`** — the path to match. Always absolute (starts with `/`):
+**`from`** is the path to match, always absolute (starts with `/`):
 
-- `/about` — an exact path.
-- `/blog/*` — a subtree: everything under `/blog/`. The `*` is only allowed as a
+- `/about`: an exact path.
+- `/blog/*`: a subtree, everything under `/blog/`. The `*` is only allowed as a
   trailing `/*`.
-- `/*` — the entire site.
+- `/*`: the entire site.
 
-**`to`** — the destination:
+**`to`** is the destination:
 
 - For a redirect (3xx), an absolute path (`/new`) **or** a full URL
   (`https://example.com/new`).
 - For a rewrite or error page (200/404/410), an absolute path to one of your files.
 
-**`status`** — what the canister does. One of:
+**`status`** is what the canister does. One of:
 
 | Status | Meaning |
 |--------|---------|
@@ -35,13 +40,13 @@ lines and lines starting with `#` are ignored.
 | `302` | Temporary redirect. |
 | `307` | Temporary redirect, preserving the request method. |
 | `308` | Permanent redirect, preserving the request method. |
-| `200` | **Rewrite** — serve the `to` file's contents at the `from` URL, with no visible redirect. |
+| `200` | **Rewrite**: serve the `to` file's contents at the `from` URL, with no visible redirect. |
 | `404` | Serve the `to` file as a not-found page. |
 | `410` | Serve the `to` file, signalling the resource is permanently gone. |
 
 A `404` or `410` error page must be a **small, single-chunk file** (under ~1.9 MB).
 Large files are served as [`206` range responses](how-it-works.md#serving-large-assets)
-that the gateway reassembles into a `200`, which can't carry a 4xx status — so the sync
+that the gateway reassembles into a `200`, which can't carry a 4xx status, so the sync
 plugin rejects a 4xx rule pointing at a multi-chunk asset at deploy time, naming the
 offending rule. (A `200` rewrite to a large file is fine.)
 
@@ -74,7 +79,7 @@ Rules are evaluated top to bottom and **the first match wins**, within a fixed
 overall order:
 
 1. **Files.** An actual file at the requested path always wins over any rule. (This
-   is why there's no Netlify-style `!` "force" suffix — to override a file, remove or
+   is why there's no Netlify-style `!` "force" suffix: to override a file, remove or
    rename it rather than forcing a rule past it.)
 2. **Clean-URL rules.** The automatic [clean-URL redirects](routing.md#clean-urls)
    are applied next.
@@ -82,12 +87,12 @@ overall order:
 4. **The 404 fallback.** Finally the [not-found page](routing.md#not-found-handling).
 
 So a `/*` rule at the end of your file only catches paths that nothing earlier
-claimed — which is exactly what makes the
+claimed, which is exactly what makes the
 [SPA fallback](routing.md#single-page-apps-spa) above safe.
 
 ## What isn't supported: dynamic rules
 
-There are no `:splat` or `:placeholder` captures — you can't write
+There are no `:splat` or `:placeholder` captures: you can't write
 `/old/:rest  /new/:rest  301` to forward a captured path segment. This isn't a
 missing feature we plan to add; it's a consequence of how the Internet Computer
 serves these assets.
@@ -95,11 +100,11 @@ serves these assets.
 **Every response the canister can return is certified ahead of time.** During sync,
 the plugin builds a certification tree over a *finite, enumerable* set of
 `path → response` mappings, and the HTTP gateway verifies each response against that
-tree before serving it. A `:splat` rule would construct its destination — and thus
-its response — dynamically from whatever path the visitor requested, producing
+tree before serving it. A `:splat` rule would construct its destination (and thus
+its response) dynamically from whatever path the visitor requested, producing
 responses that were never certified. The gateway would reject them. (The same
 constraint is why [header values](headers.md) can't use `:splat` substitution
 either.)
 
-Static rules — exact paths, `/*` subtrees, and fixed destinations — cover the common
+Static rules (exact paths, `/*` subtrees, and fixed destinations) cover the common
 cases and stay fully certifiable, so those are what `_redirects` supports.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,8 +1,13 @@
-# Routing & clean URLs
+---
+title: "Routing and clean URLs"
+description: "How request paths resolve to files, clean URLs, trailing slashes, 404 handling, and single-page apps"
+sidebar:
+  order: 2
+---
 
-This page explains how an incoming request path resolves to one of your files —
-the automatic clean-URL behavior you get out of the box, and how unmatched paths
-are handled. For *changing* where paths go, see [Redirects & rewrites](redirects.md);
+This page explains how an incoming request path resolves to one of your files: the
+automatic clean-URL behavior you get out of the box, and how unmatched paths are
+handled. For *changing* where paths go, see [Redirects & rewrites](redirects.md);
 for attaching headers to paths, see [Custom headers](headers.md).
 
 ## How a path resolves
@@ -11,7 +16,7 @@ For each request, the canister resolves the path in this order:
 
 1. **An exact file match.** A file in your directory is served directly. `dist/app.js`
    answers a request for `/app.js`.
-2. **A routing rule.** If no file matches the path verbatim, the rules apply — the
+2. **A routing rule.** If no file matches the path verbatim, the rules apply: the
    automatic clean-URL rules below, then your own [`_redirects`](redirects.md), in
    that order. The first matching rule wins.
 3. **The not-found fallback.** If nothing matches, the request resolves to the
@@ -22,7 +27,7 @@ Every one of these outcomes is a *certified* response.
 ## Clean URLs
 
 You don't link to `.html` files. The canister automatically maps each HTML file to a
-clean, extension-less URL and treats that as its **canonical** address — following
+clean, extension-less URL and treats that as its **canonical** address, following
 [Cloudflare's `auto-trailing-slash` conventions](https://developers.cloudflare.com/workers/static-assets/routing/advanced/html-handling/).
 
 | Your file | Canonical URL | Also handled |
@@ -36,7 +41,7 @@ has exactly one address that search engines and visitors land on.
 
 ### A note on `.html` URLs
 
-Requesting the underlying file directly — e.g. `/about.html` — currently serves the
+Requesting the underlying file directly (e.g. `/about.html`) currently serves the
 file with a `200` rather than redirecting to the canonical `/about`. A file always
 takes precedence over a routing rule at the same path, and `/about.html` *is* a file.
 This is harmless for most sites; if you need strict canonicalization (one URL only),
@@ -56,8 +61,8 @@ Every request must resolve to a certified response, so there is always a `404` p
 
 ## Single-page apps (SPA)
 
-If your app does client-side routing — React Router, Vue Router, SvelteKit in SPA
-mode, or a hand-rolled `history.pushState` router — the server has to answer *every*
+If your app does client-side routing (React Router, Vue Router, SvelteKit in SPA
+mode, or a hand-rolled `history.pushState` router), the server has to answer *every*
 URL with the app shell so the router can take over. Add one rule to
 [`_redirects`](redirects.md):
 
@@ -71,7 +76,8 @@ contents are served at the requested URL with no visible redirect, so
 in-app navigation. Every one of those responses is certified, including the ones at
 paths that have no file behind them.
 
-See the [`spa` example](../examples/spa/) for a complete, runnable project.
+See the [`spa` example](https://github.com/dfinity/certified-assets/tree/main/examples/spa)
+for a complete, runnable project.
 
 ### What the `/*` rule changes
 
@@ -84,8 +90,8 @@ See the [`spa` example](../examples/spa/) for a complete, runnable project.
   `fetch()` for missing JSON gets HTML it can't parse, and a missing script fails with
   a confusing MIME-type error instead of a plain 404.
 
-  Give your build output an honest 404 by scoping a rule to it *above* the catch-all
-  — rules are matched in file order:
+  Give your build output an honest 404 by scoping a rule to it *above* the
+  catch-all; rules are matched in file order:
 
   ```
   /assets/*  /404.html  404
@@ -109,7 +115,7 @@ See the [`spa` example](../examples/spa/) for a complete, runnable project.
 
 - **Link assets with absolute paths.** Use `/assets/app.js`, not `assets/app.js`. A
   relative URL resolves against the *client route*, so at `/dashboard/settings` the
-  browser would request `/dashboard/settings/assets/app.js` — which the `/*` rule
+  browser would request `/dashboard/settings/assets/app.js`, which the `/*` rule
   answers with the HTML shell.
 - **Put shell headers on the file, not the route.** [`_headers`](headers.md) patterns
   match the file, and a rewrite reuses its target's headers, so a
@@ -119,6 +125,6 @@ See the [`spa` example](../examples/spa/) for a complete, runnable project.
 
 ## See also
 
-- [Redirects & rewrites](redirects.md) — send one path to another, or serve one
+- [Redirects & rewrites](redirects.md): send one path to another, or serve one
   file's contents at a different URL.
-- [Custom headers](headers.md) — attach cache-control, CSP, and other headers to paths.
+- [Custom headers](headers.md): attach cache-control, CSP, and other headers to paths.

--- a/docs/site-files.md
+++ b/docs/site-files.md
@@ -1,4 +1,9 @@
-# Site files & conventions
+---
+title: "Site files and conventions"
+description: "What gets uploaded, the special _redirects and _headers files, skipped files, custom domains, and the 404 page"
+sidebar:
+  order: 5
+---
 
 This page covers what actually gets uploaded from your asset directory, the special
 files that configure behavior instead of being served, and the conventions for things
@@ -20,20 +25,20 @@ uploads only what changed, so re-deploys are fast.
 
 ## Special files
 
-Two filenames are treated as **configuration, not content** — they're read for their
+Two filenames are treated as **configuration, not content**: they're read for their
 effect and never uploaded as assets. Place them at the root of your asset directory:
 
-- [`_redirects`](redirects.md) — redirect, rewrite, and error-page rules.
-- [`_headers`](headers.md) — custom response headers.
+- [`_redirects`](redirects.md): redirect, rewrite, and error-page rules.
+- [`_headers`](headers.md): custom response headers.
 
 ## Files that are skipped
 
 To match common build-output conventions, the plugin skips:
 
-- **Dotfiles and dot-directories** — anything whose name starts with `.` (for example
+- **Dotfiles and dot-directories.** Anything whose name starts with `.` (for example
   `.DS_Store`, `.git/`, `.env`). The one exception is `.well-known/` (below), which is
   traversed normally.
-- **Symbolic links** — both file and directory symlinks are ignored; only real files
+- **Symbolic links.** Both file and directory symlinks are ignored; only real files
   are uploaded.
 
 Everything else under `dir` is fair game, so keep build artifacts you don't want
@@ -50,9 +55,9 @@ www.example.com
 ```
 
 `.well-known/` is uploaded despite the leading dot, so the file is served at
-`/.well-known/ic-domains` — which is where the Internet Computer's boundary nodes look
+`/.well-known/ic-domains`, which is where the Internet Computer's boundary nodes look
 when registering a custom domain. Registering the domain itself is an IC platform step;
-see the [custom domains documentation](https://docs.internetcomputer.org/building-apps/frontends/custom-domains/using-custom-domains)
+see the [custom domains documentation](https://docs.internetcomputer.org/guides/frontends/custom-domains/)
 for the full process.
 
 ## The 404 page

--- a/docs/verifying-contents.md
+++ b/docs/verifying-contents.md
@@ -1,14 +1,19 @@
-# Verifying contents
+---
+title: "Verifying contents"
+description: "Prove a canister serves exactly a known build by reproducing its state hash from source"
+sidebar:
+  order: 7
+---
 
 Certification proves that what the canister **serves** matches what it has
-**committed to** — but who decides what it committed to? On its own, an asset
+**committed to**. But who decides what it committed to? On its own, an asset
 canister could commit to (and certify) anything. The **state hash** closes that
 gap: it lets a third party verify the canister serves *exactly a known frontend
-build* — the reproducible-build story, but for frontend assets instead of wasm.
+build* (the reproducible-build story, but for frontend assets instead of wasm).
 
 The trust root is the **source code**, never the operator's word. A verifier
 reproduces the build from public source, computes the hash locally, and compares
-it to the canister's. An operator who just hands you a number proves nothing —
+it to the canister's. An operator who just hands you a number proves nothing;
 that number is only a deploy self-consistency check.
 
 ## What the hash covers
@@ -22,7 +27,7 @@ that number is only a deploy self-consistency check.
 
 These are exactly the hashes the canister already stores and the HTTP gateway
 certifies end-to-end. To match the hash while serving forged content, an attacker
-would need the certified hashes to equal the real build's — and the gateway forces
+would need the certified hashes to equal the real build's, and the gateway forces
 served bytes to those hashes. So a matching hash means matching served content.
 
 **Not covered:** raw content bytes are folded in as their certified hashes, never
@@ -47,12 +52,12 @@ that produce the served directory).
 
    This is the hash of the preparation `icp deploy` produces. A platform building
    on these crates supplies its own compressors (see
-   [how it works](how-it-works.md)) — a lower Brotli quality to make short-lived
-   preview deploys cheaper, say, or none at all — and its canisters won't match
-   this value. Verifying those is between that platform and its users; the tool
-   deliberately doesn't guess at which settings someone else might have used.
+   [how it works](how-it-works.md)), perhaps a lower Brotli quality to make
+   short-lived preview deploys cheaper, or none at all, and its canisters won't
+   match this value. Verifying those is between that platform and its users; the
+   tool deliberately doesn't guess at which settings someone else might have used.
 
-3. **Read the canister's hash.** `state_hash` is a public, unguarded method — and
+3. **Read the canister's hash.** `state_hash` is a public, unguarded method, and
    an *update* call, so the reply is consensus-backed and trustworthy:
 
    ```sh
@@ -62,18 +67,18 @@ that produce the served directory).
 
 4. **Compare.** If the canister's hash equals the one you computed, it serves
    exactly the build you reproduced from source. If it doesn't, either the served
-   content, headers, or redirects do not match that source — or it was deployed
+   content, headers, or redirects do not match that source, or it was deployed
    with compressors this tool doesn't know about (see step 2).
 
    A match needs no further checking of *how* the canister was synced. The hash
    covers every stored encoding by its own hash, so matching it means the canister
-   holds exactly the bytes this tool prepared — which is what "prepared with the
+   holds exactly the bytes this tool prepared, which is what "prepared with the
    standard compressors" means. There is no separate step, and nothing to take on
    the operator's word.
 
 The deploy also prints a hash in the `icp deploy` / sync result (`canister reports
 state hash <hex>`). That value comes back from the canister on the call that
-finalizes the sync, so it tells the operator what the canister now holds — it is
+finalizes the sync, so it tells the operator what the canister now holds; it is
 *not* a locally-derived cross-check, and not third-party verification. Only the
 `state-hash` tool above, run against source you reproduced, is that.
 
@@ -83,25 +88,25 @@ The hash is bound to how content is prepared, so a verifier must use a
 `state-hash` build **matching the version that deployed the canister**. The
 parameters baked into the hash:
 
-- **Compression** — gzip at `flate2`'s default level; brotli at quality 11,
+- **Compression.** Gzip at `flate2`'s default level; brotli at quality 11,
   window 22, **as produced by the exact compressor builds this version links**.
   RFC 7932 and RFC 1951 specify *decoders*, so those settings don't determine the
-  bytes: a different encoder — or a different version of the same one — may emit
+  bytes: a different encoder, or a different version of the same one, may emit
   a different valid stream. That is why the verifier reuses this project's
   preparation code rather than reimplementing it, and why a matching version
   matters more here than for anything else in this list. These are the settings
   `sync-plugin` injects, so they are the settings behind every `icp deploy`; a
   program embedding `sync-agent` supplies its own compressors and owns its own
   verification story.
-- **Chunk boundary** — `MAX_CHUNK_SIZE` (1,900,000 bytes). Per-chunk hashes for
+- **Chunk boundary.** `MAX_CHUNK_SIZE` (1,900,000 bytes). Per-chunk hashes for
   large assets depend on where chunks split.
-- **Byte format** — a versioned, length-prefixed, domain-separated SHA-256
+- **Byte format.** A versioned, length-prefixed, domain-separated SHA-256
   stream (see the `state-hash` crate). Independent of map/header iteration order,
   but bound to this layout version.
 
 The contract can change between releases; when it does, the format version is
 bumped and every previously-computed hash is expected to change. Within a release
-series it is frozen — a patch upgrade preserves stored content, so a build that
+series it is frozen: a patch upgrade preserves stored content, so a build that
 changed these parameters would silently invalidate every deployed canister's hash.
 
 ## Relationship to certification


### PR DESCRIPTION
Implements the repo-side asks in #124, so `docs/` can be synced into
developer-docs as the Frontends section with this repo staying the single
source of truth.

Docs-only: no crate, wire-format, or recipe-schema change.

## What's here

**1–2. Frontmatter on all eight pages.** `title`, `description`, and
`sidebar.order` as proposed in the issue table.

```yaml
---
title: "Routing and clean URLs"
description: "How request paths resolve to files, clean URLs, trailing slashes, 404 handling, and single-page apps"
sidebar:
  order: 2
---
```

**The H1 is dropped**, which is the opposite of what the issue recommended on
its open question. Two reasons:

- GitHub renders YAML frontmatter as a table at the top of the blob view, nested
  `sidebar.order` included, so the page still has a visible title here. Verified
  on this branch, not assumed.
- Keeping both would mean five of the eight pages carrying a `title` that
  disagrees with their H1 (`Overview` vs `Static site overview`, `&` vs "and",
  `Access protection (private apps)` vs `Access protection`). That is exactly
  the drift a duplicated title string invites.

It also makes the sync a pure rsync, matching the 76 `caffeinelabs/motoko`
pages. No anchors move: all 20 anchor links into `docs/` (11 distinct targets)
resolve to an H2 or H3, never an H1.

The cost, for the record: the title now renders as a table row rather than a
heading, and a reader viewing the raw markdown sees the YAML block instead of a
title line.

**3. All 124 em-dashes are gone.** Done here rather than in the postprocess so
the published page and the file in this repo stay byte-identical, which is the
property that makes a sync trustworthy. Rewritten by hand, not mechanically:

- Definition bullets take the `- **Term.** Sentence.` form the docs already use
  in `routing.md`'s not-found list, or a colon form where the term is inline
  code (``- `/about`: an exact path.``).
- Prose takes a colon, semicolon, comma, or parentheses per sentence. A handful
  needed real rewording rather than a punctuation swap: the *unauthenticated
  sibling* paragraph in `access-protection.md`, the compressor caveat in
  `verifying-contents.md` step 2, and the `revoke_token` table cell.

Affected lines are re-wrapped to the existing ~85-column width.

**4. `<version>` placeholder convention kept.** The stale example version in
`overview.md` is corrected: `v1.0.0` to `v0.3.3`.

**5. Both link fixes.**

- Custom domains now points at
  `https://docs.internetcomputer.org/guides/frontends/custom-domains/`
  (verified 200; the old `building-apps/frontends/...` form only survives on a
  301 to it).
- The three links that escape `docs/` (`../ARCHITECTURE.md`,
  `../README.md#releasing`, `../examples/spa/`) are now absolute GitHub URLs at
  `main`. That is the second option the issue offered, and it removes the
  permalink rewrite from the sync script entirely.

## Verification

- Frontmatter parses as YAML on all eight files; `title`/`description`/`sidebar`
  and nothing else.
- No `#` H1 outside a fenced code block; the first heading in every file is now
  an H2. Every anchor link into `docs/` was re-resolved against the headings that
  remain: 20 links, 11 distinct targets, all H2 or H3, none broken.
- `grep -c '—' docs/*.md` is 0 across the tree.
- Re-ran the extractor logic from `protection.rs`'s
  `documented_calls_are_accepted_by_the_canister` against the edited
  `access-protection.md`: all six management methods are still found, so the
  reformatted reference table doesn't open a hole in that test's coverage.

## Not in scope

Em-dashes outside `docs/` are untouched (18 in `README.md`, 31 across
`examples/*/README.md`). Worth revisiting only if the example READMEs are ever
published too.

Closes #124
