### PR TITLE
docs: clarify the client/gateway/canister trust model and what `raw` skips

### DIFF
--- a/docs/access-protection.md
+++ b/docs/access-protection.md
@@ -181,6 +181,14 @@ makes), unauthorized visitors can't pull your content. But:
   token values are stored hashed; a low-entropy chosen passphrase is still
   brute-forceable, like any password hash.)
 - TLS terminates at the boundary node, which sees the cookie in clear.
+- The gate itself runs canister-side, so it holds on every hostname, but its
+  *response* is only verified if the visitor's gateway verifies. Over a
+  [`raw` URL](how-it-works.md#the-raw-hosts-skip-verification) the redirect and the
+  login page arrive unchecked, so a non-verifying gateway could substitute a
+  fabricated login form and harvest tokens. Send people to a verifying gateway. (The
+  access cookie is host-only, so a `raw` host is a separate cookie jar: a session on
+  the certified host isn't carried there, and signing in on `raw` means handing the
+  token to whatever served that page.)
 - There is **no brute-force protection, lockout, or rate-limiting**: login attempts
   are unbilled, untracked queries. The deterrent is high-entropy random tokens.
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -17,17 +17,77 @@ a **certification tree**, a hash structure the canister commits to as part of it
 public state. For every path, the canister can produce a proof that "this exact
 response is what I committed to serve here."
 
-When a browser requests your site, the request goes through the Internet Computer's
-**[HTTP gateway](https://docs.internetcomputer.org/references/http-gateway-protocol-spec/)**,
-which calls the canister, receives the response *and its certificate*, and verifies
-the certificate before passing anything to the browser. A boundary node or gateway
-can't alter, inject, or swap your content without the proof failing. A plain web host
-asks you to trust the server; here the response is cryptographically tied to the
-canister's certified state.
+Serving happens in a **query**, which is answered by a single replica rather than by
+consensus. Certification is what makes that answer trustworthy: the proof chains the
+response back to state the canister committed *through* consensus, so no single replica
+can invent a response that verifies.
+
+The canister certifies **every** response it serves, and there is no way to turn that
+off. It accepts only version 2 of the certification protocol, and everything it returns
+carries a full certification expression; it never uses the gateway protocol's
+`no_certification` escape hatch. Whatever you request, the proof comes with it.
 
 This is also why [redirects](redirects.md#what-isnt-supported-dynamic-rules) and
 [headers](headers.md#reserved-headers) are constrained to what can be enumerated and
 certified ahead of time.
+
+### Who verifies the certificate
+
+A proof only helps if somebody checks it, and in a browser that somebody is the
+**[HTTP gateway](https://docs.internetcomputer.org/references/http-gateway-protocol-spec/)**.
+Three parties are involved:
+
+- The **canister** certifies every response, as above.
+- The **gateway** calls the canister, verifies the certificate, and forwards the
+  response. Its promise to the client is "I checked this proof against the canister's
+  certified state."
+- The **client** picks a gateway by pointing at its URL. A browser can't verify an IC
+  certificate on its own, so it delegates that check. **Choosing the gateway is the
+  whole trust decision.**
+
+Go through a gateway that verifies, and nothing between it and the canister can alter,
+inject, or swap your content without the proof failing. A plain web host asks you to
+trust the server; here the response is cryptographically tied to the canister's
+certified state.
+
+### The `raw` hosts skip verification
+
+Alongside their verifying hostname, gateways have long answered on a second one that
+forwards the response **without** checking the proof: `<canister-id>.raw.icp0.io`
+serves the same site as `<canister-id>.icp0.io`, unverified.
+
+That dates from certification v1, when a canister had no way to tell the gateway "this
+response is dynamic, don't try to verify it." A non-verifying hostname was the only
+escape hatch available to canisters serving content they couldn't certify ahead of
+time. Version 2 replaced it with something better: a canister now says so per response,
+in band, through the `no_certification` expression mentioned above. The `raw` hostnames
+outlived the problem they solved, and survive mainly as a debugging aid.
+
+This canister never needed the escape hatch. It is v2-only and certifies everything, so
+it behaves identically on both hostnames: it attaches the certificate either way, and on
+`raw` the gateway simply discards it. Nothing about the canister's guarantee weakens
+there, but the client has chosen a party that doesn't check, so it gets no better
+assurance than from an ordinary web host.
+
+**The canister can't refuse `raw` requests.** Its only clue is the `Host` header, which
+the client supplies and nothing authenticates. Matching it against `raw` would hardcode
+a hostname convention that no protocol defines: which hostnames verify and which don't
+is a property of how a particular gateway is deployed, not something the gateway
+protocol states. With gateways independently operated, self-hosted, and behind custom
+domains, such a check is wrong in both directions, since a non-verifying gateway can
+answer on any hostname and a verifying one can be named anything at all.
+
+So the guidance is client-side: **link to a gateway that verifies, and treat a `raw`
+URL as a debugging tool rather than a way to serve or visit a site.** A `raw` link is
+copy-pasteable and gets shared, and nothing in the response tells a visitor it arrived
+unverified.
+
+If you'd rather not trust a gateway at all, check the proof yourself: call the canister
+through an
+[agent](https://internetcomputer.org/docs/building-apps/interact-with-canisters/agents/overview)
+and verify the certificate in your own code, or use the
+[state hash](verifying-contents.md), whose `state_hash` call is an update and therefore
+consensus-backed.
 
 ## Serving large assets
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -69,13 +69,13 @@ it behaves identically on both hostnames: it attaches the certificate either way
 there, but the client has chosen a party that doesn't check, so it gets no better
 assurance than from an ordinary web host.
 
-**The canister can't refuse `raw` requests.** Its only clue is the `Host` header, which
-the client supplies and nothing authenticates. Matching it against `raw` would hardcode
-a hostname convention that no protocol defines: which hostnames verify and which don't
-is a property of how a particular gateway is deployed, not something the gateway
-protocol states. With gateways independently operated, self-hosted, and behind custom
-domains, such a check is wrong in both directions, since a non-verifying gateway can
-answer on any hostname and a verifying one can be named anything at all.
+**The canister can't reliably refuse `raw` requests.** Its only clue is the `Host`
+header, which the client supplies and nothing authenticates. Matching it against `raw`
+would hardcode a hostname convention that no protocol defines: which hostnames verify
+and which don't is a property of how a particular gateway is deployed, not something
+the gateway protocol states. With gateways independently operated, self-hosted, and
+behind custom domains, such a check is wrong in both directions, since a non-verifying
+gateway can answer on any hostname and a verifying one can be named anything at all.
 
 So the guidance is client-side: **link to a gateway that verifies, and treat a `raw`
 URL as a debugging tool rather than a way to serve or visit a site.** A `raw` link is
@@ -84,7 +84,7 @@ unverified.
 
 If you'd rather not trust a gateway at all, check the proof yourself: call the canister
 through an
-[agent](https://internetcomputer.org/docs/building-apps/interact-with-canisters/agents/overview)
+[agent](https://docs.internetcomputer.org/guides/canister-calls/calling-from-clients/)
 and verify the certificate in your own code, or use the
 [state hash](verifying-contents.md), whose `state_hash` call is an update and therefore
 consensus-backed.

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -11,10 +11,14 @@ serves it over HTTP with **response certification**. You point it at your build
 directory; it uploads your files, certifies them, and serves them.
 
 Certification is what makes this different from a plain web host: every response the
-canister returns carries a cryptographic proof, and the IC's HTTP gateway verifies
+canister returns carries a cryptographic proof, and a verifying HTTP gateway checks
 that proof before handing the response to the browser. Visitors get content the
-canister has provably committed to; no boundary node or gateway can tamper with it
-in transit.
+canister has provably committed to, with nothing in between able to tamper with it in
+transit.
+
+The canister certifies every response, always. Whether that proof gets *checked*
+depends on the gateway a visitor goes through, so link to one that verifies and treat
+[`raw` URLs](how-it-works.md#the-raw-hosts-skip-verification) as a debugging tool.
 
 You configure it through [`icp-cli`](https://github.com/dfinity/icp-cli) using a
 **recipe**, which bundles a matched pair of the canister and its sync plugin. Most
@@ -110,7 +114,8 @@ and non-alphanumerics replaced by `_`, e.g. `backend` → `ICP_CLI_CID_BACKEND`)
 
 You don't have to configure any of these; they're on by default:
 
-- **Response certification.** Every response is certified and gateway-verified.
+- **Response certification.** Every response carries a proof, [checked by a verifying
+  gateway](how-it-works.md#who-verifies-the-certificate).
 - **[Clean URLs](routing.md).** `/about` serves `/about.html`, `/blog/` serves
   `/blog/index.html`, with redirects that keep one canonical URL per page.
 - **[Compression](how-it-works.md#content-encoding).** Text, JS, JSON, SVG, and

--- a/docs/redirects.md
+++ b/docs/redirects.md
@@ -99,12 +99,12 @@ serves these assets.
 
 **Every response the canister can return is certified ahead of time.** During sync,
 the plugin builds a certification tree over a *finite, enumerable* set of
-`path → response` mappings, and the HTTP gateway verifies each response against that
+`path → response` mappings, and a verifying gateway checks each response against that
 tree before serving it. A `:splat` rule would construct its destination (and thus
 its response) dynamically from whatever path the visitor requested, producing
-responses that were never certified. The gateway would reject them. (The same
-constraint is why [header values](headers.md) can't use `:splat` substitution
-either.)
+responses that were never certified. The canister would have no certified response to
+serve, and a verifying gateway would reject one anyway. (The same constraint is why
+[header values](headers.md) can't use `:splat` substitution either.)
 
 Static rules (exact paths, `/*` subtrees, and fixed destinations) cover the common
 cases and stay fully certifiable, so those are what `_redirects` supports.

--- a/docs/verifying-contents.md
+++ b/docs/verifying-contents.md
@@ -25,12 +25,14 @@ that number is only a deploy self-consistency check.
   hashes for large multi-chunk assets);
 - the redirect rules, in match order.
 
-These are exactly the hashes the canister already stores and the HTTP gateway
-certifies end-to-end. To match the hash while serving forged content, an attacker
-would need the certified hashes to equal the real build's, and the gateway forces
-served bytes to those hashes. So a matching hash means matching served content.
+These are exactly the hashes the canister already stores and certifies end-to-end. To
+match the hash while serving forged content, an attacker would need the certified
+hashes to equal the real build's, and a verifying gateway forces served bytes to those
+hashes. So a matching hash means matching served content, for any visitor whose
+gateway checks the proof (see
+[who verifies the certificate](how-it-works.md#who-verifies-the-certificate)).
 
-**Not covered:** raw content bytes are folded in as their certified hashes, never
+**Not covered:** asset content bytes are folded in as their certified hashes, never
 re-hashed; and permissions / authorization state are out of scope (they don't
 affect *what* is served, only *who may sync*).
 
@@ -114,9 +116,12 @@ changed these parameters would silently invalidate every deployed canister's has
 Certification and the state hash are complementary:
 
 - **Certification** (always on) proves *each response* matches what the canister
-  committed to, verified by the gateway on every request.
+  committed to, checked by the visitor's gateway on every request.
 - **The state hash** proves *what the canister committed to* matches a known
   source build, verified by you, once, out of band.
 
 Together they chain trust from your source code all the way to the bytes in a
-visitor's browser.
+visitor's browser. The last link in that chain is the visitor's gateway: over a
+[`raw` URL](how-it-works.md#the-raw-hosts-skip-verification) nobody checks the proof,
+so the state hash still says what the canister committed to but no longer guarantees
+that a visitor received it.

--- a/docs/verifying-contents.md
+++ b/docs/verifying-contents.md
@@ -25,11 +25,11 @@ that number is only a deploy self-consistency check.
   hashes for large multi-chunk assets);
 - the redirect rules, in match order.
 
-These are exactly the hashes the canister already stores and certifies end-to-end. To
-match the hash while serving forged content, an attacker would need the certified
-hashes to equal the real build's, and a verifying gateway forces served bytes to those
-hashes. So a matching hash means matching served content, for any visitor whose
-gateway checks the proof (see
+These are exactly the hashes the canister already stores and certifies. To match the
+hash while serving forged content, an attacker would need the certified hashes to
+equal the real build's, and a verifying gateway forces served bytes to those hashes.
+So a matching hash means matching served content, for any visitor whose gateway checks
+the proof (see
 [who verifies the certificate](how-it-works.md#who-verifies-the-certificate)).
 
 **Not covered:** asset content bytes are folded in as their certified hashes, never


### PR DESCRIPTION
Closes #123

## Why

Our docs asserted that the HTTP gateway verifies every response, with no note that verification is a property of *the gateway a visitor chose to go through*. On a `raw` hostname nothing checks the proof, so the guarantee as written was stronger than what a visitor on that host actually receives.

The canister itself is fine, and this PR changes no behavior. It is certification-v2 only ([`http_request` traps otherwise](https://github.com/dfinity/certified-assets/blob/main/crates/canister-core/src/lib.rs#L144)) and always emits a full certification expression, never the gateway protocol's `no_certification`. So "every response this canister serves is certified" is structurally true. What was missing from the docs is the other half: somebody has to *check* the proof, and which party does is the client's choice of gateway.

## What changed

**`docs/how-it-works.md`** — the substance. "Response certification" now states the canister's unconditional guarantee and explains why certification exists at all (serving is a query, answered by one replica; the proof is what chains it back to consensus-committed state). Two new subsections:

- **Who verifies the certificate** — the three-party model (canister certifies → gateway verifies → client picks the gateway), ending on "choosing the gateway is the whole trust decision."
- **The `raw` hosts skip verification** — framed as a certification-v1 leftover. `raw` existed because a v1 canister had no in-band way to say "this response is dynamic, don't verify it"; v2 replaced that with `no_certification`, per response. Also covers why the canister cannot reliably refuse `raw`: the only signal is the client-supplied `Host` header, and which hostnames verify is a deployment property that no protocol defines, so such a check is wrong in both directions.

**`docs/overview.md`** — dropped "no boundary node or gateway can tamper with it" and "certified and gateway-verified", with a two-sentence pointer so the overview stays light.

**`docs/access-protection.md`** — a threat-model bullet: the gate runs canister-side so it holds on every hostname, but its *response* is unverified on `raw`, where a non-verifying gateway could substitute a fabricated login form. Includes the practical part: the access cookie is host-only, so `raw` is a separate cookie jar and signing in there hands the token to whatever served that page.

**`docs/verifying-contents.md`** — this page's whole argument is a trust chain ending "all the way to the bytes in a visitor's browser", so it needed the same treatment: the state hash still proves what the canister committed to, but over `raw` nothing guarantees a visitor received it.

## Note for reviewers

This is **not purely additive** — it rewords a security claim in four places. Worth reading those hunks rather than skimming a docs diff. `docs/verifying-contents.md` is the least obvious one: its trust-chain conclusion is now explicitly conditioned on the visitor's gateway.

## Verification

- All relative doc links and heading anchors resolve; external links return 200.
- No em-dashes, per the style established in #125.
- `cargo test -p e2e --test protection documented_calls_are_accepted_by_the_canister` passes (that test reads the committed markdown; this PR adds no candid snippets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
